### PR TITLE
<fix>[storage-migration]: fix storage live migration no space left

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -1211,9 +1211,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         dst_abs_path = translate_absolute_path_from_install_path(cmd.destPath)
 
         with lvm.OperateLv(dst_abs_path, shared=False):
-            current_size = int(lvm.get_lv_size(dst_abs_path))
-            if current_size < cmd.requiredSize:
-                lvm.extend_lv_from_cmd(dst_abs_path, cmd.requiredSize, cmd, extend_thin_by_specified_size=True)
+            lvm.extend_lv_from_cmd(dst_abs_path, cmd.requiredSize, cmd, extend_thin_by_specified_size=True, skip_if_sufficient=True)
 
         rsp.totalCapacity, rsp.availableCapacity = lvm.get_vg_size(cmd.vgUuid)
         return jsonobject.dumps(rsp)

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -7769,7 +7769,7 @@ class VmPlugin(kvmagent.KvmAgent):
 
         job_over = False
         @thread.AsyncThread
-        @linux.retry(times=10, sleep_time=1)
+        @linux.retry(times=10, sleep_time=0.5)
         def _touch_qmp_socket():
             if job_over:
                 return

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -1352,12 +1352,12 @@ def extend_lv(path, extend_size):
                              (path, extend_size, r, o, e))
 
 @bash.in_bash
-def extend_lv_from_cmd(path, size, cmd, extend_thin_by_specified_size=False):
+def extend_lv_from_cmd(path, size, cmd, extend_thin_by_specified_size=False, skip_if_sufficient=False):
     # type: (str, long, object, bool) -> None
     if cmd.provisioning is None or \
             cmd.addons is None or \
             cmd.provisioning != VolumeProvisioningStrategy.ThinProvisioning:
-        extend_lv(path, size)
+        extend_lv(path, size, skip_if_sufficient)
         return
 
     current_size = int(get_lv_size(path))
@@ -1368,11 +1368,11 @@ def extend_lv_from_cmd(path, size, cmd, extend_thin_by_specified_size=False):
             size = v_size
         else:
             size = size + cmd.addons[thinProvisioningInitializeSize]
-        extend_lv(path, size)
+        extend_lv(path, size, skip_if_sufficient)
         return
 
     if int(size) - current_size > cmd.addons[thinProvisioningInitializeSize]:
-        extend_lv(path, current_size + cmd.addons[thinProvisioningInitializeSize])
+        extend_lv(path, current_size + cmd.addons[thinProvisioningInitializeSize], skip_if_sufficient)
     else:
         extend_lv(path, size)
 


### PR DESCRIPTION
when migrating to a thinprovision sblk primary storage, there may be insufficient space at the beginning of the migration

Resolves: ZSTAC-59766

Change-Id:1013B74D7D4941E9904924293866D0o0


(cherry picked from commit 8997a3f45c1f3e411403362d61eebce2ab460892)

sync from gitlab !4677