### PR TITLE
<fix>[sharedblock]: modify the default return of func get_lv_locking_type

### DIFF
--- a/kvmagent/kvmagent/test/shareblock_testsuite/test_sharedblock_check_lock.py
+++ b/kvmagent/kvmagent/test/shareblock_testsuite/test_sharedblock_check_lock.py
@@ -69,8 +69,8 @@ class TestSharedBlockPlugin(TestCase, SharedBlockPluginTestStub):
         self.assertEqual(True, rsp.success, rsp.error)
 
         # If there is no lv, restarting lvmlockd may not restore vg lock（lvm 2.03.11）
-        bash.bash_errorout("lvcreate --size 10M %s" % vgUuid)
-        bash.bash_errorout("lvcreate --size 10M %s" % vg2Uuid)
+        bash.bash_errorout("lvcreate --size 10M --name test-1 %s" % vgUuid)
+        bash.bash_errorout("lvcreate --size 10M --name test-1 %s" % vg2Uuid)
 
         # kill lvmlockd
         lvm.stop_lvmlockd()
@@ -80,6 +80,10 @@ class TestSharedBlockPlugin(TestCase, SharedBlockPluginTestStub):
         self.assertEqual(True, rsp.success, rsp.error)
         self.assertEqual(rsp.failedVgs.hasattr(vgUuid), True, str(rsp.failedVgs))
         self.assertEqual(rsp.failedVgs.hasattr(vg2Uuid), True, str(rsp.failedVgs))
+
+        self.assertEqual(True, lvm.lv_is_active("/dev/%s/test-1" % vgUuid))
+        type = lvm.get_lv_locking_type("/dev/%s/test-1" % vgUuid)
+        self.assertEqual(True, type == lvm.LvmlockdLockType.NULL)
 
         rsp = self.connect(blockUuids[0 : 1], blockUuids, vgUuid, hostUuid, hostId, forceWipe=False)
         self.assertEqual(True, rsp.success, rsp.error)

--- a/kvmagent/kvmagent/test/shareblock_testsuite/test_sharedblock_volume_migrate.py
+++ b/kvmagent/kvmagent/test/shareblock_testsuite/test_sharedblock_volume_migrate.py
@@ -99,7 +99,8 @@ class TestSharedBlockPlugin(TestCase, SharedBlockPluginTestStub):
                 }
             ],
             provisioning=lvm.VolumeProvisioningStrategy.ThickProvisioning,
-            volumePath="sharedblock://{}/{}".format(vgUuid,snaphostUuid)
+            volumePath="sharedblock://{}/{}".format(vgUuid,snaphostUuid),
+            kvmHostAddons={"qcow2Options":" -o cluster_size=2097152 "}
         )
         self.assertEqual(True, lvm.lv_exists("/dev/%s/%s" % (vg2Uuid, volumeUuid)))
         self.assertEqual(True, lvm.lv_exists("/dev/%s/%s" % (vg2Uuid, snaphostUuid)))
@@ -133,7 +134,8 @@ class TestSharedBlockPlugin(TestCase, SharedBlockPluginTestStub):
             ],
             provisioning=lvm.VolumeProvisioningStrategy.ThinProvisioning,
             volumePath="sharedblock://{}/{}".format(vg2Uuid,snaphostUuid),
-            addons={"thinProvisioningInitializeSize":5368709120}
+            addons={"thinProvisioningInitializeSize":5368709120},
+            kvmHostAddons={"qcow2Options":" -o cluster_size=2097152 "}
         )
         self.assertEqual(True, lvm.lv_exists("/dev/%s/%s" % (vgUuid, volumeUuid)))
         self.assertEqual(True, lvm.lv_exists("/dev/%s/%s" % (vgUuid, snaphostUuid)))
@@ -169,7 +171,8 @@ class TestSharedBlockPlugin(TestCase, SharedBlockPluginTestStub):
             ],
             provisioning=lvm.VolumeProvisioningStrategy.ThinProvisioning,
             volumePath="sharedblock://{}/{}".format(vg2Uuid,snaphostUuid),
-            addons={"thinProvisioningInitializeSize":5368709120}
+            addons={"thinProvisioningInitializeSize":5368709120},
+            kvmHostAddons={"qcow2Options":" -o cluster_size=2097152 "}
         )
 
 
@@ -201,7 +204,8 @@ class TestSharedBlockPlugin(TestCase, SharedBlockPluginTestStub):
                     "skipIfExisting" : True
                 }
             ],
-            volumePath="sharedblock://{}/{}".format(vgUuid,snaphostUuid)
+            volumePath="sharedblock://{}/{}".format(vgUuid,snaphostUuid),
+            kvmHostAddons={"qcow2Options":" -o cluster_size=2097152 "}
         )
 
         self.assertEqual(True, rsp.success, rsp.error)

--- a/kvmagent/kvmagent/test/utils/sharedblock_utils.py
+++ b/kvmagent/kvmagent/test/utils/sharedblock_utils.py
@@ -225,14 +225,15 @@ def sharedblock_add_disk(vgUuid=None, hostUuid=None, diskUuid=None, allSharedBlo
     }))
 
 @misc.return_jsonobject()
-def sharedblock_migrate_volumes(vgUuid=None, hostUuid=None, migrateVolumeStructs=None, provisioning=None, volumePath=None, addons={}):
+def sharedblock_migrate_volumes(vgUuid=None, hostUuid=None, migrateVolumeStructs=None, provisioning=None, volumePath=None, addons={}, kvmHostAddons={}):
     return get_sharedblock_plugin().migrate_volumes(misc.make_a_request({
         "vgUuid": vgUuid ,# random uuid
         "hostUuid": hostUuid,
         "migrateVolumeStructs":migrateVolumeStructs,
         "provisioning":provisioning,
         "addons":addons,
-        "volumePath":volumePath
+        "volumePath":volumePath,
+        "kvmHostAddons":kvmHostAddons
     }))
 
 @misc.return_jsonobject()

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -1715,19 +1715,14 @@ def get_lv_locking_type(path):
         return LvmlockdLockType.from_abbr(output.strip(), raise_exception=True)
 
     locking_type = LvmlockdLockType.NULL
-    active = None
     with lock.NamedLock(path.split("/")[-1]):
         try:
-            active = lv_is_active(path)
-            if not active:
+            if not lv_is_active(path):
                 return locking_type
             locking_type = _get_lv_locking_type(path)
         except Exception as e:
             output = bash.bash_o("lvmlockctl -i | grep %s | head -n1 | awk '{print $3}'" % lv_uuid(path))
             locking_type = LvmlockdLockType.from_abbr(output.strip(), raise_exception=False)
-            if active is True and locking_type == LvmlockdLockType.NULL:
-                # NOTE(weiw): this usually because of manipulation of locking by hand
-                locking_type = LvmlockdLockType.SHARE
 
     return locking_type
 


### PR DESCRIPTION
when lv is active but no lock, get_lv_locking_type will return null

Resolves: ZSTAC-63000

Change-Id:90A92E3F4F2640C1BAA1FE3858A2B37A

sync from gitlab !4435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能改进**
  - 优化了逻辑卷锁定状态的检测流程，提升了系统稳定性。

- **Bug修复**
  - 修正了逻辑卷锁定类型判断逻辑，确保了操作的准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->