### PR TITLE
<fix>[zstacklib]: fix syntax in iproute.py

### DIFF
--- a/zstacklib/zstacklib/utils/iproute.py
+++ b/zstacklib/zstacklib/utils/iproute.py
@@ -85,12 +85,12 @@ class NamespaceAlreadyExists(RuntimeError):
 
 class InvalidScope(RuntimeError):
     def __init__(self, scope):
-        super(NoSuchScope, self).__init__("Scope : %(scope)s is invalid." % {'scope': scope})
+        super(InvalidScope, self).__init__("Scope : %(scope)s is invalid." % {'scope': scope})
         self.scope = scope
 
 class InvalidIpVersion(RuntimeError):
     def __init__(self, ip_version):
-        super(NoSuchScope, self).__init__("IpVersion : %(ip_version)s is invalid." % {'ip_version': ip_version})
+        super(InvalidIpVersion, self).__init__("IpVersion : %(ip_version)s is invalid." % {'ip_version': ip_version})
         self.ip_version = ip_version
 
 class NoSuchLinkDevice(RuntimeError):


### PR DESCRIPTION
Change-Id: I7270686a6273627a71697177627a646c656f7166

sync from gitlab !4658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 修正了异常处理中类名的使用错误，将 `NoSuchScope` 更正为 `InvalidScope`，将 `NoSuchIpVersion` 更正为 `InvalidIpVersion`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->