### PR TITLE
<fix>[vm]: use migratable xml to keep libvirt back-compitability

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -2115,6 +2115,13 @@ class Vm(object):
     def get_name(self):
         return self.domain_xmlobject.description.text_
 
+    def get_migratable_xml(self):
+        try:
+            return self.domain.XMLDesc(libvirt.VIR_DOMAIN_XML_MIGRATABLE)
+        except Exception as e:
+            logger.warn("unable to get migratable xml for vm[uuid:%s], %s" % (self.uuid, str(e)))
+            return self.domain_xml
+
     def refresh(self):
         (state, _, _, _, _) = self.domain.info()
         self.state = self.power_state[state]
@@ -3180,7 +3187,7 @@ class Vm(object):
             migrate_disks[disk_name] = volume
 
         xml_changed = False
-        tree = etree.ElementTree(etree.fromstring(self.domain_xml))
+        tree = etree.ElementTree(etree.fromstring(self.get_migratable_xml()))
         devices = tree.getroot().find('devices')
         for disk in tree.iterfind('devices/disk'):
             dev = disk.find('target').attrib['dev']


### PR DESCRIPTION
Libvirt support dumpxml with VIR_DOMAIN_XML_MIGRATABLE which could
 dump XML suitable for migration.

VIR_DOMAIN_XML_MIGRATABLE influence following cases:

1. If default use controller is present, xml will remove it to keep
 compatible with older versions of libvirt
2. Default PCI controller will be removed if there is only one present
 and its model is pci-root
3. For panic models 'S390' and 'PSERIES' will be removed but cloud only
 use 'ISA' or 'HYPERV'
4. Cpu capability check when check set to 'full' which may break live
 migration due to disabled cpu feature check

Resolves: ZSTAC-58098

Change-Id: I72786671787a616170706f6c796376776f6a7661
Signed-off-by: AlanJager <ye.zou@zstack.io>
(cherry picked from commit fa8a991b91e32260c8e40b1671137fdae5b8baa9)
(cherry picked from commit 839cef2a30a73efb8ba393c51ebbe0d2e179e2f3)

sync from gitlab !4539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 增加了一种方法来检索可迁移的虚拟机XML。
- **改进**
	- 更新了虚拟机状态刷新逻辑，以便基于域信息进行更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->