### PR TITLE
<fix>[vm]: Fix failed delete snapshot when using raw image

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -3812,13 +3812,15 @@ class Vm(object):
             return
         checking_file = top
         while checking_file:
+            if linux.get_volume_format(checking_file) == 'raw':
+                continue
             max_transfer = min(
                 linux.hdev_get_max_transfer_via_ioctl(checking_file),
                 linux.hdev_get_max_transfer_via_segments(checking_file))
             cluster_size = linux.qcow2_get_cluster_size(checking_file)
             if max_transfer < cluster_size:
                 msg = ('Live merge snapshot precheck failed, the qcow2 image '
-                       'cluster size %s large that the block device max '
+                       'cluster size %s large than the block device max '
                        'transfer  %s.') % (cluster_size, max_transfer)
                 raise kvmagent.KvmError(msg)
             if checking_file == base and not fullrebase:

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -1150,6 +1150,15 @@ def qcow2_get_cluster_size(path):
     return int(out.strip())
 
 
+def get_volume_format(path):
+    try:
+        info = json.loads(shell.call(
+            "%s %s --output json" % (qemu_img.subcmd('info'), path)))
+        return info["format"]
+    except Exception as e:
+        logger.error('failed to get %s format, error: %s' % (path, e))
+
+
 class AbstractFileConverter(object):
     __metaclass__ = abc.ABCMeta
 


### PR DESCRIPTION
When qemu version <= 2.12.0, the qcow2 cluster size is checked to see if
the snapshot meets the deletion requirements during delete snapshot, but
it does not consider whether there is a raw image on the backing file
chain. Therefore, skip the check if a raw image was detected.

Resolves: ZSTAC-63214

Change-Id: I6e69747375636f7965696578687873677274656d

sync from gitlab !4462