### PR TITLE
<fix>[vm]: Fix failed to create snapshots directory

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -3327,8 +3327,7 @@ class Vm(object):
                 continue
 
             snapshot_dir = os.path.dirname(vs_struct.installPath)
-            if not os.path.exists(snapshot_dir):
-                os.makedirs(snapshot_dir)
+            os.makedirs(snapshot_dir)
 
             disk_names.append(disk_name)
             source_file = VmPlugin.get_source_file_by_disk(target_disk)


### PR DESCRIPTION
Due to nfs attribute cache, the os.path.exists may return incorrect
restult, which may cause missing create snapshots directory.
Considering that os.makedirs is an idempotent operation, it can be used
to create snapshots directory directly.

Resolves: ZSV-4288

Change-Id: I6c6d706e766f6c7a656e6e796a67767679736464

sync from gitlab !4427