### PR TITLE
<fix>[volume]: support enableing extended l2 entries of qcow2

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -1266,6 +1266,8 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
                                                  "%s::%s::%s" % (VOLUME_TAG, cmd.hostUuid, time.time()))
             if cmd.volumeFormat != 'raw':
                 qcow2_options = self.calc_qcow2_option(self, cmd.kvmHostAddons, False, cmd.provisioning)
+                if cmd.qcow2Options:
+                    qcow2_options += cmd.qcow2Options
                 with lvm.OperateLv(install_abs_path, shared=False, delete_when_exception=True):
                     linux.qcow2_create_with_option(install_abs_path, cmd.size, qcow2_options)
                     linux.qcow2_fill(0, 1048576, install_abs_path)


### PR DESCRIPTION
support enableing/disabling extended l2 entries of qcow2 for better performance

Resolves: ZSTAC-61808

Change-Id:11A0DB6248E5424D8ABB-59D8D55EDE58

sync from gitlab !4260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug修复**
  - 修复了块插件中处理`qcow2`选项的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->