### PR TITLE
<fix>[vm]: use xfs instead of ext4 to save storage usage

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -2917,7 +2917,7 @@ class Vm(object):
                 memory_snapshot_path = None
                 if vs_struct.installPath.startswith("/dev/"):
                     lvm.active_lv(vs_struct.installPath)
-                    shell.call("mkfs.ext4 -F %s" % vs_struct.installPath)
+                    shell.call("mkfs.xfs -f %s" % vs_struct.installPath)
                     mount_path = vs_struct.installPath.replace("/dev/", "/tmp/")
                     if not os.path.exists(mount_path):
                         linux.mkdir(mount_path)


### PR DESCRIPTION
Resolves: ZSTAC-61770

Change-Id: I61696863727166656e6f66766e73697872766369
(cherry picked from commit aba4aaddc645b815bdcbd61a4209b1a4c7034832)

sync from gitlab !4500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了虚拟机文件系统的创建命令，从 `mkfs.ext4` 更改为 `mkfs.xfs`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->