### PR TITLE
<fix>[imagestore]: skip block operation for vhost

### DIFF
--- a/kvmagent/kvmagent/plugins/imagestore.py
+++ b/kvmagent/kvmagent/plugins/imagestore.py
@@ -100,7 +100,7 @@ class ImageStoreClient(object):
         with linux.ShowLibvirtErrorOnException(vm):
             cmdstr = '%s stopmirr -force=%s -domain %s -delbitmap=%s -drive "%s"' % \
                      (self.ZSTORE_CLI_PATH, force, vm, complete, node)
-            shell.check_run(cmdstr)
+            shell.call(cmdstr)
 
     def query_mirror_volumes(self, vm):
         with linux.ShowLibvirtErrorOnException(vm):

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -6309,6 +6309,9 @@ def _stop_world():
 def block_volume_over_incorrect_driver(volume):
     return volume.deviceType == "file" and volume.installPath.startswith("/dev/")
 
+def volume_support_block_node(volume):
+    return volume.deviceType != "vhost"
+
 def file_volume_check(volume):
     # `file` support has been removed with block/char devices since qemu-6.0.0
     # https://github.com/qemu/qemu/commit/8d17adf34f501ded65a106572740760f0a75577c
@@ -7587,9 +7590,10 @@ class VmPlugin(kvmagent.KvmAgent):
                     return jsonobject.dumps(rsp)
                 raise kvmagent.KvmError('unable to find data volume[%s] on vm[uuid:%s]' % (volume.installPath, vm.uuid))
 
-            node_name = self.get_disk_device_name(target_disk)
-            isc = ImageStoreClient()
-            isc.stop_mirror(cmd.vmInstanceUuid, True, node_name)
+            if volume_support_block_node(volume):
+                node_name = self.get_disk_device_name(target_disk)
+                isc = ImageStoreClient()
+                isc.stop_mirror(cmd.vmInstanceUuid, True, node_name)
 
             vm.detach_data_volume(volume)
         except kvmagent.KvmError as e:


### PR DESCRIPTION
vhost volume do not support block node,
block operation will fail.

Resolves: ZSTAC-65130

Change-Id: I78736c6a64687775756a64787163686a75726d66

sync from gitlab !4680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 增加了对数据卷是否支持块节点的检查功能。
- **Bug 修复**
	- 优化了镜像存储停止镜像功能的系统调用处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->