### PR TITLE
<fix>[sharedblock]: check the status of sanlock and lvmlockd service

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -1739,4 +1739,8 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         for t in threads:
             t.join()
 
+        if lvm.is_lvmlockd_socket_abnormal():
+            for vgUuid in cmd.vgUuids:
+                rsp.failedVgs.update({vgUuid: "lvmlockd socket is abnormal."})
+
         return jsonobject.dumps(rsp)

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -2928,3 +2928,6 @@ def compare_segmented_xxhash(src_path, dst_path, total_size, raise_exception=Fal
                     else:
                         return False
     return True
+
+def check_unixsock_connection(socket_path, timeout=10):
+    return shell.run("nc -z -U %s -w %s" % (socket_path, timeout))


### PR DESCRIPTION
restart the lvmlockd process when lvmlockd socket exception causes the lvm command to fail

Resolves: ZSTAC-61986

Change-Id:B84504153321421ABB5BF6510CC93A70

sync from gitlab !4301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 增加了检查LVM锁守护进程套接字是否异常的功能。
  - 实现了新的Unix套接字连接检查功能。

- **改进**
  - 对存储卷组进行异常检查，如果发现LVM锁守护进程套接字异常，将更新响应信息以指示失败。

- **Bug修复**
  - 修正了LVM锁守护进程重启的条件，确保仅在必要时重启。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->