### PR TITLE
<fix>[shared_block]: fix migrate qcow2 lv

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -1450,12 +1450,14 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
                     lv_size = int(linux.qcow2_virtualsize(current_abs_path))
                     lv_size = lvm.calcLvReservedSize(lv_size)
                 elif struct.independent:
-                    lv_size = int(linux.qcow2_measure_required_size(current_abs_path))
+                    cluster_size = linux.qcow2_get_cluster_size(current_abs_path)
+                    lv_size = linux.qcow2_measure_required_size(current_abs_path, cluster_size=cluster_size)
                     lv_size = lvm.calcLvReservedSize(lv_size)
                 else:
                     lv_size = int(lvm.get_lv_size(current_abs_path))
                     if linux.qcow2_get_backing_file(current_abs_path) == '':
-                        measure_size = int(linux.qcow2_measure_required_size(current_abs_path))
+                        cluster_size = linux.qcow2_get_cluster_size(current_abs_path)
+                        measure_size = linux.qcow2_measure_required_size(current_abs_path, cluster_size=cluster_size)
                         if lvm.calcLvReservedSize(measure_size) > lv_size:
                             struct.put('compressed_qcow2', True)
                 struct.put('lv_size', lv_size)

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -4410,9 +4410,9 @@ class Vm(object):
                 linux.hdev_get_max_transfer_via_ioctl(checking_file),
                 linux.hdev_get_max_transfer_via_segments(checking_file))
             cluster_size = linux.qcow2_get_cluster_size(checking_file)
-            if max_transfer < cluster_size:
+            if cluster_size > 0 and max_transfer < cluster_size:
                 msg = ('Live merge snapshot precheck failed, the qcow2 image '
-                       'cluster size %s large that the block device max '
+                       'cluster size %s larger than the block device max '
                        'transfer  %s.') % (cluster_size, max_transfer)
                 raise kvmagent.KvmError(msg)
             if checking_file == base and not fullrebase:

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -1231,15 +1231,19 @@ def qcow2_fill(seek, length, path, raise_excpetion=False):
     cmd(raise_excpetion)
     logger.debug("qcow2_fill return code: %s, stdout: %s, stderr: %s" % (cmd.return_code, cmd.stdout, cmd.stderr))
 
-def qcow2_measure_required_size(path):
-    out = shell.call("%s --output=json -f qcow2 -O qcow2 %s" % (qemu_img.subcmd('measure'), path))
+
+def qcow2_measure_required_size(path, cluster_size=0):
+    opts = "" if cluster_size == 0 else "-o cluster_size=%s" % cluster_size
+
+    out = shell.call("%s --output=json -f qcow2 -O qcow2 %s %s" % (qemu_img.subcmd('measure'), opts, path))
     return long(simplejson.loads(out)["required"])
 
 
 def qcow2_get_cluster_size(path):
-    out = shell.call("%s %s | grep 'cluster_size:' | cut -d ':' -f 2" %
-                     (qemu_img.subcmd('info'), path))
-    return int(out.strip())
+    out = shell.call("%s --output=json %s" % (qemu_img.subcmd('info'), path))
+    ret = simplejson.loads(out)
+    return 0 if 'cluster-size' not in ret else ret['cluster-size']
+
 
 def qcow2_discard(path):
     virtual_size = int(qcow2_get_virtual_size(path))


### PR DESCRIPTION
use same cluster size to measure and create lv
different cluster size cause different space usage.

Resolves: ZSTAC-63193

Change-Id: I6c78666d6b6b746e7272766e696e746c73736a76

sync from gitlab !4466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了共享块插件中计算卷大小逻辑，以包含对 qcow2 操作的改进。
	- 在虚拟机插件中增加了对快照合并能力的检查条件，提高了系统的稳定性和灵活性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->