### PR TITLE
<fix>[ansible]: restart libvirtd if required from control plane

### DIFF
--- a/kvmagent/ansible/kvm.py
+++ b/kvmagent/ansible/kvm.py
@@ -50,6 +50,7 @@ unittest_flag = 'false'
 mn_ip = None
 isInstallHostShutdownHook = 'false'
 isEnableKsm = 'none'
+restartLibvirtd = 'false'
 
 
 # get parameter from shell
@@ -835,8 +836,9 @@ def start_kvmagent():
     if chroot_env != 'false':
         return
 
-    if init == 'true':
+    if init == 'true' or restartLibvirtd == 'true':
         # name: restart libvirtd when init installation to make sure qemu.conf changes
+        # or restart libvirtd when restartLibvirtd is true (from control plane settings)
         # take effects
         service_status("libvirtd", "state=restarted enabled=yes", host_post_info)
 

--- a/kvmagent/ansible/kvm.py
+++ b/kvmagent/ansible/kvm.py
@@ -51,6 +51,7 @@ mn_ip = None
 isInstallHostShutdownHook = 'false'
 isEnableKsm = 'none'
 restartLibvirtd = 'false'
+enableSpiceTls = None
 
 
 # get parameter from shell
@@ -504,6 +505,17 @@ def copy_kvm_files():
     qemu_conf_src = os.path.join(file_root, "qemu.conf")
     qemu_conf_dst = "/etc/libvirt/qemu.conf"
     qemu_conf_status = copy_to_remote(qemu_conf_src, qemu_conf_dst, None, host_post_info)
+
+    if enableSpiceTls == 'true':
+        # unnote following lines in qemu.conf
+        #spice_tls_x509_cert_dir = "/var/lib/zstack/kvm/package/spice-certs/"
+        #spice_tls = 1
+        replace_content(qemu_conf_dst, "regexp='#spice_tls_x509_cert_dir.*' replace='spice_tls_x509_cert_dir = \"/var/lib/zstack/kvm/package/spice-certs/\"'", host_post_info)
+        replace_content(qemu_conf_dst, "regexp='#spice_tls.*' replace='spice_tls = 1'", host_post_info)
+    elif enableSpiceTls == 'false':
+        # disable spice_tls
+        replace_content(qemu_conf_dst, "regexp='spice_tls_x509_cert_dir = \"/var/lib/zstack/kvm/package/spice-certs/\"' replace='#spice_tls_x509_cert_dir ='", host_post_info)
+        replace_content(qemu_conf_dst, "regexp='spice_tls = 1' replace='#spice_tls = 1'", host_post_info)
 
     # copy zstacklib pkg
     zslib_src = os.path.join("files/zstacklib", pkg_zstacklib)

--- a/kvmagent/ansible/qemu.conf
+++ b/kvmagent/ansible/qemu.conf
@@ -127,7 +127,7 @@
 #
 # This option allows the certificate directory to be changed.
 #
-#spice_tls_x509_cert_dir = "/etc/pki/libvirt-spice"
+#spice_tls_x509_cert_dir = "/var/lib/zstack/kvm/package/spice-certs/"
 
 
 # The default SPICE password. This parameter is only used if the


### PR DESCRIPTION
Resolves: ZSTAC-59969

Change-Id: I746d7a6e7a666663786e7673616b6f796a6e6874

sync from gitlab !4522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在KVM配置中添加了处理启用和禁用Spice TLS的功能。如果`enableSpiceTls`为真，则修改`qemu.conf`以启用Spice TLS；如果为假，则禁用它。此外，引入了`restartLibvirtd`来根据控制平面设置重启libvirtd。
	- 更新了QEMU配置文件中SPICE TLS X.509证书目录的路径。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->