### PR TITLE
<fix>[vm]: detach volume should wait for result if already under detaching

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -3047,7 +3047,9 @@ class Vm(object):
                     return not bool(disk)
 
                 try:
-                    self.domain.detachDeviceFlags(xmlstr, libvirt.VIR_DOMAIN_AFFECT_LIVE)
+                    disk_is_unplugging = "is already in the process of unplug"
+                    with misc.ignore_exception(libvirt.libvirtError, disk_is_unplugging):
+                        self.domain.detachDeviceFlags(xmlstr, libvirt.VIR_DOMAIN_AFFECT_LIVE)
 
                     if not linux.wait_callback_success(wait_for_detach, None, 5, 1):
                         raise Exception("unable to detach the volume[uuid:%s] from the vm[uuid:%s];"
@@ -3072,7 +3074,6 @@ class Vm(object):
             if volume.deviceType == 'iscsi':
                 if not volume.useVirtio:
                     logout_iscsi()
-
 
         except libvirt.libvirtError as ex:
             vm = get_vm_by_uuid(self.uuid)

--- a/zstacklib/zstacklib/utils/misc.py
+++ b/zstacklib/zstacklib/utils/misc.py
@@ -9,6 +9,7 @@ import traceback
 import hashlib
 import os
 
+from contextlib import contextmanager
 from zstacklib.utils import bash
 from zstacklib.utils import log
 from zstacklib.utils import linux
@@ -69,3 +70,13 @@ def isHyperConvergedHost():
     if r != 0 or o.strip() != "true":
         return False
     return True
+
+
+@contextmanager
+def ignore_exception(exception_type, message=None):
+    try:
+        yield
+    except exception_type as ex:
+        if message is not None and message not in str(ex.message):
+            raise ex
+        logger.debug("exception caught by the ignore_exception func : %s" % ex.message)


### PR DESCRIPTION
1.New version qemu will raise exception when try to detach (device_del in qemu)
a volume which is already in the process of unplugging, so just ignore the error
but wait for the volume detached.

2.Add a function called "ignore_exception(exception_type, message=None)"
that ignores a specific type of exception.
The "exception_type" parameter indicates the type of exception to ignore.
If the "message" parameter is None,
the exception will be ignored and a log message will be printed.
If the "message" parameter is not None,
the exception will be raised if the message string is contained within the exception.

Resolves: ZSTAC-61404

Change-Id: I646c73736e6c73636d62776b68706f6a6b727363

sync from gitlab !4326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 优化了设备卸载流程中的错误处理机制。
- **代码重构**
  - 移除了设备卸载中不必要的代码行。
- **新特性**
  - 新增了一个用于捕捉和处理特定异常的上下文管理器函数。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->