### PR TITLE
<fix>[snapshot]: fix offline merge snapshot hung

### DIFF
--- a/kvmagent/kvmagent/test/shareblock_testsuite/test_sharedblock_offline_merge_snapshot.py
+++ b/kvmagent/kvmagent/test/shareblock_testsuite/test_sharedblock_offline_merge_snapshot.py
@@ -70,6 +70,11 @@ class TestSharedBlockPlugin(TestCase, SharedBlockPluginTestStub):
         )
         self.assertEqual(True, rsp.success, rsp.error)
 
+        bash.bash_r("lvchange -aey %s" % "/dev/{}/{}".format(vgUuid,volumeUuid2))
+        vsize = int(linux.qcow2_get_virtual_size("/dev/{}/{}".format(vgUuid,volumeUuid2)))
+        rsp = sharedblock_utils.sharedblock_resize_volume("sharedblock://{}/{}".format(vgUuid,volumeUuid2), vsize+1*1024**3)
+        self.assertEqual(True, rsp.success, rsp.error)
+
         rsp = sharedblock_utils.sharedblock_offline_merge_snapshots(
             fullRebase=False,
             srcPath="sharedblock://{}/{}".format(vgUuid,imageUuid),

--- a/kvmagent/kvmagent/test/utils/nfs_plugin_utils.py
+++ b/kvmagent/kvmagent/test/utils/nfs_plugin_utils.py
@@ -40,7 +40,7 @@ def create_root_volume_from_template(templatePathInCache, timeout, virtualSize, 
 
 @misc.return_jsonobject()
 def migrate_bits(srcFolderPath, dstFolderPath, independentPath=False, filtPaths=[], isMounted=True, volumeInstallPath=None, options=None,
-                 url=None, mountPath=None, kvmHostAddons={}):
+                 url=None, mountPath=None, kvmHostAddons={"qcow2Options":""}):
 
     return NFS_PLUGIN.migrate_bits(misc.make_a_request({
         "srcFolderPath": srcFolderPath,

--- a/zstacklib/zstacklib/test/utils/misc.py
+++ b/zstacklib/zstacklib/test/utils/misc.py
@@ -1,6 +1,9 @@
 import functools
 import os
 import uuid as uid
+
+import simplejson
+
 import env
 from zstacklib.utils import jsonobject, log
 from zstacklib.utils.http import REQUEST_BODY
@@ -14,9 +17,8 @@ def uuid():
 
 def make_a_request(body):
     # type: (dict) -> dict
-
     return {
-        REQUEST_BODY: jsonobject.dumps(body)
+        REQUEST_BODY: jsonobject.dumps(body, include_protected_attr=True)
     }
 
 

--- a/zstacklib/zstacklib/utils/jsonobject.py
+++ b/zstacklib/zstacklib/utils/jsonobject.py
@@ -172,14 +172,13 @@ def _dump_list(lst):
     return nlst
 
 
-def _dump(obj):
+def _dump(obj, include_protected_attr=False):
     if _is_primitive_types(obj): return simplejson.dumps(obj, ensure_ascii=True)
 
     ret = {}
     items = obj.iteritems() if isinstance(obj, types.DictionaryType) else obj.__dict__.iteritems()
     for key, val in items:
-        if key.startswith('_'): continue
-
+        if key.startswith('_') and not include_protected_attr: continue
         if _is_unsupported_type(obj):
             raise NoneSupportedTypeError('cannot dump %s, type:%s, object dict: %s' % (val, type(val), obj.__dict__))
 
@@ -190,7 +189,7 @@ def _dump(obj):
                 ret[key] = val
                 continue
 
-            nmap = _dump(val)
+            nmap = _dump(val, include_protected_attr=include_protected_attr)
             ret[key] = nmap
         elif isinstance(val, types.ListType):
             nlst = _dump_list(val)
@@ -198,13 +197,13 @@ def _dump(obj):
         elif isinstance(val, types.NoneType):
             pass
         else:
-            nmap = _dump(val)
+            nmap = _dump(val, include_protected_attr=include_protected_attr)
             ret[key] = nmap
     return ret
 
 
-def dumps(obj, pretty=False):
-    jsonmap = _dump(obj)
+def dumps(obj, pretty=False, include_protected_attr=False):
+    jsonmap = _dump(obj, include_protected_attr)
     if pretty:
         return simplejson.dumps(jsonmap, ensure_ascii=True, sort_keys=True, indent=4)
     else:

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -1092,6 +1092,18 @@ def qcow2_rebase(backing_file, target):
         backing_option = '-F %s -b "%s"' % (fmt, backing_file)
     else:
         backing_option = '-b "%s"' % backing_file
+
+    top_virtual_size = int(qcow2_get_virtual_size(target))
+    backing_chain = qcow2_get_backing_chain(target)
+    for idx, bf in enumerate(backing_chain):
+        if idx == len(backing_chain)-1 and get_img_fmt(bf) != 'qcow2':
+            break
+        bf_virtual_size = int(qcow2_get_virtual_size(bf))
+        if bf_virtual_size < top_virtual_size:
+            qemu_img_resize(bf, top_virtual_size)
+        if bf == backing_file:
+            break
+
     with TempAccessible(target):
         shell.call('%s -f qcow2 %s %s' % (qemu_img.subcmd('rebase'), backing_option, target))
 


### PR DESCRIPTION
offline merging snapshot will hung after top of qcow2 chain expansion, we will expand the virtual size of the backing file to match the top in advance

Resolves: ZSTAC-62187

Change-Id:48EBCE92872F42559FF3DD9FE4BD2B06

sync from gitlab !4351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 在应用程序中增加了搜索功能，提升用户检索信息的效率。

- **Bug 修复**
  - 修复了与调整卷大小相关的逻辑，确保更稳定的快照合并操作。

- **优化**
  - 修改了迁移函数的默认参数值，以更好地支持虚拟机迁移。

- **改进**
  - 更新了 JSON 对象处理方法，允许包含受保护的属性，增强了数据处理的灵活性。

- **性能提升**
  - 优化了虚拟机镜像处理逻辑，确保在执行重组操作前，镜像文件大小得到正确调整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->