### PR TITLE
<fix>[vm]: detach nic should wait for result if already under detaching

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -4142,6 +4142,10 @@ class Vm(object):
 
             return not iproute.is_device_ifname_exists(cmd.nic.nicInternalName)
 
+        def wait_for_detach():
+            if not linux.wait_callback_success(check_device, interval=0.5, timeout=10):
+                raise Exception('NIC device is still attached after 10 seconds. Please check virtio driver or stop VM and detach again.')
+
         if check_device(None):
             return
 
@@ -4157,9 +4161,14 @@ class Vm(object):
             else:
                 self.domain.detachDevice(xml)
 
-            if not linux.wait_callback_success(check_device, interval=0.5, timeout=10):
-                raise Exception('NIC device is still attached after 10 seconds. Please check virtio driver or stop VM and detach again.')
-        except:
+            wait_for_detach()
+        except libvirt.libvirtError as e:
+            logger.warn(linux.get_exception_stacktrace())
+
+            # c.f. https://bugzilla.redhat.com/show_bug.cgi?id=1878659
+            # support new qemu version which will raise exception when detach a nic which is already in the process of unplug
+            if "is already in the process of unplug" in str(e.message):
+                wait_for_detach()
             # check one more time
             if not check_device(None):
                 logger.warn('failed to detach a nic[mac:%s], dump vm xml:\n%s' % (cmd.nic.mac, self.domain_xml))


### PR DESCRIPTION
New version qemu will raise exception when try to detach (device_del in qemu)
 a nic which is already in the process of unplugging, so just ignore the error
 but wait for the nic detached.

Resolves: ZSTAC-57874

Change-Id: I716366706177677477617a6c7469676c7878776a
(cherry picked from commit 2d102ee6bee024d0d30fc8d75cb266b49b8d0328)

sync from gitlab !4293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增加了等待网卡设备脱离的功能，如果超时设备仍未脱离将抛出异常。

- **改进**
  - 对虚拟机插件中检测设备的函数进行了重构。
  - 修改了网卡设备脱离的逻辑，以支持新版本的QEMU异常处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->