### PR TITLE
<fix>[bmv2_gateway_agent]: support iscsi for root volume

### DIFF
--- a/kvmagent/kvmagent/plugins/baremetal_v2_gateway_agent.py
+++ b/kvmagent/kvmagent/plugins/baremetal_v2_gateway_agent.py
@@ -951,7 +951,8 @@ class BaremetalV2GatewayAgentPlugin(kvmagent.KvmAgent):
             chassis_port=cmd.chassisInfo.port,
             api_id=cmd.threadContext.api,
             task_name=cmd.threadContext["task-name"],
-            provision_mac=instance_obj.provision_mac
+            provision_mac=instance_obj.provision_mac,
+            instance_uuid=instance_obj.uuid
         )
 
         with open(ks_config_path, 'w') as f:

--- a/kvmagent/kvmagent/plugins/bmv2_gateway_agent/object.py
+++ b/kvmagent/kvmagent/plugins/bmv2_gateway_agent/object.py
@@ -155,7 +155,8 @@ class VolumeObj(Base):
         'token': 'token',
         'tpTimeout': 'tpTimeout',
         'monIp': 'monIp',
-        'iscsiPath': 'iscsiPath'
+        'iscsiPath': 'iscsiPath',
+        'targetIqn': 'targetIqn'
     }
 
     @classmethod

--- a/kvmagent/kvmagent/plugins/bmv2_gateway_agent/templates/import-data.ks.j2
+++ b/kvmagent/kvmagent/plugins/bmv2_gateway_agent/templates/import-data.ks.j2
@@ -65,7 +65,15 @@ def get_dest_dev(dest_wwn):
     raise Exception("Failed to find dest disk[%s]" % dest_wwn)
 
 def get_src_dev():
+    cmd = "mkdir -p /etc/iscsi && touch /etc/iscsi/initiatorname.iscsi && echo 'InitiatorName=iqn.2015-01.io.zstack:initiator.instance.{{instance_uuid}}' > /etc/iscsi/initiatorname.iscsi"
+    shell_cmd(cmd)
+    cmd = "systemctl restart iscsid"
+    shell_cmd(cmd)
+    time.sleep(1)
     cmd = "iscsiadm -m discovery -t sendtargets -p {{gateway_ip}}:3260"
+    shell_cmd(cmd)
+    time.sleep(1)
+    cmd = "iscsiadm --mode node --targetname {{iqn_name}} -p {{gateway_ip}}:3260 --login -o new"
     shell_cmd(cmd)
     time.sleep(1)
     cmd = "iscsiadm --mode node --targetname {{iqn_name}} -p {{gateway_ip}}:3260 --login"

--- a/kvmagent/kvmagent/plugins/bmv2_gateway_agent/volume/__init__.py
+++ b/kvmagent/kvmagent/plugins/bmv2_gateway_agent/volume/__init__.py
@@ -2,11 +2,13 @@ from kvmagent.plugins.bmv2_gateway_agent import exception
 from kvmagent.plugins.bmv2_gateway_agent.volume import ceph
 from kvmagent.plugins.bmv2_gateway_agent.volume import sharedblock
 from kvmagent.plugins.bmv2_gateway_agent.volume import thirdparty_ceph
+from kvmagent.plugins.bmv2_gateway_agent.volume import expon
 
 mapping = {
     'ceph': ceph.CephVolume,
     'sharedblock': sharedblock.SharedBlockVolume,
-    'thirdpartyCeph': thirdparty_ceph.ThirdPartyCephVolume
+    'thirdpartyCeph': thirdparty_ceph.ThirdPartyCephVolume,
+    'expon': expon.ExponVolume
 }
 
 
@@ -14,6 +16,8 @@ def get_driver(instance_obj, volume_obj):
     ps_type = volume_obj.primary_storage_type.lower()
     if is_third_party_ceph(volume_obj):
         ps_type = 'thirdpartyCeph'
+    if is_third_party_addon(ps_type):
+        ps_type = get_type_from_third_party_addon(volume_obj)
     if ps_type not in mapping:
         raise exception.PrimaryStorageTypeNotSupport(
             primary_storage_type=ps_type)
@@ -22,3 +26,11 @@ def get_driver(instance_obj, volume_obj):
 
 def is_third_party_ceph(token_object):
     return hasattr(token_object, "token") and token_object.token
+
+
+def is_third_party_addon(ps_type):
+    return ps_type == "addon"
+
+
+def get_type_from_third_party_addon(volume_obj):
+    return volume_obj.path.split(":")[0]

--- a/kvmagent/kvmagent/plugins/bmv2_gateway_agent/volume/expon.py
+++ b/kvmagent/kvmagent/plugins/bmv2_gateway_agent/volume/expon.py
@@ -1,0 +1,74 @@
+from kvmagent.plugins.bmv2_gateway_agent.volume import base
+
+from zstacklib.utils import shell, linux
+
+
+class ExponVolume(base.BaseVolume):
+
+    def __init__(self, *args, **kwargs):
+        super(ExponVolume, self).__init__(*args, **kwargs)
+
+    def check_exist(self):
+        pass
+
+    @property
+    def nbd_backend(self):
+        return self.real_path
+
+    @property
+    def iscsi_backend(self):
+        return self.nbd_dev
+
+    @property
+    def iscsi_target(self):
+        return self.volume_obj.targetIqn
+
+    @property
+    def real_path(self):
+        return self.volume_obj.path.replace('expon://', '')
+
+    def attach(self):
+        pass
+
+    def detach(self):
+        pass
+
+    def detach_volume(self):
+        pass
+
+# monIp: 172.27.16.181,172.27.16.99,...
+    def prepare_instance_resource(self):
+        instance_gateway_ip = self.instance_obj.gateway_ip
+        mon_ip = self.volume_obj.monIp
+        dev_name = linux.find_route_interface_by_destination_ip(mon_ip)
+        shell.run("iptables -t nat -A PREROUTING -s %s -d %s -p tcp --dport 3260 -j DNAT --to-destination %s:3260" %
+                  (self.instance_obj.provision_ip, instance_gateway_ip, mon_ip))
+        shell.run("iptables -t nat -A POSTROUTING -s %s -o %s -j SNAT --to-source %s" % (
+            self.instance_obj.provision_ip, dev_name, mon_ip))
+
+    def destroy_instance_resource(self):
+        instance_gateway_ip = self.instance_obj.gateway_ip
+        mon_ip = self.volume_obj.monIp
+        dev_name = linux.find_route_interface_by_destination_ip(mon_ip)
+        shell.run("iptables -t nat -D PREROUTING -s %s -d %s -p tcp --dport 3260 -j DNAT --to-destination %s:3260" %
+                  (self.instance_obj.provision_ip, instance_gateway_ip, mon_ip))
+        shell.run("iptables -t nat -D POSTROUTING -s %s -o %s -j SNAT --to-source %s" % (
+            self.instance_obj.provision_ip, dev_name, mon_ip))
+
+    def pre_take_volume_snapshot(self):
+        pass
+
+    def post_take_volume_snapshot(self, src_vol):
+        pass
+
+    def resume(self):
+        pass
+
+    def rollback_volume_snapshot(self, src_vol):
+        pass
+
+    def get_lun_id(self):
+        pass
+
+    def roll_back_attach_volume(self):
+        self.detach_volume()


### PR DESCRIPTION
support iscsi for root volume , for Local type bm

Resolves: ZSTAC-64162

Change-Id: I7763756c616b766d706868616f6669616e6e6265

sync from gitlab !4606

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
    - 在`baremetal_v2_gateway_agent.py`文件中，`_create_import_data_config`函数现在除了`provision_mac`外，还包括`instance_uuid`参数。
    - 在`object.py`的`VolumeObj`类中新增了`targetIqn`属性，以及现有的`iscsiPath`属性。
    - 在`import-data.ks.j2`模板中添加了命令，用于在源设备连接到网关IP之前设置iSCSI发起者。
    - 在`kvmagent`的`bmv2_gateway_agent`插件的`__init__.py`文件中，`mapping`字典中新增了一个`addon`卷类型。
    - 引入了`AddonVolume`类，该类提供了在BMv2 Gateway Agent中管理卷的方法，包括检查存在性、附加/分离卷、准备实例资源、处理卷快照以及管理LUN ID。还包括了与NBD和iSCSI等不同后端工作的方法。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->