### PR TITLE
<fix>[zstacklib]: fix nfs cache inconsistency during create directory

### DIFF
--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -765,6 +765,13 @@ def md5sum(file_path):
     #return sum5.strip()
 
 def mkdir(path, mode=0o755):
+    # NOTE(ywang): try to access the path to refresh fs cache,
+    # therefore the exception is no need to handle
+    try:
+        os.access(path, os.R_OK)
+    except Exception:
+        pass
+
     if os.path.isdir(path):
         return True
 


### PR DESCRIPTION
For nfs fs, the attributes of the files are stored in the attribute
cache, os it may happend that host1 deletes the file, but host2 decides
that the file still exists because the cache is not refreshed.
Therefore, access the file/directory to trigger a cache refresh before
determine if the file exists.

Resolves: ZSV-4288

Change-Id: I776775717669647676716174776c786567767171

sync from gitlab !4439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进功能**
  - 优化了创建目录时的文件系统缓存刷新机制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->