### PR TITLE
<fix>[zstackctl]: restore server port to 5000 when ssl disabled

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -3007,8 +3007,7 @@ cs_enable_console_proxy_cert(){
 cs_enable_ui_ssl_cert(){
     echo_subtitle "Configure UI server SSL certificate"
     trap 'traplogger $LINENO "$BASH_COMMAND" $?'  DEBUG
-    zstack-ctl config_ui server_port=5443
-    zstack-ctl config_ui enable_ssl=true
+    zstack-ctl config_ui --enable-ssl=true --server_port=5443 > /dev/null
 }
 
 check_zstack_server(){

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -10167,11 +10167,15 @@ class ConfigUiCmd(Command):
                 ctl.write_ui_property(k.lstrip('--'), v)
 
         # use 5443 instead if enable_ssl
-        if args.enable_ssl and args.enable_ssl.lower() == 'true':
-            # if args.webhook_port == '5000':
-            #     args.webhook_port = '5443'
-            if args.server_port == '5000':
+        # This is a HACK: modify enable_ssl config will update server_port (webhook_port will not change)
+        if args.enable_ssl is not None:
+            current_server_port = ctl.read_ui_property("server_port")
+            if args.enable_ssl.lower() == 'true' and current_server_port == '5000':
+                print('Enable SSL: The server port is updated to 5443. Restart UI server to make the configuration take effect.')
                 args.server_port = '5443'
+            elif args.enable_ssl.lower() == 'false' and current_server_port == '5443':
+                print('Disable SSL: The server port is updated to 5000. Restart UI server to make the configuration take effect.')
+                args.server_port = '5000'
 
         # copy args.ssl_keystore to ctl.ZSTACK_UI_KEYSTORE_CP
         if args.ssl_keystore and args.ssl_keystore != ctl.ZSTACK_UI_KEYSTORE:


### PR DESCRIPTION
Resolves: ZSV-4885

Change-Id: I6f6d676677776571736c77797869646a6b6d6a6a

sync from gitlab !4546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
    - 在`install.sh`脚本中，`cs_enable_ui_ssl_cert`函数现在使用`zstack-ctl config_ui --enable-ssl=true --server_port=5443`来配置UI服务器SSL证书设置，取代了单独的配置行。
    - 在`ctl.py`的`run`方法中，更新了处理SSL配置的逻辑，根据`enable_ssl`标志和当前`server_port`设置动态调整`server_port`。如果`enable_ssl`不是`None`并且设置为`true`，并且当前`server_port`为`5000`，则将`server_port`更新为`5443`并显示相应消息。如果`enable_ssl`设置为`false`，并且当前`server_port`为`5443`，则将`server_port`更新为`5000`并显示消息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->