### PR TITLE
<fix>[host]: get libvirt version after update libvirt

### DIFF
--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -1648,6 +1648,8 @@ if __name__ == "__main__":
                 rsp.success = False
                 rsp.error = "failed to update host os using zstack-mn,qemu-kvm-ev-mn repo, stdout: %s, stderr: %s" % (shell_cmd.stdout, shell_cmd.stderr)
 
+        rsp.libvirtVersion = shell.call("rpm -q libvirt --qf ' %{VERSION}-%{RELEASE}'")
+
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror


### PR DESCRIPTION
Resolves: ZSTAC-63777

Change-Id: I6f797563786c697463696e787272766765686b64

sync from gitlab !4549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 添加了在`update_os`方法中检索libvirt版本并将其分配给`rsp.libvirtVersion`的功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->