### PR TITLE
<fix>[installation]: rename license directory to zs_license

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -4004,7 +4004,7 @@ fi
 echo "Management ip address: $MANAGEMENT_IP" >> $ZSTACK_INSTALL_LOG
 
 # Copy zstack trial license into /var/lib/zstack/license
-ZSTACK_TRIAL_LICENSE="/opt/zstack-dvd/$BASEARCH/$ZSTACK_RELEASE/license/zstack_trial_license"
+ZSTACK_TRIAL_LICENSE="/opt/zstack-dvd/$BASEARCH/$ZSTACK_RELEASE/zs_license/zstack_trial_license"
 if [ -f $ZSTACK_TRIAL_LICENSE ]; then
   mkdir -p $LICENSE_FOLDER && /bin/cp -f $ZSTACK_TRIAL_LICENSE $LICENSE_FOLDER || fail "Failed to copy ZStack trial license to $LICENSE_FOLDER"
 fi


### PR DESCRIPTION
Rename license directory to zs_license to avoid name conflict between
license directory and LICENSE file.

Resolves: ZSV-4449

Change-Id: I746b747a746666777a636c6d646f7767656b676f

sync from gitlab !4450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能更新**
  - 更新了试用许可证文件的存放路径。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->