### PR TITLE
<fix>[zstackbuild]: Do not touch imagestore folder

### DIFF
--- a/zstackbuild/projects/zstack-sharedblock.xml
+++ b/zstackbuild/projects/zstack-sharedblock.xml
@@ -27,8 +27,6 @@
     </target>
 
     <target name="assemble-zstack-sharedblock">
-        <makeDir dir="${imagestorebackupstorage.ansible.dir}" />
-
         <copy todir="${zsblk.ansible.dir}">
             <fileset dir="${zsblk.bdir}">
                 <include name="**/*" />


### PR DESCRIPTION
Do not touch imagestore folder when assemble sblk

Resolves: ZSTAC-62160

Change-Id: I6a6b756474746f6e68717976776a6b727a656c65

sync from gitlab !4339