### PR TITLE
<fix>[ansible]: do not restart libvirted when deploy kvmagent

### DIFF
--- a/kvmagent/ansible/kvm.py
+++ b/kvmagent/ansible/kvm.py
@@ -835,6 +835,11 @@ def start_kvmagent():
     if chroot_env != 'false':
         return
 
+    if init == 'true':
+        # name: restart libvirtd when init installation to make sure qemu.conf changes
+        # take effects
+        service_status("libvirtd", "state=restarted enabled=yes", host_post_info)
+
     # name: restart kvmagent, do not use ansible systemctl due to kvmagent can start by itself, so systemctl will not know
     # the kvm agent status when we want to restart it to use the latest kvm agent code
     if host_info.distro in RPM_BASED_OS and host_info.major_version >= 7:

--- a/kvmagent/ansible/kvm.py
+++ b/kvmagent/ansible/kvm.py
@@ -835,9 +835,6 @@ def start_kvmagent():
     if chroot_env != 'false':
         return
 
-    if any(status != "changed:False" for status in [libvirtd_status, libvirtd_conf_status, qemu_conf_status, copy_smart_nics_status]):
-        # name: restart libvirtd if status is stop or cfg changed
-        service_status("libvirtd", "state=restarted enabled=yes", host_post_info)
     # name: restart kvmagent, do not use ansible systemctl due to kvmagent can start by itself, so systemctl will not know
     # the kvm agent status when we want to restart it to use the latest kvm agent code
     if host_info.distro in RPM_BASED_OS and host_info.major_version >= 7:

--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -2921,8 +2921,7 @@ done
                 rsp.error = "update /etc/libvirt/qemu.conf failed, please check qemu.conf"
                 return jsonobject.dumps(rsp)
 
-        shell.call('systemctl restart libvirtd')
-        rsp.restartLibvirt = True
+        rsp.restartLibvirt = False
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror

--- a/kvmagent/kvmagent/test/unittest_tools/install_kvm.sh
+++ b/kvmagent/kvmagent/test/unittest_tools/install_kvm.sh
@@ -16,5 +16,5 @@ cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
 cd /usr/local/zstack/ansible || true
 echo ${host_ip} > /usr/local/zstack/ansible/hosts
 source /root/venv2/bin/activate
-PYTHONPATH=/root/.zguest/zstack-utility/zstacklib/ansible python /root/.zguest/zstack-utility/kvmagent/ansible/kvm.py -i /usr/local/zstack/ansible/hosts -e "{\"host\":\"${host_ip}\",\"pip_url\":\"${pip_url}\",\"trusted_host\":\"${trusted_host}\",\"zstack_repo\":\"${zstack_repo}\",\"zstack_root\":\"${zstack_root}\",\"pkg_zstacklib\":\"${pkg_zstacklib}\",\"pkg_kvmagent\":\"${pkg_kvmagent}\",\"unittest_flag\":\"${unittest_flag}\"}"
+PYTHONPATH=/root/.zguest/zstack-utility/zstacklib/ansible python /root/.zguest/zstack-utility/kvmagent/ansible/kvm.py -i /usr/local/zstack/ansible/hosts -e "{\"host\":\"${host_ip}\",\"pip_url\":\"${pip_url}\",\"trusted_host\":\"${trusted_host}\",\"zstack_repo\":\"${zstack_repo}\",\"zstack_root\":\"${zstack_root}\",\"pkg_zstacklib\":\"${pkg_zstacklib}\",\"pkg_kvmagent\":\"${pkg_kvmagent}\",\"unittest_flag\":\"${unittest_flag}\", \"init\":\"true\"}"
 deactivate


### PR DESCRIPTION
separate libvirt's lifecyle operations from kvmagent's lifecyle

only restart libvirtd when its needed (socket closed or manual
 restarted)

Resolves: ZSTAC-63076

Change-Id: I687770747473766e6a7770756e726d7a7567656d
Signed-off-by: AlanJager <ye.zou@zstack.io>
(cherry picked from commit 4fbad5dfa846a4c1a2a569b7a4fd605c064b54d2)

sync from gitlab !4514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug 修复**
    - 在 `start_kvmagent` 函数中移除了重启 `libvirtd` 前对各种状态的检查。
    - 更新了 `host_plugin.py` 中 `update_spice_channel_config` 函数的逻辑，现在不再重启 `libvirtd` 服务，而是将响应中的 `restartLibvirt` 设置为 `False`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->