### PR TITLE
<fix>[volumesnapshot]: precreate qcow2 with backingFile before taking snapshot

### DIFF
--- a/kvmagent/kvmagent/plugins/nfs_primarystorage_plugin.py
+++ b/kvmagent/kvmagent/plugins/nfs_primarystorage_plugin.py
@@ -829,7 +829,10 @@ class NfsPrimaryStoragePlugin(kvmagent.KvmAgent):
             dirname = os.path.dirname(cmd.installUrl)
             if not os.path.exists(dirname):
                 os.makedirs(dirname)
-            linux.qcow2_create_with_cmd(cmd.installUrl, cmd.size, cmd)
+            if cmd.backingFile:
+                linux.qcow2_create_with_backing_file_and_cmd(cmd.backingFile, cmd.installUrl, cmd, cmd.size)
+            else:
+                linux.qcow2_create_with_cmd(cmd.installUrl, cmd.size, cmd)
         try:
             _create_dir_and_file()
         except Exception as e:


### PR DESCRIPTION
precreate qcow2 with backingFile before taking snapshot

Resolves: ZSTAC-62245

Change-Id:BD16A5B88DCC424F89E0E87537F5D8FF


(cherry picked from commit 26ccf49f11aa54e431aad7449f8f45d7a636708a)

sync from gitlab !4385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 当提供了 `backingFile` 时，现在使用新方法 `qcow2_create_with_backing_file_and_cmd` 创建目录和文件；如果没有提供，将使用原始方法 `qcow2_create_with_cmd`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->