### PR TITLE
<fix>[prometheus]: ignore device with cdrom device letters

### DIFF
--- a/kvmagent/kvmagent/plugins/prometheus.py
+++ b/kvmagent/kvmagent/plugins/prometheus.py
@@ -803,7 +803,7 @@ LoadPlugin virt
 	RefreshInterval {{INTERVAL}}
 	HostnameFormat name
     PluginInstanceFormat name
-    BlockDevice "/:hd[a-z]/"
+    BlockDevice "/:hd[c-e]/"
     BlockDevice "{{IGNORE}}"
     IgnoreSelected true
     ExtraStats "vcpu memory"


### PR DESCRIPTION
Resolves: ZSTAC-63687
Resolves: ZSTAC-54583

Change-Id: I6f6d6c7765646f636c656b61766b6a70616e6873
Signed-off-by: AlanJager <ye.zou@zstack.io>
(cherry picked from commit 41891321c36b8d4a23e79daae6c62b832082b2c3)
Signed-off-by: AlanJager <ye.zou@zstack.io>

sync from gitlab !4528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了 `BlockDevice` 配置，从 `/:hd[a-z]/` 更改为 `/:hd[c-e]/`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->