### PR TITLE
<fix>[zstackctl]: set wait_timeout=28800 for every flyway connection

### DIFF
--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -8177,15 +8177,19 @@ class UpgradeDbCmd(Command):
                             (db_user, db_hostname, db_port, sql))
 
         def migrate():
+            # set wait_timeout to 28800s(8 hours) to avoid 'MySQL has gone away' error
+            # because the database upgrading process may cost a long time
+            init_sql = "set wait_timeout=28800;"
+
             try:
                 schema_path = 'filesystem:%s' % upgrading_schema_dir
 
                 if db_password:
-                    shell_no_pipe('bash %s migrate -outOfOrder=true -user=%s -password=%s -url=%s -locations=%s' % (
-                    flyway_path, db_user, db_password, db_url, schema_path))
+                    shell_no_pipe('bash %s migrate -outOfOrder=true -user=%s -password=%s -url=%s -locations=%s -initSql="%s"' % (
+                    flyway_path, db_user, db_password, db_url, schema_path, init_sql))
                 else:
-                    shell_no_pipe('bash %s migrate -outOfOrder=true -user=%s -url=%s -locations=%s' % (
-                    flyway_path, db_user, db_url, schema_path))
+                    shell_no_pipe('bash %s migrate -outOfOrder=true -user=%s -url=%s -locations=%s -initSql=%s' % (
+                    flyway_path, db_user, db_url, schema_path, init_sql))
             except Exception as e:
                 sql = "update schema_version set checksum = 249136114 where script = 'V3.5.0.1__schema.sql' and checksum = -1670610242"
                 execute_sql(sql)


### PR DESCRIPTION
Resolves: ZSTAC-51556

Change-Id: I616f6875796c6c69657877766563697075647074
Signed-off-by: AlanJager <ye.zou@zstack.io>

sync from gitlab !4532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
	- 为了解决数据库升级过程中可能出现的 'MySQL has gone away' 错误，增加了初始化 SQL 语句 `set wait_timeout=28800;`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->