### PR TITLE
<feature>[zstackbuild]: enable network cicd

### DIFF
--- a/zstackbuild/projects/zstack-network.xml
+++ b/zstackbuild/projects/zstack-network.xml
@@ -11,17 +11,21 @@
         <checkFile file="${zstacknetwork.source}" />
 
         <exec executable="make" dir="${zstacknetwork.source}" failonerror="true">
+            <env key="GOROOT" value="/usr/lib/golang1.19" />
             <arg value="clean" />
         </exec>
 
         <exec executable="make" dir="${zstacknetwork.source}" failonerror="true">
+            <env key="GOROOT" value="/usr/lib/golang1.19" />
             <arg value="package" />
+            <arg value="ARCH=amd64 arm64 loong64" />
         </exec>
 
         <copy todir="${zsn.bdir}/">
             <fileset dir="${zstacknetwork.source}/target/package/zsn-agent">
                 <include name="zsn-agent.bin" />
                 <include name="zsn-agent.aarch64.bin" />
+                <include name="zsn-agent.loongarch64.bin" />
             </fileset>
         </copy>
     </target>


### PR DESCRIPTION
enable aarch64, mips64el,loongarch64 zstack-network cicd
libpcap upgraded from 1.9 to 1.10, to support loongarch64

Resolves: ZSTAC-61940

Change-Id: I696b6a6a786b77766b7173686c6870766e696f75

sync from gitlab !4724