### PR TITLE
<fix>[host]: Fix failed find suitable qemu-kvm rpm package

### DIFF
--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -1249,7 +1249,7 @@ if __name__ == "__main__":
         yum_cmd = yum_cmd.format(releasever, ',zstack-experimental-mn' if cmd.enableExpRepo else '', exclude, updates)
         #support update qemu-kvm and update OS
         if releasever in ['c74', 'c76'] and ("qemu-kvm" in updates or cmd.releaseVersion is not None):
-            update_qemu_cmd = "export YUM0={};yum --disablerepo=* --enablerepo=zstack-mn,qemu-kvm-ev-mn  swap -y -- remove qemu-img-ev -- install qemu-img " \
+            update_qemu_cmd = "export YUM0={}; yum --enablerepo=* clean all && yum --disablerepo=* --enablerepo=zstack-mn,qemu-kvm-ev-mn  swap -y -- remove qemu-img-ev -- install qemu-img " \
                               "&& yum remove qemu-kvm-ev qemu-kvm-common-ev -y && yum --disablerepo=* --enablerepo=zstack-mn,qemu-kvm-ev-mn install qemu-kvm qemu-kvm-common -y && "
             yum_cmd = update_qemu_cmd.format(releasever) + yum_cmd
 


### PR DESCRIPTION
During the updateClusterOS execution, the qemu-kvm replacement is done
before updating the specify rpm, and the yum repo cache is not cleaned
at this time, which will search qemu-kvm package in the old repo and
cause failed to replace qemu-kvm package.
Therefore, clean the yum repo cache before updating the rpm to avoid
using an unexpected repo.

Resolves: ZSTAC-60240,ZSTAC-61881

Change-Id: I74687469686d716d696a736d67666775616f6c6b

sync from gitlab !4393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进功能**
	- 更新操作系统时，现在会先清理 yum 缓存，以确保 qemu-kvm 包更新的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->