### PR TITLE
<fix>[installation]: update UI server port when upgrade

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -2629,6 +2629,17 @@ cs_config_zstack_properties(){
         fi
     fi
 
+    # update UI server port for upgrading system
+    if [ x"$UPGRADE" = x'y' ];then
+        old_server_port=`zstack-ctl show_ui_config | grep server_port | awk -F'=' '{ print $2 }' | sed -e 's/^[[:space:]]*//'`
+        old_enable_ssl=`zstack-ctl show_ui_config | grep enable_ssl | awk -F'=' '{ print $2 }' | sed -e 's/^[[:space:]]*//'`
+        if [ x"$old_enable_ssl" = x"true" ] && [ x"$old_server_port" = x"5000" ];then
+            zstack-ctl config_ui --enable-ssl=true --server_port=5443 > /dev/null
+        elif [ x"$old_enable_ssl" = x"false" ] && [ x"$old_server_port" = x"5443" ];then
+            zstack-ctl config_ui --enable-ssl=false --server_port=5000 > /dev/null
+        fi
+    fi
+
     pass
 }
 


### PR DESCRIPTION
For *a newly installed system*:
(zsv version >= 4.2.0)

|              | zstack.ui.properties | Actual ports used |
| ------------ | -------------------- | ----------------- |
| ssl_disabled | server_port = 80     | 80                |
| ssl_enabled  | server_port = 443    | 443               |

For *an old system*:
(zsv version <= 4.1.6)

When you update enable_ssl config, the ui.properties will not changed,
but actual port is updated.

|              | zstack.ui.properties | Actual ports used |
| ------------ | -------------------- | ----------------- |
| ssl_disabled | server_port = 5000   | 5000              |
| ssl_enabled  | server_port = 5000   | 5443              |

When *an old system upgraded*:
(from zsv version <= 4.1.6, upgrade to zsv version >= 4.2.0)

|              | zstack.ui.properties | Actual ports used |
| ------------ | -------------------- | ----------------- |
| ssl_disabled | server_port = 5000   | 5000              |
| ssl_enabled  | server_port = 5443   | 5443              |

Resolves: ZSV-5067
Related: ZSV-4876

Change-Id: I776f6e71616c6b67616f617578776b6969616164

sync from gitlab !4554