### PR TITLE
<fix>[ha]: reset file system fencer failure count when over max attempts

### DIFF
--- a/kvmagent/kvmagent/plugins/ha_plugin.py
+++ b/kvmagent/kvmagent/plugins/ha_plugin.py
@@ -625,10 +625,12 @@ class FileSystemHeartbeatController(AbstractStorageFencer):
             return success_heartbeat
 
         self.failure += 1
-        if self.failure == self.max_attempts:
+        if self.failure >= self.max_attempts:
             logger.warn('failed to touch the heartbeat file[%s] %s times, we lost the connection to the storage,'
                         'shutdown ourselves' % (self.get_heartbeat_file_path, self.max_attempts))
-
+            # reset failure count to make sure this fencer still
+            # run to fence vm and recover storage during failures
+            self.failure = 0
             success_heartbeat = False
         return success_heartbeat
 


### PR DESCRIPTION
write_fencer_heartbeat should fail when failure >= self.max_attempts
and fencer need to reset its failure count to make sure itself could
run a new round to detect storage failure

In ZSTAC-65289 storage could be recovered several minutes after failure
so keep fencer tries best to bring it back

Resolves: ZSTAC-65289

Change-Id: I70687a66736b6162746e6b796361766e61746b6f
Signed-off-by: AlanJager <ye.zou@zstack.io>

sync from gitlab !4733