### PR TITLE
<fix>[ha]:operation file locking

### DIFF
--- a/kvmagent/kvmagent/plugins/ha_plugin.py
+++ b/kvmagent/kvmagent/plugins/ha_plugin.py
@@ -398,20 +398,7 @@ class SanlockHealthChecker(AbstractStorageFencer):
     def update_vm_ha_params(self, vg_uuids):
         if len(vg_uuids) == 0:
             return
-
-        if not os.path.exists(SHAREBLOCK_VM_HA_PARAMS_PATH):
-            return
-
-        with open(SHAREBLOCK_VM_HA_PARAMS_PATH, 'r+') as f:
-            cmd = f.read().strip()
-            if len(cmd) == 0:
-                return
-
-            cmd_json = json.loads(cmd)
-            cmd_json["vgUuids"] = vg_uuids
-            f.seek(0)
-            f.truncate(0)
-            f.write(jsonobject.dumps(cmd_json))
+        update_shareblock_vm_ha_params(vg_uuids)
 
     def firevg(self, vg_uuid):
         self.fired_vgs[vg_uuid] = time.time()
@@ -872,6 +859,37 @@ global_allow_fencer_rule = {} # type: dict[str, list]
 global_block_fencer_rule = {} # type: dict[str, list]
 global_fencer_rule_lock = threading.Lock()
 SHAREBLOCK_VM_HA_PARAMS_PATH = "/var/run/zstack/shareBlockVmHaParams"
+WRITE_SHAREBLOCKVMHAPARAMS_LOCK = threading.Lock()
+
+
+def create_shareblock_vm_ha_params(cmd):
+    with WRITE_SHAREBLOCKVMHAPARAMS_LOCK:
+        if os.path.exists(SHAREBLOCK_VM_HA_PARAMS_PATH):
+            return
+        with open(SHAREBLOCK_VM_HA_PARAMS_PATH, "w") as f:
+            f.write(jsonobject.dumps(cmd))
+
+
+def update_shareblock_vm_ha_params(vg_uuids):
+    with WRITE_SHAREBLOCKVMHAPARAMS_LOCK:
+        if not os.path.exists(SHAREBLOCK_VM_HA_PARAMS_PATH):
+            return
+        with open(SHAREBLOCK_VM_HA_PARAMS_PATH, 'r+') as f:
+            cmd = f.read().strip()
+            if len(cmd) == 0:
+                return
+
+            cmd_json = jsonobject.loads(cmd)
+            cmd_json["vgUuids"] = vg_uuids
+            f.seek(0)
+            f.truncate(0)
+            f.write(jsonobject.dumps(cmd_json))
+
+
+def remove_shareblock_vm_ha_params():
+    with WRITE_SHAREBLOCKVMHAPARAMS_LOCK:
+        if os.path.exists(SHAREBLOCK_VM_HA_PARAMS_PATH):
+            os.remove(SHAREBLOCK_VM_HA_PARAMS_PATH)
 
 def add_fencer_rule(cmd):
     with global_fencer_rule_lock:
@@ -1374,8 +1392,8 @@ class HaPlugin(kvmagent.KvmAgent):
     def cancel_sharedblock_self_fencer(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         self.cancel_fencer(cmd.vgUuid)
-        if os.path.exists(SHAREBLOCK_VM_HA_PARAMS_PATH) and len(self.sblk_health_checker.all_vgs) == 0:
-            os.remove(SHAREBLOCK_VM_HA_PARAMS_PATH)
+        if len(self.sblk_health_checker.all_vgs) == 0:
+            remove_shareblock_vm_ha_params()
         return jsonobject.dumps(AgentRsp())
 
     def do_heartbeat_on_sharedblock(self, cmd):
@@ -1548,9 +1566,7 @@ class HaPlugin(kvmagent.KvmAgent):
     @kvmagent.replyerror
     def setup_sharedblock_self_fencer(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
-        if not os.path.exists(SHAREBLOCK_VM_HA_PARAMS_PATH):
-            with open(SHAREBLOCK_VM_HA_PARAMS_PATH, 'w') as f:
-                f.write(jsonobject.dumps(cmd))
+        create_shareblock_vm_ha_params(cmd)
 
         self.setup_sharedblock_self_fencer_from_json(cmd)
         return jsonobject.dumps(AgentRsp())

--- a/kvmagent/kvmagent/plugins/ha_plugin.py
+++ b/kvmagent/kvmagent/plugins/ha_plugin.py
@@ -876,10 +876,10 @@ def update_shareblock_vm_ha_params(vg_uuids):
             return
         with open(SHAREBLOCK_VM_HA_PARAMS_PATH, 'r+') as f:
             cmd = f.read().strip()
-            if len(cmd) == 0:
+            if len(cmd) == 0 or cmd == '{}':
                 return
 
-            cmd_json = jsonobject.loads(cmd)
+            cmd_json = json.loads(cmd)
             cmd_json["vgUuids"] = vg_uuids
             f.seek(0)
             f.truncate(0)


### PR DESCRIPTION
1. Avoiding json parsing errors with jsonobject.loads methods;
2. Shareblock HA locker will use threading lock instead of file lock.

Resolves: ZSV-5546
Related: ZSTAC-64244

Change-Id: I686a6d6472627173706168766e676d7a71726866
(cherry picked from commit 4c06788b2245e40fc322bddb5c4f9437372d629f)

sync from gitlab !4721