### PR TITLE
<fix>[qga]: update qga monitor log

### DIFF
--- a/kvmagent/kvmagent/plugins/qga_zwatch.py
+++ b/kvmagent/kvmagent/plugins/qga_zwatch.py
@@ -78,7 +78,6 @@ class ZWatchMetricMonitor(kvmagent.KvmAgent):
                     try:
                         if not self.state or http.AsyncUirHandler.STOP_WORLD:
                             break
-                        logger.debug('update vm list')
                         domains = get_domains()
                         vm_states, vm_dict = get_guest_tools_states(domains)
                         self.report_vm_qga_state({
@@ -87,14 +86,16 @@ class ZWatchMetricMonitor(kvmagent.KvmAgent):
                             vmUuid: qgaStatus.zsToolsFound for vmUuid, qgaStatus in vm_states.items()
                         })
                         # remove stopped vm which in running_vm_list
-                        logger.debug('debug: vm list: %s' % self.running_vm_list)
+                        logger.debug('current QGA running vm list (count: %d): %s' %
+                                     (len(self.running_vm_list), self.running_vm_list))
                         last_monitor_vm_list = self.running_vm_list[:]
                         with self.running_vm_lock:
                             self.running_vm_list = [
                                 vmUuid for vmUuid, qgaStatus in vm_states.items() if qgaStatus.qgaRunning
                             ]
                         new_vm_list = set(self.running_vm_list) - set(last_monitor_vm_list)
-                        logger.debug('debug: new vm list: %s' % new_vm_list)
+                        logger.debug('recently detected vm list without QGA (count: %d): %s' %
+                                     (len(new_vm_list), new_vm_list))
                         for vmUuid in new_vm_list:
                             # new vm found
                             qga = vm_dict.get(vmUuid)


### PR DESCRIPTION
Resolves: ZSTAC-62525

Change-Id: I6868776c23125da3ea0a45f5b1b55c969b17d6fe

sync from gitlab !4374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能优化**
  - 优化了虚拟机列表更新时的调试日志。
  - 调整了当前运行 QGA 的虚拟机列表及最近检测到的未运行 QGA 的虚拟机列表的调试日志显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->