### PR TITLE
<fix>[sharedblock]: check the connection of lvmlockd socket

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -1621,4 +1621,8 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         for t in threads:
             t.join()
 
+        if lvm.is_lvmlockd_socket_abnormal():
+            for vgUuid in cmd.vgUuids:
+                rsp.failedVgs.update({vgUuid: "lvmlockd socket is abnormal."})
+
         return jsonobject.dumps(rsp)

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -2673,3 +2673,6 @@ def compare_segmented_xxhash(src_path, dst_path, total_size, raise_exception=Fal
                     else:
                         return False
     return True
+
+def check_unixsock_connection(socket_path, timeout=10):
+    return shell.run("nc -z -U %s -w %s" % (socket_path, timeout))

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -32,6 +32,7 @@ DEB_SANLOCK_CONFIG_FILE_PATH = "/etc/default/sanlock"
 LIVE_LIBVIRT_XML_DIR = "/var/run/libvirt/qemu"
 SANLOCK_IO_TIMEOUT = 40
 LVMLOCKD_LOG_FILE_PATH = "/var/log/lvmlockd/lvmlockd.log"
+LVMLOCKD_SOCKET = "/run/lvm/lvmlockd.socket"
 LVMLOCKD_LOG_RSYSLOG_PATH = "/etc/rsyslog.d/lvmlockd.conf"
 LVMLOCKD_SERVICE_PATH = "/lib/systemd/system/lvm2-lvmlockd.service"
 LVMLOCKD_LOG_LOGROTATE_PATH = "/etc/logrotate.d/lvmlockd"
@@ -628,15 +629,42 @@ def config_lvmlocal_conf(node, value):
 
 
 @bash.in_bash
+def is_lvmlockd_socket_abnormal():
+    if linux.check_unixsock_connection(LVMLOCKD_SOCKET) == 0:
+        return False
+
+    @linux.retry(3, 1)
+    def check_lvmlockd_log():
+        # check if lvmlockd can receive the lvm command
+        fake_vg = 'fake_vg_%s' % linux.get_current_timestamp()
+        start_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        vgck(fake_vg, 10)
+        end_time = (datetime.datetime.now() + datetime.timedelta(seconds=2)).strftime("%Y-%m-%d %H:%M:%S")
+        if not lvmlockd_log_search('vgck', start_time, end_time):
+            raise RetryException("lvmlockd socket exceptions!")
+    try:
+        check_lvmlockd_log()
+        return False
+    except Exception as e:
+        logger.warn(str(e))
+        return True
+
+@bash.in_bash
 def start_lvmlockd(io_timeout=40):
     if not os.path.exists(os.path.dirname(LVMLOCKD_LOG_FILE_PATH)):
         os.mkdir(os.path.dirname(LVMLOCKD_LOG_FILE_PATH))
 
     config_lvmlockd(io_timeout)
-    running_lockd_version = get_running_lvmlockd_version()
-    if running_lockd_version and LooseVersion(running_lockd_version) < LooseVersion(get_lvmlockd_version()):
+
+    def is_lvmlockd_upgraded():
+        running_lockd_version = get_running_lvmlockd_version()
+        return running_lockd_version is not None and LooseVersion(running_lockd_version) < LooseVersion(get_lvmlockd_version())
+
+    restart_lvmlockd = is_lvmlockd_upgraded() or (LooseVersion(get_lvmlockd_version()) >= LooseVersion("2.03") and is_lvmlockd_socket_abnormal())
+    if restart_lvmlockd:
         write_lvmlockd_adopt_file()
         stop_lvmlockd()
+        linux.rm_file_force(LVMLOCKD_SOCKET)
     for service in ["sanlock", get_lvmlockd_service_name()]:
         cmd = shell.ShellCmd("timeout 30 systemctl start %s" % service)
         cmd(is_exception=True)


### PR DESCRIPTION
check the connection of lvmlockd socket, then determine if it is necessary to restart the lvmlockd service

Resolves: ZSTAC-61986

Change-Id:C62D76876DF24ACBAF721B1A9EB90380

sync from gitlab !4505

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 增加了对异常LVM lockd套接字的检查，并相应更新失败的VGs。
	- 新增了一个函数`check_unixsock_connection`，用于使用`nc`命令验证Unix套接字连接。
	- 添加了`LVMLOCKD_SOCKET`常量和`is_lvmlockd_socket_abnormal`函数，用于检查LVM锁守护进程套接字状态，并对`start_lvmlockd`进行了重构，以处理套接字异常和版本升级。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->