### PR TITLE
<fix>[vm]: support inactive volume check

### DIFF
--- a/imagestorebackupstorage/ansible/imagestorebackupstorage.py
+++ b/imagestorebackupstorage/ansible/imagestorebackupstorage.py
@@ -108,7 +108,7 @@ command = 'if [ -d /opt/zstack/chroot/usr/lib64 ]; then grep -c  "^/opt/zstack/c
 run_remote_command(command, host_post_info)
 
 if host_info.distro in RPM_BASED_OS:
-    qemu_pkg = "fuse-sshfs nmap collectd tar net-tools"
+    qemu_pkg = "fuse-sshfs nmap collectd tar net-tools sg3_utils nvme-cli"
     qemu_pkg = qemu_pkg + ' python2-pyparted nettle open-iscsi' if releasever in kylin else qemu_pkg + ' pyparted iscsi-initiator-utils'
 
     if not remote_bin_installed(host_post_info, "qemu-img", return_status=True):

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -445,6 +445,13 @@ class VmSyncResponse(kvmagent.AgentResponse):
         self.vmInShutdowns = None
 
 
+last_inactive_vol_paths = {}  # type: dict[str, set[str]]
+class VolumeSyncResponse(kvmagent.AgentResponse):
+    def __init__(self):
+        super(VolumeSyncResponse, self).__init__()
+        self.inactiveVolumePaths = {}  # type: dict[str, list[str]]
+
+
 class AttachDataVolumeCmd(kvmagent.AgentCommand):
     def __init__(self):
         super(AttachDataVolumeCmd, self).__init__()
@@ -893,7 +900,7 @@ class GetVirtualizerInfoRsp(kvmagent.AgentResponse):
     def __init__(self):
         super(GetVirtualizerInfoRsp, self).__init__()
         self.hostInfo = VirtualizerInfoTO()
-        self.vmInfoList = [] # type: VirtualizerInfoTO[]
+        self.vmInfoList = []  # type: list[VirtualizerInfoTO]
 
 class VirtualizerInfoTO(object):
     def __init__(self):
@@ -6035,6 +6042,7 @@ class VmPlugin(kvmagent.KvmAgent):
     KVM_ONLINE_INCREASE_MEMORY_PATH = "/vm/increase/mem"
     KVM_GET_CONSOLE_PORT_PATH = "/vm/getvncport"
     KVM_VM_SYNC_PATH = "/vm/vmsync"
+    KVM_VOLUME_SYNC_PATH = "/vm/volumesync"
     KVM_ATTACH_VOLUME = "/vm/attachdatavolume"
     KVM_DETACH_VOLUME = "/vm/detachdatavolume"
     KVM_MIGRATE_VM_PATH = "/vm/migrate"
@@ -6702,6 +6710,44 @@ class VmPlugin(kvmagent.KvmAgent):
         for vm in no_qemu_process_running_vms:
             rsp.states[vm] = Vm.VM_STATE_SHUTDOWN
 
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    @lock.lock('volume-sync-task')
+    def volume_sync(self, req):
+        rsp = VolumeSyncResponse()
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+
+        global last_inactive_vol_paths
+        current_inactive_vol_paths = {}  # type: dict[str, set[str]]
+
+        def get_inactive_vols_from_file_path(fpath):
+            file_dir = fpath if os.path.isdir(fpath) else os.path.dirname(fpath)
+            o = bash.bash_o('grep -Eo "%s[_/a-z0-9\\-]*" %s' % (file_dir, os.path.join(linux.LIVE_LIBVIRT_XML_DIR, "*.xml")))
+            active_vol_paths = set(line.split(":")[-1].strip() for line in o.splitlines())
+
+            file_name = "" if os.path.isdir(fpath) else os.path.basename(fpath)
+            wildcard_name = file_name if "*" in file_name else "%s*" % file_name
+            all_vol_paths = set(glob.glob(os.path.join(file_dir, wildcard_name)))
+
+            return all_vol_paths - active_vol_paths
+
+        for storage_url in cmd.storagePaths:
+            # TODO support other protocols
+            if storage_url.startswith("file://"):
+                inactive_vol_paths = get_inactive_vols_from_file_path(storage_url[7:])
+            else:
+                inactive_vol_paths = set()
+
+            current_inactive_vol_paths[storage_url] = inactive_vol_paths
+
+        for storage_url in current_inactive_vol_paths:
+            if storage_url in last_inactive_vol_paths:
+                twice_inactive_vol_paths = current_inactive_vol_paths[storage_url] & last_inactive_vol_paths[storage_url]
+                if twice_inactive_vol_paths:
+                    rsp.inactiveVolumePaths[storage_url] = list(twice_inactive_vol_paths)
+
+        last_inactive_vol_paths = current_inactive_vol_paths
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror
@@ -9633,6 +9679,7 @@ host side snapshot files chian:
         http_server.register_async_uri(self.KVM_ONLINE_INCREASE_CPU_PATH, self.online_increase_cpu)
         http_server.register_async_uri(self.KVM_ONLINE_INCREASE_MEMORY_PATH, self.online_increase_mem)
         http_server.register_async_uri(self.KVM_VM_SYNC_PATH, self.vm_sync)
+        http_server.register_async_uri(self.KVM_VOLUME_SYNC_PATH, self.volume_sync)
         http_server.register_async_uri(self.KVM_ATTACH_VOLUME, self.attach_data_volume)
         http_server.register_async_uri(self.KVM_DETACH_VOLUME, self.detach_data_volume)
         http_server.register_async_uri(self.KVM_ATTACH_ISO_PATH, self.attach_iso)


### PR DESCRIPTION
Resolves: SUG-622

Change-Id: I7666786b686374686c757a6275706d7079676978

sync from gitlab !4258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 在备份存储功能中增加了对 `sg3_utils` 和 `nvme-cli` 工具的支持，以提高与新硬件的兼容性。
  - 在虚拟机插件中新增了 `VolumeSyncResponse` 类，用于更好地处理卷同步响应。
  - 新增了 `volume_sync` 方法，用于同步虚拟机卷并识别非活动卷路径。

- **功能优化**
  - 更新了 `GetVirtualizerInfoRsp` 类，改进了虚拟机信息列表的类型注释，以提高代码的清晰度和类型安全。

- **Bug 修复**
  - 修复了可能影响虚拟机卷同步的问题，并通过异步URI注册改善了处理性能。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->