### PR TITLE
<feature>[shared_block]: added volume encryption for sugon implementation

### DIFF
--- a/zstacklib/zstacklib/utils/secret.py
+++ b/zstacklib/zstacklib/utils/secret.py
@@ -2,13 +2,11 @@
 @author: qiuyu
 '''
 
-import os
 import base64
 import commands
 
 from zstacklib.utils import log
 from zstacklib.utils import shell
-from zstacklib.utils import qemu_img
 
 logger = log.get_logger(__name__)
 
@@ -16,3 +14,39 @@ logger = log.get_logger(__name__)
 def get_image_hash(img_path):
     _, md5 = commands.getstatusoutput("md5sum %s | cut -d ' ' -f 1" % img_path)
     return md5
+
+def is_img_encrypted(img_path):
+    return not shell.run('/usr/bin/qemu-img info %s | grep "encrypted: yes"' %
+                         img_path)
+
+def is_encrypted_by_cmd(cmd):
+    if cmd and cmd.kvmHostAddons:
+        if cmd.kvmHostAddons.encryptKey:
+            return True
+    return False
+
+def get_qemu_encrypt_options(cmd):
+    b64_key = base64.b64encode(cmd.kvmHostAddons.encryptKey)
+    if cmd.size:
+        return ' --object secret,id={0},data={1},format=base64'\
+               ' -o encrypt.format=luks,encrypt.key-secret={0},'\
+               'encrypt.cipher-alg=sm4,size={2} '\
+               .format('sec_' + cmd.volumeUuid, b64_key, cmd.size)
+    return ' --object secret,id={0},data={1},format=base64'\
+           ' -o encrypt.format=luks,encrypt.key-secret={0},'\
+           'encrypt.cipher-alg=sm4 '\
+           .format('sec_' + cmd.volumeUuid, b64_key)
+
+def get_img_path_with_secret_objects(img_path, cmd=None):
+    if not is_img_encrypted(img_path):
+        return img_path
+
+    return ' \'json:{"encrypt.key-secret": "%s", "driver": "qcow2",'\
+           ' "file": {"driver": "file", "filename":"%s"}}\' '\
+           % ('sec_' + cmd.volumeUuid, img_path)
+
+def get_qemu_resize_encrypt_options(cmd, install_abs_path):
+    b64_key = base64.b64encode(cmd.kvmHostAddons.encryptKey)
+    return ' --object secret,id={0},data={1},format=base64 --image-opts ' \
+           'driver=qcow2,encrypt.key-secret={0},file.filename={2} '\
+        .format('sec_' + cmd.volumeUuid, b64_key, install_abs_path)


### PR DESCRIPTION
- Create encrypted root and data volume
    - Enable encrypted data volume attach/detach,
    - Implement encrypted volume VM migration
    - Enable offline snapshots for encrypted volumes
    - Support stop, start, and migration of VMs with encrypted volumes

    Resolves: ZSTAC-60711

    Change-Id: I717865736679656469756b7471646d6f61627077

sync from gitlab !4349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 为虚拟机的数据卷附加和快照添加了加密相关功能。
  - 引入了处理创建和删除qcow2密钥的方法。
  - 对支持加密的不同功能如克隆、调整大小、创建模板等增加了支持。
  - 引入了管理秘密密钥和处理加密相关功能的函数。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->