### PR TITLE
<fix>[sharedblock]: check multipath consistency

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -494,6 +494,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             try:
                 create_vg(hostUuid, vgUuid, self.get_disk_paths(disks))
                 find_vg(vgUuid)
+                lvm.check_pv_multipath(vgUuid, diskPaths)
             except RetryException as ee:
                 raise Exception("can not find vg %s with disks: %s and create vg with forceWipw=%s, %s" %
                                 (vgUuid, diskPaths, forceWipe, str(ee)))


### PR DESCRIPTION
after the VG is created, check the data consistency of each PV in the multipath

Resolves: ZSTAC-59798

Change-Id:88A92E304F2680C1BAA1FE3858A2B34d

sync from gitlab !4486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
    - 在创建卷组后，增加了对多路径磁盘的检查功能，以提高数据一致性和系统稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->