### PR TITLE
<fix>[sharedblock]: fix sanlock orphan lock

### DIFF
--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -762,8 +762,8 @@ def start_lvmlockd(io_timeout=40):
 
     restart_lvmlockd = is_lvmlockd_upgraded() or (LooseVersion(get_lvmlockd_version()) >= LooseVersion("2.03") and is_lvmlockd_socket_abnormal())
     if restart_lvmlockd:
-        write_lvmlockd_adopt_file()
         stop_lvmlockd()
+        write_lvmlockd_adopt_file()
         linux.rm_file_force(LVMLOCKD_SOCKET)
     for service in ["sanlock", get_lvmlockd_service_name()]:
         cmd = shell.ShellCmd("timeout 30 systemctl start %s" % service)


### PR DESCRIPTION
when restarting the lvmlockd service, first stop the lvmlockd service to prevent locking lv, then write the adopt file, and finally start the service

Resolves: ZSTAC-63052

Change-Id:88A92E304F2680C1BAA1FE3858A2B34c

sync from gitlab !4585