### PR TITLE
<fix>[installation]: update certificate config when zsphere install

### DIFF
--- a/docs/modules/zstackctl/pages/status.adoc
+++ b/docs/modules/zstackctl/pages/status.adoc
@@ -40,7 +40,7 @@ PID file: /usr/local/zstack/management-server.pid
 log file: /usr/local/zstack/apache-tomcat/logs/management-server.log
 version: 4.3.12 (ZStack-Cloud 4.3.12.4663)
 MN status: Running [PID:24108] <3>
-UI status: Running [PID:35833] http://10.0.57.94:5000 <4>
+UI status: Running [PID:35833] http://10.0.57.94:80 <4>
 ----
 <1> ZSTACK_HOME 目录位置
 <2> 管理节点配置文件位置

--- a/installation/install.sh
+++ b/installation/install.sh
@@ -2546,6 +2546,8 @@ config_system(){
     show_spinner cs_append_iptables
     show_spinner cs_setup_nginx
     show_spinner cs_enable_usb_storage
+    show_spinner cs_enable_console_proxy_cert
+    show_spinner cs_enable_ui_ssl_cert
     if [ ! -z $NEED_NFS ];then
         show_spinner cs_setup_nfs
     fi
@@ -2994,6 +2996,18 @@ cs_enable_usb_storage(){
     fi
 
     [ -f /etc/modules-load.d/usb-storage.conf ] || echo 'usb_storage' > /etc/modules-load.d/usb-storage.conf || true
+}
+
+cs_enable_console_proxy_cert(){
+    echo_subtitle "Configure console proxy certificate"
+    trap 'traplogger $LINENO "$BASH_COMMAND" $?'  DEBUG
+    zstack-ctl configure consoleProxyCertFile=$ZSTACK_INSTALL_ROOT/zstack-ui/ui.keystore.pem
+}
+
+cs_enable_ui_ssl_cert(){
+    echo_subtitle "Configure UI server SSL certificate"
+    trap 'traplogger $LINENO "$BASH_COMMAND" $?'  DEBUG
+    zstack-ctl config_ui --enable-ssl=true --server_port=5443 > /dev/null
 }
 
 check_zstack_server(){

--- a/installation/install.sh
+++ b/installation/install.sh
@@ -146,7 +146,10 @@ ZSTACK_OLD_LICENSE_FOLDER=$ZSTACK_INSTALL_ROOT/license
 DEFAULT_MN_PORT='8080'
 MN_PORT="$DEFAULT_MN_PORT"
 
-DEFAULT_UI_PORT='5000'
+UI_SERVER_PORT='443'
+UI_SERVER_SCHEMA='https'
+SNS_PORT='443'
+SNS_SCHEMA='https'
 RESOLV_CONF='/etc/resolv.conf'
 
 BASEARCH=`uname -m`
@@ -1463,11 +1466,11 @@ upgrade_zstack(){
 
     # set ticket.sns.topic.http.url if not exists
     zstack-ctl show_configuration | grep 'ticket.sns.topic.http.url' >/dev/null 2>&1
-    [ $? -ne 0 ] && zstack-ctl configure ticket.sns.topic.http.url=http://localhost:5000/zwatch/webhook
+    [ $? -ne 0 ] && zstack-ctl configure ticket.sns.topic.http.url=$SNS_SCHEMA://localhost:$SNS_PORT/zwatch/webhook
 
     # set sns.systemTopic.endpoints.http.url if not exists
     zstack-ctl show_configuration | grep 'sns.systemTopic.endpoints.http.url' >/dev/null 2>&1
-    [ $? -ne 0 ] && zstack-ctl configure sns.systemTopic.endpoints.http.url=http://localhost:5000/zwatch/webhook
+    [ $? -ne 0 ] && zstack-ctl configure sns.systemTopic.endpoints.http.url=$SNS_SCHEMA://localhost:$SNS_PORT/zwatch/webhook
 
     # upgrade legacy mini zwatch webhook
     upgrade_mini_zwatch_webhook
@@ -2483,7 +2486,7 @@ sp_setup_install_param(){
     trap 'traplogger $LINENO "$BASH_COMMAND" $?'  DEBUG
     if [ x"$MINI_INSTALL" = x"y" ];then
         show_spinner sd_install_zstack_mini_ui
-        DEFAULT_UI_PORT=8200
+        UI_SERVER_PORT=8200
         zstack-ctl configure ui_mode=mini
         zstack-ctl configure AppCenter.server.mode=on
         zstack-ctl configure log.management.server.retentionSizeGB=200
@@ -2623,6 +2626,17 @@ cs_config_zstack_properties(){
         zstack-ctl configure Ansible.executable=${ZSTACK_ANSIBLE_EXECUTABLE}
         if [ $? -ne 0 ];then
             fail "failed to configure ansible executable to $ZSTACK_ANSIBLE_EXECUTABLE"
+        fi
+    fi
+
+    # update UI server port for upgrading system
+    if [ x"$UPGRADE" = x'y' ];then
+        old_server_port=`zstack-ctl show_ui_config | grep server_port | awk -F'=' '{ print $2 }' | sed -e 's/^[[:space:]]*//'`
+        old_enable_ssl=`zstack-ctl show_ui_config | grep enable_ssl | awk -F'=' '{ print $2 }' | sed -e 's/^[[:space:]]*//'`
+        if [ x"$old_enable_ssl" = x"true" ] && [ x"$old_server_port" = x"5000" ];then
+            zstack-ctl config_ui --enable-ssl=true --server_port=5443 > /dev/null
+        elif [ x"$old_enable_ssl" = x"false" ] && [ x"$old_server_port" = x"5443" ];then
+            zstack-ctl config_ui --enable-ssl=false --server_port=5000 > /dev/null
         fi
     fi
 
@@ -3007,7 +3021,7 @@ cs_enable_console_proxy_cert(){
 cs_enable_ui_ssl_cert(){
     echo_subtitle "Configure UI server SSL certificate"
     trap 'traplogger $LINENO "$BASH_COMMAND" $?'  DEBUG
-    zstack-ctl config_ui --enable-ssl=true --server_port=5443 > /dev/null
+    zstack-ctl config_ui --enable-ssl=true --server_port=443 > /dev/null
 }
 
 check_zstack_server(){
@@ -4557,7 +4571,7 @@ echo_star_line
 touch $README
 
 echo -e "${PRODUCT_NAME} All In One ${VERSION} Installation Completed:
- - UI is running, visit $(tput setaf 4)http://$MANAGEMENT_IP:$DEFAULT_UI_PORT$(tput sgr0) in Chrome
+ - UI is running, visit $(tput setaf 4)$UI_SERVER_SCHEMA://$MANAGEMENT_IP:$UI_SERVER_PORT$(tput sgr0) in Chrome
       Use $(tput setaf 3)${PRODUCT_NAME,,}-ctl [stop_ui|start_ui]$(tput sgr0) to stop/start the UI service
 
  - Management node is running

--- a/installation/online_install.sh
+++ b/installation/online_install.sh
@@ -1441,7 +1441,7 @@ echo_star_line
 echo "${PRODUCT_NAME} All In One ${VERSION}Installation Completed:"
 echo " - Installation path: $ZSTACK_INSTALL_ROOT"
 echo ""
-echo -e " - UI is running, visit $(tput setaf 4)http://$MANAGEMENT_IP:5000$(tput sgr0) in Chrome or Firefox"
+echo -e " - UI is running, visit $(tput setaf 4)http://$MANAGEMENT_IP:80$(tput sgr0) in Chrome or Firefox"
 echo "      Use $(tput setaf 3)zstack-ctl [stop_ui|start_ui]$(tput sgr0) to stop/start the UI service"
 echo ""
 echo -e " - Management node is running"

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -10167,11 +10167,15 @@ class ConfigUiCmd(Command):
                 ctl.write_ui_property(k.lstrip('--'), v)
 
         # use 5443 instead if enable_ssl
-        if args.enable_ssl and args.enable_ssl.lower() == 'true':
-            # if args.webhook_port == '5000':
-            #     args.webhook_port = '5443'
-            if args.server_port == '5000':
+        # This is a HACK: modify enable_ssl config will update server_port (webhook_port will not change)
+        if args.enable_ssl is not None:
+            current_server_port = ctl.read_ui_property("server_port")
+            if args.enable_ssl.lower() == 'true' and current_server_port == '5000':
+                print('Enable SSL: The server port is updated to 5443. Restart UI server to make the configuration take effect.')
                 args.server_port = '5443'
+            elif args.enable_ssl.lower() == 'false' and current_server_port == '5443':
+                print('Disable SSL: The server port is updated to 5000. Restart UI server to make the configuration take effect.')
+                args.server_port = '5000'
 
         # copy args.ssl_keystore to ctl.ZSTACK_UI_KEYSTORE_CP
         if args.ssl_keystore and args.ssl_keystore != ctl.ZSTACK_UI_KEYSTORE:

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -1527,7 +1527,7 @@ class Command(object):
     def run(self, args):
         raise CtlError('the command is not implemented')
 
-def create_check_ui_status_command(timeout=10, ui_ip='127.0.0.1', ui_port='5000', if_https=False):
+def create_check_ui_status_command(timeout=10, ui_ip='127.0.0.1', ui_port='80', if_https=False):
     protocol = 'https' if if_https else 'http'
     if shell_return('which wget') == 0:
         return ShellCmd(
@@ -4640,8 +4640,8 @@ listen  proxy-ui 0.0.0.0:8888
     mode http
     option  http-server-close
     balance source
-    server zstack-1 {{ host1 }}:5000 weight 10 check inter 3s rise 2 fall 2
-    server zstack-2 {{ host2 }}:5000 weight 10 check inter 3s rise 2 fall 2
+    server zstack-1 {{ host1 }}:80 weight 10 check inter 3s rise 2 fall 2
+    server zstack-2 {{ host2 }}:80 weight 10 check inter 3s rise 2 fall 2
     option  tcpka
         '''
         if len(self.host_post_info_list) == 3:
@@ -4705,9 +4705,9 @@ listen  proxy-ui 0.0.0.0:8888
     mode http
     option  http-server-close
     balance source
-    server zstack-1 {{ host1 }}:5000 weight 10 check inter 3s rise 2 fall 2
-    server zstack-2 {{ host2 }}:5000 weight 10 check inter 3s rise 2 fall 2
-    server zstack-3 {{ host3 }}:5000 weight 10 check inter 3s rise 2 fall 2
+    server zstack-1 {{ host1 }}:80 weight 10 check inter 3s rise 2 fall 2
+    server zstack-2 {{ host2 }}:80 weight 10 check inter 3s rise 2 fall 2
+    server zstack-3 {{ host3 }}:80 weight 10 check inter 3s rise 2 fall 2
     option  tcpka
         '''
 
@@ -8952,7 +8952,7 @@ class StopUiCmd(Command):
                 port = fd2.readline()
                 port = port.strip(' \t\n\r')
         else:
-            port = '5000'
+            port = '80'
         (_, pids) = commands.getstatusoutput("netstat -lnp | grep ':%s' |  awk '{sub(/\/.*/,""); print $NF}'" % port)
         if _ == 0 and pids.strip() != '':
             info("find pids %s at ui port: %s, kill it" % (pids,port))
@@ -9070,7 +9070,7 @@ class DashboardStatusCmd(Command):
                                 port = fd2.readline()
                                 port = port.strip(' \t\n\r')
                         else:
-                            port = 5000
+                            port = 80
                         info('UI status: %s [PID:%s] http://%s:%s' % (colored('Running', 'green'), pid, default_ip, port))
                     return
 
@@ -9121,7 +9121,7 @@ class UiStatusCmd(Command):
         # no need to consider ha because it's not supported any more
         #ha_info_file = '/var/lib/zstack/ha/ha.yaml'
         portfile = '/var/run/zstack/zstack-ui.port'
-        ui_port = 5000
+        ui_port = 80
         if ui_mode == "mini":
             portfile = '/var/run/zstack/zstack-mini-ui.port'
             ui_port = 8200
@@ -9566,7 +9566,7 @@ class StartDashboardCmd(Command):
 
     def install_argparse_arguments(self, parser):
         parser.add_argument('--host', help="UI server IP. [DEFAULT] localhost", default='localhost')
-        parser.add_argument('--port', help="UI server port. [DEFAULT] 5000", default='5000')
+        parser.add_argument('--port', help="UI server port. [DEFAULT] 80", default='80')
 
     def _remote_start(self, host, params):
         cmd = '/etc/init.d/zstack-dashboard start --rabbitmq %s' % params
@@ -9633,11 +9633,11 @@ class StartDashboardCmd(Command):
 
         distro = platform.dist()[0]
         if distro in RPM_BASED_OS:
-            shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || (iptables -I INPUT -p tcp -m tcp --dport 5000 -j ACCEPT && service iptables save)' % args.port)
+            shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || (iptables -I INPUT -p tcp -m tcp --dport 80 -j ACCEPT && service iptables save)' % args.port)
         elif distro in DEB_BASED_OS:
-            shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || (iptables -I INPUT -p tcp -m tcp --dport 5000 -j ACCEPT && /etc/init.d/iptables-persistent save)' % args.port)
+            shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || (iptables -I INPUT -p tcp -m tcp --dport 80 -j ACCEPT && /etc/init.d/iptables-persistent save)' % args.port)
         else:
-            shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || iptables -I INPUT -p tcp -m tcp --dport 5000 -j ACCEPT ' % args.port)
+            shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || iptables -I INPUT -p tcp -m tcp --dport 80 -j ACCEPT ' % args.port)
 
         scmd = '. %s/bin/activate\nZSTACK_DASHBOARD_PORT=%s nohup python -c "from zstack_dashboard import web; web.main()" --rabbitmq %s >/var/log/zstack/zstack-dashboard.log 2>&1 </dev/null &' % (virtualenv, args.port, param)
         script(scmd, no_pipe=True)
@@ -9732,7 +9732,7 @@ class StartUiCmd(Command):
                 info('UI status: %s ' % (colored('Running', 'green')))
             else:
                 info('UI status: %s  //%s:%s' % (
-                    colored('Running', 'green'), default_ip, "5000"))
+                    colored('Running', 'green'), default_ip, "80"))
 
                 return False
         return True
@@ -9855,12 +9855,6 @@ class StartUiCmd(Command):
         if not os.path.exists(ctl.ZSTACK_UI_KEYSTORE):
             self._gen_default_ssl_keystore()
 
-        # server_port default value is 5443 if enable_ssl is True
-        # if args.enable_ssl and args.webhook_port == '5000':
-        #     args.webhook_port = '5443'
-        if args.enable_ssl and args.server_port == '5000':
-            args.server_port = '5443'
-
         # set http to https is enable ssl set
         webhook_ip = ctl.read_property('management.server.vip')
         if not webhook_ip:
@@ -9925,15 +9919,15 @@ class StartUiCmd(Command):
 
         distro = platform.dist()[0]
         if distro in RPM_BASED_OS:
-            shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || (iptables -I INPUT -p tcp -m tcp --dport 5000 -j ACCEPT && service iptables save)' % args.server_port)
+            shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || (iptables -I INPUT -p tcp -m tcp --dport 80 -j ACCEPT && service iptables save)' % args.server_port)
             shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || (iptables -I INPUT -p tcp -m tcp --dport %s -j ACCEPT && service iptables save)' % (args.server_port, args.server_port))
             shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || (iptables -I INPUT -p tcp -m tcp --dport %s -j ACCEPT && service iptables save)' % (args.webhook_port, args.webhook_port))
         elif distro in DEB_BASED_OS:
-            shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || (iptables -I INPUT -p tcp -m tcp --dport 5000 -j ACCEPT && /etc/init.d/iptables-persistent save)' % args.server_port)
+            shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || (iptables -I INPUT -p tcp -m tcp --dport 80 -j ACCEPT && /etc/init.d/iptables-persistent save)' % args.server_port)
             shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || (iptables -I INPUT -p tcp -m tcp --dport %s -j ACCEPT && /etc/init.d/iptables-persistent save)' % (args.server_port, args.server_port))
             shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || (iptables -I INPUT -p tcp -m tcp --dport %s -j ACCEPT && /etc/init.d/iptables-persistent save)' % (args.webhook_port, args.webhook_port))
         else:
-            shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || iptables -I INPUT -p tcp -m tcp --dport 5000 -j ACCEPT ' % args.server_port)
+            shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || iptables -I INPUT -p tcp -m tcp --dport 80 -j ACCEPT ' % args.server_port)
             shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || iptables -I INPUT -p tcp -m tcp --dport %s -j ACCEPT ' % (args.server_port, args.server_port))
             shell('iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || iptables -I INPUT -p tcp -m tcp --dport %s -j ACCEPT ' % (args.webhook_port, args.webhook_port))
         enableSSL = 'false'
@@ -10047,7 +10041,7 @@ class ConfigUiCmd(Command):
         parser.add_argument('--mn-port', help="ZStack Management Host port. [DEFAULT] 8080")
         parser.add_argument('--webhook-host', help="Webhook Host IP. [DEFAULT] 127.0.0.1")
         parser.add_argument('--webhook-port', help="Webhook Host port. [DEFAULT] 5001")
-        parser.add_argument('--server-port', help="UI server port. [DEFAULT] 5000")
+        parser.add_argument('--server-port', help="UI server port. [DEFAULT] 80")
         parser.add_argument('--ui-address', help="ZStack UI Address.")
         parser.add_argument('--log', help="UI log folder. [DEFAULT] %s" % ui_logging_path)
         parser.add_argument('--catalina-opts', help="UI catalina options, seperated by `,`")
@@ -10097,15 +10091,15 @@ class ConfigUiCmd(Command):
             if not ctl.read_ui_property("webhook_host"):
                 ctl.write_ui_property("webhook_host", '127.0.0.1')
             if not ctl.read_ui_property("webhook_port"):
-                # from 4.0 set webhook_port to 5001,since the 5000 is for nginx
+                # from 4.2.0 set webhook_port to 5001,since the 80 is for nginx
                 ctl.write_ui_property("webhook_port", '5001')
             if not ctl.read_ui_property("server_port"):
-                ctl.write_ui_property("server_port", '5000')
-            # from 4.0 set webhook_port to 5001,since the 5000 is for nginx
+                ctl.write_ui_property("server_port", '80')
+            # from 4.0 set webhook_port to 5001,since the 80 is for nginx
             if ctl.read_ui_property("webhook_port") == ctl.read_ui_property("server_port"):
-            #'webhook port same with server port in zstack.ui.properties, auto set webhook port to server port +1'
+            #'webhook port same with server port in zstack.ui.properties, auto set webhook port to server port +5001'
                 port = ctl.read_ui_property("server_port")
-                port = str(int(port)+1)
+                port = str(int(port)+5001)
                 ctl.write_ui_property("webhook_port", port)
             if not ctl.read_ui_property("log"):
                 ctl.write_ui_property("log", ui_logging_path)
@@ -10142,7 +10136,7 @@ class ConfigUiCmd(Command):
             ctl.write_ui_property("mn_port", '8080')
             ctl.write_ui_property("webhook_host", '127.0.0.1')
             ctl.write_ui_property("webhook_port", '5001')
-            ctl.write_ui_property("server_port", '5000')
+            ctl.write_ui_property("server_port", '80')
             ctl.write_ui_property("log", ui_logging_path)
             ctl.write_ui_property("enable_ssl", 'false')
             ctl.write_ui_property("enable_http2", 'false')
@@ -10166,16 +10160,16 @@ class ConfigUiCmd(Command):
                     raise CtlError('custom param %s is invalid, must begin with --' % k)
                 ctl.write_ui_property(k.lstrip('--'), v)
 
-        # use 5443 instead if enable_ssl
+        # use 443 instead if enable_ssl
         # This is a HACK: modify enable_ssl config will update server_port (webhook_port will not change)
         if args.enable_ssl is not None:
             current_server_port = ctl.read_ui_property("server_port")
-            if args.enable_ssl.lower() == 'true' and current_server_port == '5000':
-                print('Enable SSL: The server port is updated to 5443. Restart UI server to make the configuration take effect.')
-                args.server_port = '5443'
-            elif args.enable_ssl.lower() == 'false' and current_server_port == '5443':
-                print('Disable SSL: The server port is updated to 5000. Restart UI server to make the configuration take effect.')
-                args.server_port = '5000'
+            if args.enable_ssl.lower() == 'true' and current_server_port == '80':
+                print('Enable SSL: The server port is updated to 443. Restart UI server to make the configuration take effect.')
+                args.server_port = '443'
+            elif args.enable_ssl.lower() == 'false' and current_server_port == '443':
+                print('Disable SSL: The server port is updated to 80. Restart UI server to make the configuration take effect.')
+                args.server_port = '80'
 
         # copy args.ssl_keystore to ctl.ZSTACK_UI_KEYSTORE_CP
         if args.ssl_keystore and args.ssl_keystore != ctl.ZSTACK_UI_KEYSTORE:


### PR DESCRIPTION
1. Update consoleProxyCertFile and UI server SSL certificate
   when zsphere install.
2. Simplify enable UI SSL certificate script,
   and stop printing extra text during installation.

Resolves: ZSV-4877
Related: ZSV-4876

Change-Id: I6763666863636f7a7179746e65626c6a65616f69
(cherry picked from commit 79241ee4d4b9b3ce9a2d27c37017fa604457bc91)
(squashed commit 757dffe3474d6d6dd38b3416008c9a04494012a1)

sync from gitlab !4557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 为控制台代理和UI服务器配置了SSL证书，增强了安全性。
- **文档**
	- 更新了UI状态URL中的端口号，从`5000`变更为`80`。
- **Bug修复**
	- 更新了安装脚本和UI访问相关的端口配置，确保HTTPS支持，提高了系统的安全性和易用性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->