### PR TITLE
<fix>[zstacklib]: increase socket connect timeout to 15 seconds

### DIFF
--- a/zstacklib/zstacklib/utils/http.py
+++ b/zstacklib/zstacklib/utils/http.py
@@ -288,6 +288,9 @@ class HttpServer(object):
         site_config['server.socket_port'] = self.port
         site_config['server.thread_pool'] = int(os.getenv('POOLSIZE', '10'))
 
+        # Set the socket connect timeout to 15 seconds, keeping it consistent with the default value of the control plane.
+        site_config['server.socket_timeout'] = 15
+
         # remove limitation of request body size, default is 100MB.
         site_config['server.max_request_body_size'] = 0
 


### PR DESCRIPTION
Resolves: ZSTAC-61971

Change-Id: I616c736b61766d6c6d7a75716872796c61636476

sync from gitlab !4330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 为服务器增加了一个新的 socket 超时设置，以调整处理进入请求的行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->