### PR TITLE
<fix>[zstacklib]: fix volume all file has no backing

### DIFF
--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -1227,15 +1227,14 @@ def get_qcow2_base_backing_file_recusively(path):
 def get_qcow2_base_images_recusively(vol_install_dir, image_cache_dir):
     real_vol_dir = os.path.realpath(vol_install_dir)
     real_cache_dir = os.path.realpath(image_cache_dir)
-    backing_files = shell.call(
-        "set -o pipefail; find %s -type f -name '*.qcow2' -exec %s {} \;| grep 'backing file:' | awk '{print $3}'"
-        % (real_vol_dir, qemu_img.subcmd('info'))).splitlines()
 
     base_image = set()
-    for backing_file in backing_files:
-        real_image_path = os.path.realpath(backing_file)
-        if real_image_path.startswith(real_cache_dir):
-            base_image.add(real_image_path)
+    for p in list_all_file(real_vol_dir):
+        backing_file = qcow2_get_backing_file(p)
+        if backing_file:
+            real_image_path = os.path.realpath(backing_file)
+            if real_image_path.startswith(real_cache_dir):
+                base_image.add(real_image_path)
 
     return base_image
 


### PR DESCRIPTION
Resolves: ZSTAC-60300

Change-Id: I64637a79686f636f627368636c67767262676376

sync from gitlab !4543

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能更新**
	- 更新了获取 QCOW2 基础镜像的逻辑，通过更结构化的方式检查备份文件，以改进基础镜像的识别方法。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->