### PR TITLE
<fix>[nfs]: fix nfs reconnect failed

### DIFF
--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -401,11 +401,11 @@ def is_mounted(path=None, url=None):
         url = re.sub(r'/{2,}','/',url.rstrip('/'))
 
     if url and path:
-        cmdstr = "mount | grep '%s on ' | grep '%s ' " % (url, path)
+        cmdstr = "mount | grep -E '%s[ /]+on' | grep '%s ' " % (url, path)
     elif not url:
         cmdstr = "mount | grep '%s '" % path
     elif not path:
-        cmdstr = "mount | grep '%s on '" % url
+        cmdstr = "mount | grep -E '%s[ /]+on'" % url
     else:
         raise Exception('path and url cannot both be None')
 


### PR DESCRIPTION
when the last character of the URL for adding NFS is'/', it will cause reconnection to NFS to fail because it is determined whether NFS is mounted or not

Resolves: ZSTAC-63204

Change-Id: opda407080a84b26a388648929ef98cc

sync from gitlab !4560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
	- 改进了挂载信息解析的灵活性和准确性，用于处理`mount`命令输出中挂载URL和路径的匹配模式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->