### PR TITLE
<fix>[nfsPrimaryStorage]: migrate check image dependency

### DIFF
--- a/kvmagent/kvmagent/plugins/localstorage.py
+++ b/kvmagent/kvmagent/plugins/localstorage.py
@@ -128,6 +128,7 @@ class GetVolumeBaseImagePathRsp(AgentResponse):
     def __init__(self):
         super(GetVolumeBaseImagePathRsp, self).__init__()
         self.path = None
+        self.otherPaths = []
         self.size = None
 
 class GetQCOW2ReferenceRsp(AgentResponse):
@@ -413,12 +414,18 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
         if not os.path.basename(cmd.volumeInstallDir).endswith(cmd.volumeUuid):
             raise Exception('maybe you pass a wrong install dir')
 
-        path = linux.get_qcow2_base_image_recusively(cmd.volumeInstallDir, cmd.imageCacheDir)
-        if not path:
-            return jsonobject.dumps(rsp)
+        paths = linux.get_qcow2_base_images_recusively(cmd.volumeInstallDir, cmd.imageCacheDir)
+        current_chain = linux.qcow2_get_file_chain(cmd.volumeInstallPath)
 
-        rsp.path = path
-        rsp.size = linux.get_qcow2_file_chain_size(path)
+        for path in current_chain:
+            real_path = os.path.realpath(path)
+            if real_path in paths:
+                rsp.path = real_path
+                rsp.size = linux.get_qcow2_file_chain_size(rsp.path)
+                paths.remove(real_path)
+                break
+
+        rsp.otherPaths = list(paths)
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror

--- a/kvmagent/kvmagent/plugins/zses.py
+++ b/kvmagent/kvmagent/plugins/zses.py
@@ -61,6 +61,7 @@ class GetVolumeBaseImagePathRsp(AgentResponse):
     def __init__(self):
         super(GetVolumeBaseImagePathRsp, self).__init__()
         self.path = None
+        self.otherPaths = []
         self.size = None
 
 class GetQCOW2ReferenceRsp(AgentResponse):
@@ -165,12 +166,17 @@ class ZsesStoragePlugin(kvmagent.KvmAgent):
         if not os.path.basename(cmd.volumeInstallDir).endswith(cmd.volumeUuid):
             raise Exception('maybe you pass a wrong install dir')
 
-        path = linux.get_qcow2_base_image_recusively(cmd.volumeInstallDir, cmd.imageCacheDir)
-        if not path:
-            return jsonobject.dumps(rsp)
+        paths = linux.get_qcow2_base_images_recusively(cmd.volumeInstallDir, cmd.imageCacheDir)
+        current_chain = linux.qcow2_get_file_chain(cmd.volumeInstallPath)
 
-        rsp.path = path
-        rsp.size = linux.get_qcow2_file_chain_size(path)
+        for path in current_chain:
+            if path in paths:
+                rsp.path = path
+                rsp.size = linux.get_qcow2_file_chain_size(rsp.path)
+                paths.remove(path)
+                break
+
+        rsp.otherPaths = paths
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror

--- a/kvmagent/kvmagent/test/nfs_testsuit/test_nfs_migrate_bits.py
+++ b/kvmagent/kvmagent/test/nfs_testsuit/test_nfs_migrate_bits.py
@@ -1,3 +1,4 @@
+import os.path
 import time
 
 from kvmagent.test.nfs_testsuit.test_ha_plugin_testsub import NfsPluginTestStub
@@ -46,7 +47,8 @@ class TestHaNfsPlugin(TestCase, NfsPluginTestStub):
         dstPsDir = "/tmp/nfs-storage/"
         linux.mkdir(dstPsDir)
 
-        image_path = "/opt/zstack/nfsprimarystorage/prim-{}/imagecache/template/{}/".format(primaryStorageUuid, imageUuid)
+        cache_dir = "/opt/zstack/nfsprimarystorage/prim-{}/imagecache".format(primaryStorageUuid)
+        image_path = "{}/template/{}/".format(cache_dir, imageUuid)
         shell.call('mkdir -p %s' % image_path)
 
         installUrl = "/opt/zstack/nfsprimarystorage/prim-{}/rootVolumes/acct-36c27e8ff05c4780bf6d2fa65700f22e/vol-{}/{}.qcow2" \
@@ -60,6 +62,11 @@ class TestHaNfsPlugin(TestCase, NfsPluginTestStub):
                                                                 volumeUuid, primaryStorageUuid, primaryStorageUuid, kvmHostAddons)
 
         self.assertEqual(True, rsp.success, rsp.error)
+
+        rsp = nfs_plugin_utils.get_volume_base_image(installUrl, os.path.dirname(installUrl),
+                                                     os.path.dirname(image_path), volumeUuid)
+        self.assertEqual(image_path + "min-vm.qcow2", rsp.path, "found wrong base image %s" % rsp.path)
+        self.assertEqual([], rsp.otherPaths, "found wrong base images %s" % rsp.otherPaths)
 
         linux.qcow2_fill(10*1024**2, 20*1024**2, installUrl)
         srcPath = "/opt/zstack/nfsprimarystorage/prim-{}/rootVolumes/acct-36c27e8ff05c4780bf6d2fa65700f22e/vol-{}/".format(primaryStorageUuid, volumeUuid)

--- a/kvmagent/kvmagent/test/utils/nfs_plugin_utils.py
+++ b/kvmagent/kvmagent/test/utils/nfs_plugin_utils.py
@@ -54,3 +54,13 @@ def migrate_bits(srcFolderPath, dstFolderPath, independentPath=False, filtPaths=
         "mountPath": mountPath,
         "kvmHostAddons":kvmHostAddons
     }))
+
+
+@misc.return_jsonobject()
+def get_volume_base_image(volumeInstallPath, volumeInstallDir, imageCacheDir, volumeUuid):
+    return NFS_PLUGIN.get_volume_base_image_path(misc.make_a_request({
+        "volumeInstallPath": volumeInstallPath,
+        "volumeInstallDir": volumeInstallDir,
+        "imageCacheDir": imageCacheDir,
+        "volumeUuid": volumeUuid
+    }))

--- a/zstacklib/zstacklib/test/utils/misc.py
+++ b/zstacklib/zstacklib/test/utils/misc.py
@@ -17,8 +17,11 @@ def uuid():
 
 def make_a_request(body):
     # type: (dict) -> dict
+
+    bodyStr = jsonobject.dumps(body, include_protected_attr=True)
+    logger.debug("make request" + bodyStr)
     return {
-        REQUEST_BODY: jsonobject.dumps(body, include_protected_attr=True)
+        REQUEST_BODY: bodyStr
     }
 
 

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -1205,7 +1205,7 @@ def get_qcow2_base_backing_file_recusively(path):
     chain = qcow2_get_file_chain(path)
     return chain[-1]
 
-def get_qcow2_base_image_recusively(vol_install_dir, image_cache_dir):
+def get_qcow2_base_images_recusively(vol_install_dir, image_cache_dir):
     real_vol_dir = os.path.realpath(vol_install_dir)
     real_cache_dir = os.path.realpath(image_cache_dir)
     backing_files = shell.call(
@@ -1218,14 +1218,7 @@ def get_qcow2_base_image_recusively(vol_install_dir, image_cache_dir):
         if real_image_path.startswith(real_cache_dir):
             base_image.add(real_image_path)
 
-    if len(base_image) == 1:
-        return base_image.pop()
-
-    if len(base_image) == 0:
-        return None
-
-    if len(base_image) > 1:
-        raise Exception('more than one image file found in cache dir')
+    return base_image
 
 def qcow2_fill(seek, length, path, raise_excpetion=False):
     cmd = shell.ShellCmd("qemu-io -c 'write %s %s' %s -n" % (seek, length, path))


### PR DESCRIPTION
when nfs storage migrate, check image cache
dependency when no image cache record on source nfs.

Resolves: ZSTAC-60300

Change-Id: I7369746b6563617175627770616b6c747a726d70


(cherry picked from commit e1a19fd7dcb9f0e7ba10682b978d9a17cf673a10)

sync from gitlab !4739