### PR TITLE
<fix>[prometheus]: improve collect disk info for collectd_expoter

### DIFF
--- a/kvmagent/kvmagent/plugins/prometheus.py
+++ b/kvmagent/kvmagent/plugins/prometheus.py
@@ -1303,9 +1303,9 @@ LoadPlugin virt
 </Plugin>
 
 <Plugin disk>
-  Disk "/^sd[a-z]$/"
-  Disk "/^hd[a-z]$/"
-  Disk "/^vd[a-z]$/"
+  Disk "/^sd[a-z]{1,2}$/"
+  Disk "/^hd[a-z]{1,2}$/"
+  Disk "/^vd[a-z]{1,2}$/"
   Disk "/^nvme[0-9][a-z][0-9]$/"
   IgnoreSelected false
 </Plugin>


### PR DESCRIPTION
Resolves: ZSTAC-62380

Change-Id: I6b66666976756471706f6872656d776b6b706a61

sync from gitlab !4357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 优化了硬盘名称匹配的正则表达式，以更精确地识别不同类型的硬盘名称。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->