### PR TITLE
<fix>[ceph]: modify the capacity calculation method of zstone ceph

### DIFF
--- a/zstacklib/zstacklib/utils/zstone.py
+++ b/zstacklib/zstacklib/utils/zstone.py
@@ -1,5 +1,6 @@
 import zstacklib.utils.jsonobject as jsonobject
-from zstacklib.utils import shell
+from zstacklib.utils import shell, bash
+from distutils.version import LooseVersion
 
 class ZStoneCephPoolCapacityGetter():
     def fill_pool_capacity(self, result):
@@ -14,3 +15,26 @@ class ZStoneCephPoolCapacityGetter():
                     pool_capacity.used_capacity = pool.stats.stored
                     pool_capacity.pool_total_size = pool_capacity.available_capacity + pool_capacity.used_capacity
                     break
+
+        if not calc_capacity_with_ratio():
+            return
+        ratio = get_full_ratio()
+        for pool_capacity in result:
+            pool_capacity.pool_total_size = long(pool_capacity.pool_total_size / ratio)
+            pool_capacity.available_capacity = long(pool_capacity.available_capacity + pool_capacity.pool_total_size * (1-ratio))
+            pool_capacity.used_capacity = pool_capacity.pool_total_size - pool_capacity.available_capacity
+
+
+
+def calc_capacity_with_ratio():
+    return LooseVersion(get_zstone_version()) >= LooseVersion("4.3.6")
+
+
+def get_zstone_version():
+    o = bash.bash_errorout("/opt/zstone/bin/zstnlet -h | grep Version:")
+    return o.split("Version:")[1].strip()
+
+
+def get_full_ratio():
+    o = bash.bash_errorout("ceph osd dump | grep -E '^full_ratio'")
+    return float(o.split()[1].strip())


### PR DESCRIPTION
when the zstone ceph version is higher than or equal to 4.3.6, use threshold to recalculate capacity

Resolves: ZSTAC-62371

Change-Id:6CBAB5D8F7E84DE8BD6432FA3F0B9C52

sync from gitlab !4361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入了新的存储池容量计算和版本比较逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->