### PR TITLE
<fix>[host]: get libvirt version after update libvirt

### DIFF
--- a/kvmagent/ansible/kvm.py
+++ b/kvmagent/ansible/kvm.py
@@ -50,6 +50,7 @@ unittest_flag = 'false'
 mn_ip = None
 isInstallHostShutdownHook = 'false'
 isEnableKsm = 'none'
+restart_libvirtd = 'false'
 
 
 # get parameter from shell
@@ -801,8 +802,10 @@ def start_kvmagent():
     if chroot_env != 'false':
         return
 
-    if any(status != "changed:False" for status in [libvirtd_status, libvirtd_conf_status, qemu_conf_status, copy_smart_nics_status]):
-        # name: restart libvirtd if status is stop or cfg changed
+    if init == 'true' or restart_libvirtd == 'true':
+        # name: restart libvirtd when init installation to make sure qemu.conf changes
+        # or restart libvirtd when restartLibvirtd is true (from control plane settings)
+        # take effects
         service_status("libvirtd", "state=restarted enabled=yes", host_post_info)
     # name: restart kvmagent, do not use ansible systemctl due to kvmagent can start by itself, so systemctl will not know
     # the kvm agent status when we want to restart it to use the latest kvm agent code

--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -1624,6 +1624,8 @@ if __name__ == "__main__":
                 rsp.success = False
                 rsp.error = "failed to update host os using zstack-mn,qemu-kvm-ev-mn repo, stdout: %s, stderr: %s" % (shell_cmd.stdout, shell_cmd.stderr)
 
+        rsp.libvirtVersion = shell.call("rpm -q libvirt --qf ' %{VERSION}-%{RELEASE}'")
+
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror

--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -1146,6 +1146,7 @@ class HostPlugin(kvmagent.KvmAgent):
 
         rsp.qemuImgVersion = qemu_img_version
         rsp.libvirtVersion = self.libvirt_version
+        rsp.libvirtPackageVersion = linux.get_libvirt_package_version()
         rsp.ipAddresses = ipV4Addrs
         rsp.cpuArchitecture = platform.machine()
         rsp.uptime = shell.call('uptime -s').strip()
@@ -1624,7 +1625,7 @@ if __name__ == "__main__":
                 rsp.success = False
                 rsp.error = "failed to update host os using zstack-mn,qemu-kvm-ev-mn repo, stdout: %s, stderr: %s" % (shell_cmd.stdout, shell_cmd.stderr)
 
-        rsp.libvirtVersion = shell.call("rpm -q libvirt --qf ' %{VERSION}-%{RELEASE}'")
+        rsp.libvirtVersion = linux.get_libvirt_package_version()
 
         return jsonobject.dumps(rsp)
 

--- a/kvmagent/kvmagent/test/unittest_tools/install_kvm.sh
+++ b/kvmagent/kvmagent/test/unittest_tools/install_kvm.sh
@@ -16,5 +16,5 @@ cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
 cd /usr/local/zstack/ansible || true
 echo ${host_ip} > /usr/local/zstack/ansible/hosts
 source /root/venv2/bin/activate
-PYTHONPATH=/root/.zguest/zstack-utility/zstacklib/ansible python /root/.zguest/zstack-utility/kvmagent/ansible/kvm.py -i /usr/local/zstack/ansible/hosts -e "{\"host\":\"${host_ip}\",\"pip_url\":\"${pip_url}\",\"trusted_host\":\"${trusted_host}\",\"zstack_repo\":\"${zstack_repo}\",\"zstack_root\":\"${zstack_root}\",\"pkg_zstacklib\":\"${pkg_zstacklib}\",\"pkg_kvmagent\":\"${pkg_kvmagent}\",\"unittest_flag\":\"${unittest_flag}\"}"
+PYTHONPATH=/root/.zguest/zstack-utility/zstacklib/ansible python /root/.zguest/zstack-utility/kvmagent/ansible/kvm.py -i /usr/local/zstack/ansible/hosts -e "{\"host\":\"${host_ip}\",\"pip_url\":\"${pip_url}\",\"trusted_host\":\"${trusted_host}\",\"zstack_repo\":\"${zstack_repo}\",\"zstack_root\":\"${zstack_root}\",\"pkg_zstacklib\":\"${pkg_zstacklib}\",\"pkg_kvmagent\":\"${pkg_kvmagent}\",\"unittest_flag\":\"${unittest_flag}\", \"init\":\"true\"}"
 deactivate

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -2520,6 +2520,10 @@ class TempAccessible(object):
             os.chmod(self.fpath, self.fmode)
 
 
+def get_libvirt_package_version():
+    return shell.call("rpm -q libvirt --qf ' %{VERSION}-%{RELEASE}'")
+
+
 def get_libvirt_version():
     return shell.call("libvirtd --version").split()[-1]
 


### PR DESCRIPTION
Resolves: ZSTAC-63777

Change-Id: I6f797563786c697463696e787272766765686b64
(cherry picked from commit 777705427bc3f080015fbeab7fbc9807ece1be28)

sync from gitlab !4686

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
    - 在 `start_kvmagent` 方法中，添加了一个新标志 `restart_libvirtd`，用于控制在特定条件下重启 `libvirtd` 服务。
    - 在 `fact` 方法中，添加了显示 libvirt 包版本的功能。
    - 在 `update_os` 方法中，添加了显示 libvirt 包版本的功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->