### PR TITLE
<fix>[ansible]: Fix misspelling of param

### DIFF
--- a/kvmagent/ansible/kvm.py
+++ b/kvmagent/ansible/kvm.py
@@ -50,7 +50,7 @@ unittest_flag = 'false'
 mn_ip = None
 isInstallHostShutdownHook = 'false'
 isEnableKsm = 'none'
-restartLibvirtd = 'false'
+restart_libvirtd = 'false'
 enableSpiceTls = None
 
 
@@ -848,9 +848,9 @@ def start_kvmagent():
     if chroot_env != 'false':
         return
 
-    if init == 'true' or restartLibvirtd == 'true':
+    if init == 'true' or restart_libvirtd == 'true':
         # name: restart libvirtd when init installation to make sure qemu.conf changes
-        # or restart libvirtd when restartLibvirtd is true (from control plane settings)
+        # or restart libvirtd when restart_libvirtd is true (from control plane settings)
         # take effects
         service_status("libvirtd", "state=restarted enabled=yes", host_post_info)
 


### PR DESCRIPTION
Rename restartLibvirtd to restart_libvirtd to receive correct param.

Resolves: ZSTAC-63638, ZSTAC-63641

Change-Id: I7a6a61766875697477686a686b716a63616f6d75

sync from gitlab !4536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
	- 为了命名一致性，修改了与重启 `libvirtd` 相关条件检查中的变量名称。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->