### PR TITLE
<fix>[storage-migration]: fix storage live migration no space left

### DIFF
--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -1394,8 +1394,12 @@ def resize_lv(path, size, force=False):
 
 @bash.in_bash
 @linux.retry(times=15, sleep_time=random.uniform(0.1, 3))
-def extend_lv(path, extend_size):
-    r, o, e = bash.bash_roe("lvextend --size %sb %s" % (calcLvReservedSize(extend_size), path))
+def extend_lv(path, extend_size, skip_if_sufficient=False):
+    final_size = calcLvReservedSize(extend_size)
+    if skip_if_sufficient and int(get_lv_size(path)) >= final_size:
+        return
+
+    r, o, e = bash.bash_roe("lvextend --size %sb %s" % (final_size, path))
     if r == 0:
         logger.debug("successfully extend lv %s size to %s" % (path, extend_size))
         return


### PR DESCRIPTION
when migrating to a thinprovision sblk primary storage, there may be insufficient space at the beginning of the migration

Resolves: ZSTAC-59766

Change-Id:1013B74D7D4941E9904924293866D0o0

sync from gitlab !4704

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了逻辑卷扩展功能，如果当前大小已足够则可以跳过扩展。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->