### PR TITLE
<fix>[vm]: detach nic should wait for result if already under detaching

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -1212,9 +1212,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         dst_abs_path = translate_absolute_path_from_install_path(cmd.destPath)
 
         with lvm.OperateLv(dst_abs_path, shared=False):
-            current_size = int(lvm.get_lv_size(dst_abs_path))
-            if current_size < cmd.requiredSize:
-                lvm.extend_lv_from_cmd(dst_abs_path, cmd.requiredSize, cmd, extend_thin_by_specified_size=True)
+            lvm.extend_lv_from_cmd(dst_abs_path, cmd.requiredSize, cmd, extend_thin_by_specified_size=True, skip_if_sufficient=True)
 
         rsp.totalCapacity, rsp.availableCapacity = lvm.get_vg_size(cmd.vgUuid)
         return jsonobject.dumps(rsp)

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -7739,7 +7739,7 @@ class VmPlugin(kvmagent.KvmAgent):
 
         job_over = False
         @thread.AsyncThread
-        @linux.retry(times=10, sleep_time=1)
+        @linux.retry(times=10, sleep_time=0.5)
         def _touch_qmp_socket():
             if job_over:
                 return

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -1356,12 +1356,12 @@ def extend_lv(path, extend_size, skip_if_sufficient=False):
                              (path, extend_size, r, o, e))
 
 @bash.in_bash
-def extend_lv_from_cmd(path, size, cmd, extend_thin_by_specified_size=False):
+def extend_lv_from_cmd(path, size, cmd, extend_thin_by_specified_size=False, skip_if_sufficient=False):
     # type: (str, long, object, bool) -> None
     if cmd.provisioning is None or \
             cmd.addons is None or \
             cmd.provisioning != VolumeProvisioningStrategy.ThinProvisioning:
-        extend_lv(path, size)
+        extend_lv(path, size, skip_if_sufficient)
         return
 
     current_size = int(get_lv_size(path))
@@ -1372,11 +1372,11 @@ def extend_lv_from_cmd(path, size, cmd, extend_thin_by_specified_size=False):
             size = v_size
         else:
             size = size + cmd.addons[thinProvisioningInitializeSize]
-        extend_lv(path, size)
+        extend_lv(path, size, skip_if_sufficient)
         return
 
     if int(size) - current_size > cmd.addons[thinProvisioningInitializeSize]:
-        extend_lv(path, current_size + cmd.addons[thinProvisioningInitializeSize])
+        extend_lv(path, current_size + cmd.addons[thinProvisioningInitializeSize], skip_if_sufficient)
     else:
         extend_lv(path, size, True)
 


### PR DESCRIPTION
New version qemu will raise exception when try to detach (device_del in qemu)
 a nic which is already in the process of unplugging, so just ignore the error
 but wait for the nic detached.

Resolves: ZSTAC-57874

Change-Id: I716366706177677477617a6c7469676c7878776a
(cherry picked from commit 2d102ee6bee024d0d30fc8d75cb266b49b8d0328)

sync from gitlab !4661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在PXE服务器代理中增加了对UEFI启动和GRUB配置文件的管理。
  - 更新了Ceph备份存储和主存储的快照创建和上传进度功能。
  - 引入了对虚拟机和卷备份作业的强制停止参数。
  - 扩展了对新兴翼虚拟机操作系统版本的支持。
  - 增强了存储操作的效率和可靠性，特别是在共享块插件中处理卷的逻辑。
  - 优化了虚拟机迁移、备份和存储操作的处理逻辑。

- **错误修复**
  - 修正了虚拟环境安装和模块加载中的逻辑错误。
  - 优化了正则表达式用于磁盘名称匹配，提高了监控的准确性。

- **性能改进**
  - 调整了虚拟机配置插件和存储插件中的处理逻辑，提高了操作的响应速度和效率。

- **维护更新**
  - 更新了安装脚本，改进了数据库和用户的准备消息，以及基于机器架构的路径设置。
  - 调整了基于主机架构动态设置软件包名称的逻辑，增强了脚本的灵活性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->