### PR TITLE
<fix>[imagestorebackupstorage]: detect export and registry directory

### DIFF
--- a/imagestorebackupstorage/ansible/imagestorebackupstorage.py
+++ b/imagestorebackupstorage/ansible/imagestorebackupstorage.py
@@ -235,8 +235,9 @@ def load_nbd():
 load_nbd()
 
 if client == "false" and new_add == "false":
-    dst_dir = os.path.join(fs_rootpath, "registry")
-    if not file_dir_exist("path=" + dst_dir, host_post_info):
+    exp_dir = os.path.join(fs_rootpath, "export")
+    reg_dir = os.path.join(fs_rootpath, "registry")
+    if not file_dir_exist("path=" + exp_dir, host_post_info) and not file_dir_exist("path=" + reg_dir, host_post_info):
         error("ERROR: registry directory is missing, imagestore metadata may have been lost. Check it immediately!")
 
 # name: install zstack-store


### PR DESCRIPTION
Resolves: ZSTAC-62267

Change-Id: I65636876737a6f7a636972696f65766c68786669


(cherry picked from commit d50e1bf7af3842e8d2a5b84548647413f0603560)

sync from gitlab !4334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug修复**
  - 更新了条件检查，现在会验证“导出”和“注册表”子目录的存在，以避免潜在的元数据丢失。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->