### PR TITLE
<fix>[zstackbuild]: replace the build environment goroot for 4.8.10

### DIFF
--- a/zstackbuild/projects/zstack-store.xml
+++ b/zstackbuild/projects/zstack-store.xml
@@ -17,6 +17,7 @@
         </exec>
 
         <exec executable="make" dir="${imagestore.source}" failonerror="true">
+            <env key="GOROOT" value="/usr/lib/golang1.18" />
             <arg value="package" />
             <arg value="ARCH=amd64 arm64 mips64le loong64" />
         </exec>


### PR DESCRIPTION
Resolves: ZSTAC-65121

Change-Id: I6d7472617563626a6c796569787366656a63687a

sync from gitlab !4683