### PR TITLE
<bug>[sharedblock]: turn some lvm commands into read-only

### DIFF
--- a/kvmagent/kvmagent/plugins/mini_fencer.py
+++ b/kvmagent/kvmagent/plugins/mini_fencer.py
@@ -88,7 +88,7 @@ def test_fencer(vg_name, resource_name):
 
 def do_test_fencer(vg_name):
     # type: (str) -> bool
-    r, fencer_ip = getstatusoutput("timeout 3 vgs %s -otags --nolocking --noheading | tr ',' '\\n' | grep %s" % (vg_name, FENCER_TAG))
+    r, fencer_ip = getstatusoutput("timeout 3 vgs %s -otags --nolocking -t --noheading | tr ',' '\\n' | grep %s" % (vg_name, FENCER_TAG))
     if r == 0 and fencer_ip and fencer_ip != "" and is_ip_address(fencer_ip):
         fencer_ip = fencer_ip.strip().split("::")[-1]
         return test_ip_address(fencer_ip)
@@ -104,7 +104,7 @@ def do_test_fencer(vg_name):
     if r == 0 and default_gateway and default_gateway != "" and is_ip_address(default_gateway):
         return test_ip_address(default_gateway)
 
-    mgmt_ip = getoutput("timeout 3 vgs %s -otags --nolocking --noheading | tr ',' '\\n' | grep %s" % (vg_name, MANAGEMENT_TAG))
+    mgmt_ip = getoutput("timeout 3 vgs %s -otags --nolocking -t --noheading | tr ',' '\\n' | grep %s" % (vg_name, MANAGEMENT_TAG))
     mgmt_ip = mgmt_ip.strip().split("::")[-1]
     if not is_ip_address(mgmt_ip):
         logger.error("can not get mgmt nic")

--- a/kvmagent/kvmagent/plugins/mini_storage_plugin.py
+++ b/kvmagent/kvmagent/plugins/mini_storage_plugin.py
@@ -510,7 +510,7 @@ class MiniStoragePlugin(kvmagent.KvmAgent):
                 lvm.config_lvm_by_sed("use_lvmetad", "use_lvmetad=1", ["lvm.conf", "lvmlocal.conf"])
             else:
                 lvm.config_lvm_by_sed("use_lvmetad", "use_lvmetad=0", ["lvm.conf", "lvmlocal.conf"])
-            lvm.config_lvm_by_sed("issue_discards", "issue_discards=1", ["lvm.conf", "lvmlocal.conf"])
+            lvm.config_lvm_by_sed("issue_discards", "issue_discards=0", ["lvm.conf", "lvmlocal.conf"])
             lvm.config_lvm_by_sed("reserved_stack", "reserved_stack=256", ["lvm.conf", "lvmlocal.conf"])
             lvm.config_lvm_by_sed("reserved_memory", "reserved_memory=131072", ["lvm.conf", "lvmlocal.conf"])
             lvm.config_lvm_by_sed("thin_pool_autoextend_threshold", "thin_pool_autoextend_threshold=80", ["lvm.conf", "lvmlocal.conf"])

--- a/kvmagent/kvmagent/plugins/mini_storage_plugin.py
+++ b/kvmagent/kvmagent/plugins/mini_storage_plugin.py
@@ -446,7 +446,7 @@ class MiniStoragePlugin(kvmagent.KvmAgent):
     def create_vg_if_not_found(vgUuid, disks, diskPaths, hostUuid, forceWipe=False):
         @linux.retry(times=5, sleep_time=random.uniform(0.1, 3))
         def find_vg(vgUuid, raise_exception=True):
-            cmd = shell.ShellCmd("timeout 5 vgscan --ignorelockingfailure; vgs --nolocking %s -otags | grep %s" % (vgUuid, INIT_TAG))
+            cmd = shell.ShellCmd("timeout 5 vgscan --ignorelockingfailure; vgs --nolocking -t %s -otags | grep %s" % (vgUuid, INIT_TAG))
             cmd(is_exception=False)
             if cmd.return_code != 0 and raise_exception:
                 raise RetryException("can not find vg %s with tag %s" % (vgUuid, INIT_TAG))
@@ -586,7 +586,7 @@ class MiniStoragePlugin(kvmagent.KvmAgent):
 
         @linux.retry(times=3, sleep_time=random.uniform(0.1, 3))
         def find_vg(vgUuid):
-            cmd = shell.ShellCmd("vgs --nolocking %s -otags | grep %s" % (vgUuid, INIT_TAG))
+            cmd = shell.ShellCmd("vgs --nolocking -t %s -otags | grep %s" % (vgUuid, INIT_TAG))
             cmd(is_exception=False)
             if cmd.return_code == 0:
                 return True
@@ -631,7 +631,7 @@ class MiniStoragePlugin(kvmagent.KvmAgent):
     def add_disk(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         disk = CheckDisk(cmd.diskUuid)
-        command = shell.ShellCmd("vgs --nolocking %s -otags | grep %s" % (cmd.vgUuid, INIT_TAG))
+        command = shell.ShellCmd("vgs --nolocking -t %s -otags | grep %s" % (cmd.vgUuid, INIT_TAG))
         command(is_exception=False)
         if command.return_code != 0:
             self.create_vg_if_not_found(cmd.vgUuid, set(disk), [disk.get_path()], cmd.hostUuid, cmd.forceWipe)

--- a/kvmagent/kvmagent/plugins/prometheus.py
+++ b/kvmagent/kvmagent/plugins/prometheus.py
@@ -119,7 +119,7 @@ def collect_lvm_capacity_statistics():
     if r == 0:
         linux.set_fail_if_no_path()
 
-    r, o, e = bash_roe("vgs --nolocking --noheading -oname")
+    r, o, e = bash_roe("vgs --nolocking -t --noheading -oname")
     if r != 0 or len(o.splitlines()) == 0:
         return metrics.values()
 
@@ -306,7 +306,7 @@ def collect_node_disk_wwid():
                                            'node disk wwid', None, ["disk", "wwid"])
     }
 
-    pvs = bash_o("pvs --nolocking --noheading -o pv_name").strip().splitlines()
+    pvs = bash_o("pvs --nolocking -t --noheading -o pv_name").strip().splitlines()
     for pv in pvs:
         multipath_wwid = None
         if bash_r("dmsetup table %s | grep multipath" % pv) == 0:

--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -509,7 +509,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             lvm.config_lvm_by_sed("host_id", "host_id=%s" % host_id, ["lvm.conf", "lvmlocal.conf"])
             lvm.config_lvm_by_sed("sanlock_lv_extend", "sanlock_lv_extend=%s" % DEFAULT_SANLOCK_LV_SIZE, ["lvm.conf", "lvmlocal.conf"])
             lvm.config_lvm_by_sed("lvmlockd_lock_retries", "lvmlockd_lock_retries=6", ["lvm.conf", "lvmlocal.conf"])
-            lvm.config_lvm_by_sed("issue_discards", "issue_discards=1", ["lvm.conf", "lvmlocal.conf"])
+            lvm.config_lvm_by_sed("issue_discards", "issue_discards=0", ["lvm.conf", "lvmlocal.conf"])
             lvm.config_lvm_by_sed("reserved_stack", "reserved_stack=256", ["lvm.conf", "lvmlocal.conf"])
             lvm.config_lvm_by_sed("reserved_memory", "reserved_memory=131072", ["lvm.conf", "lvmlocal.conf"])
             if kvmagent.get_host_os_type() == "debian":

--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -299,6 +299,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
     CONVERT_VOLUME_FORMAT_PATH = "/sharedblock/volume/convertformat"
     SHRINK_SNAPSHOT_PATH = "/sharedblock/snapshot/shrink"
     CHECK_LOCK_PATH = "/sharedblock/lock/check"
+    CHECK_STATE_PATH = "/sharedblock/vgstate/check"
 
     def start(self):
         http_server = kvmagent.get_http_server()
@@ -334,7 +335,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         http_server.register_async_uri(self.CONVERT_VOLUME_FORMAT_PATH, self.convert_volume_format)
         http_server.register_async_uri(self.GET_DOWNLOAD_BITS_FROM_KVM_HOST_PROGRESS_PATH, self.get_download_bits_from_kvmhost_progress)
         http_server.register_async_uri(self.SHRINK_SNAPSHOT_PATH, self.shrink_snapshot)
-        http_server.register_async_uri(self.CHECK_LOCK_PATH, self.check_lock)
+        http_server.register_async_uri(self.CHECK_STATE_PATH, self.check_vg_state)
 
         self.imagestore_client = ImageStoreClient()
 
@@ -579,6 +580,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         # lvm.clean_vg_exists_host_tags(cmd.vgUuid, cmd.hostUuid, HEARTBEAT_TAG)
         # lvm.add_vg_tag(cmd.vgUuid, "%s::%s::%s::%s" % (HEARTBEAT_TAG, cmd.hostUuid, time.time(), bash.bash_o('hostname').strip()))
         self.clear_stalled_qmp_socket()
+        lvm.check_missing_pv(cmd.vgUuid)
 
         rsp.totalCapacity, rsp.availableCapacity = lvm.get_vg_size(cmd.vgUuid)
         rsp.hostId = lvm.get_running_host_id(cmd.vgUuid)
@@ -1359,7 +1361,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror
-    def check_lock(self, req):
+    def check_vg_state(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = AgentRsp()
         if cmd.vgUuids is None or len(cmd.vgUuids) == 0:
@@ -1383,6 +1385,13 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
                     elif "Reading VG %s without a lock" % vgUuid in es:
                         rsp.failedVgs.update({vgUuid : o})
                         break
+
+            if vgUuid not in rsp.failedVgs:
+                pvs_outs = bash.bash_o(
+                    "timeout -s SIGKILL 10 pvs --noheading --nolocking -t -Svg_name=%s -ouuid,name,missing" % vgUuid).strip()
+                if "missing" in pvs_outs:
+                    rsp.failedVgs.update({vgUuid : "vg %s was missing pv" % vgUuid})
+
             vgck(vg_group)
 
         # up to three worker threads executing vgck

--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -617,13 +617,13 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
 
         @linux.retry(times=3, sleep_time=random.uniform(0.1, 3))
         def find_vg(vgUuid):
-            cmd = shell.ShellCmd("vgs --nolocking %s -otags | grep %s" % (vgUuid, INIT_TAG))
+            cmd = shell.ShellCmd("vgs --nolocking -t %s -otags | grep %s" % (vgUuid, INIT_TAG))
             cmd(is_exception=False)
             if cmd.return_code == 0:
                 return True
 
             logger.debug("can not find vg %s with tag %s" % (vgUuid, INIT_TAG))
-            cmd = shell.ShellCmd("vgs --nolocking %s" % vgUuid)
+            cmd = shell.ShellCmd("vgs --nolocking -t %s" % vgUuid)
             cmd(is_exception=False)
             if cmd.return_code == 0:
                 logger.warn("found vg %s without tag %s" % (vgUuid, INIT_TAG))
@@ -691,7 +691,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             rsp.totalCapacity, rsp.availableCapacity = lvm.get_vg_size(cmd.vgUuid)
             return jsonobject.dumps(rsp)
 
-        command = shell.ShellCmd("vgs --nolocking %s -otags | grep %s" % (cmd.vgUuid, INIT_TAG))
+        command = shell.ShellCmd("vgs --nolocking -t %s -otags | grep %s" % (cmd.vgUuid, INIT_TAG))
         command(is_exception=False)
         if command.return_code != 0:
             self.create_vg_if_not_found(cmd.vgUuid, {disk}, cmd.hostUuid, allDisks, cmd.forceWipe)

--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -534,7 +534,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
 
         config_lvm(cmd.hostId, cmd.enableLvmetad)
 
-        lvm.start_lvmlockd(cmd.ioTimeout)
+        lvm.start_lock_service(cmd.ioTimeout)
         logger.debug("find/create vg %s lock..." % cmd.vgUuid)
         rsp.isFirst = self.create_vg_if_not_found(cmd.vgUuid, disks, cmd.hostUuid, allDisks, cmd.forceWipe, cmd.isFirst)
 

--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -570,12 +570,12 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
 
         lvm.check_stuck_vglk()
         logger.debug("starting vg %s lock..." % cmd.vgUuid)
-        lvm.start_vg_lock(cmd.vgUuid, retry_times_for_checking_vg_lockspace)
+        lvm.start_vg_lock(cmd.vgUuid, cmd.hostId, retry_times_for_checking_vg_lockspace)
 
         if lvm.lvm_vgck(cmd.vgUuid, 60)[0] is False and lvm.lvm_check_operation(cmd.vgUuid) is False:
             lvm.drop_vg_lock(cmd.vgUuid)
             logger.debug("restarting vg %s lock..." % cmd.vgUuid)
-            lvm.start_vg_lock(cmd.vgUuid, retry_times_for_checking_vg_lockspace)
+            lvm.start_vg_lock(cmd.vgUuid, cmd.hostId, retry_times_for_checking_vg_lockspace)
 
         # lvm.clean_vg_exists_host_tags(cmd.vgUuid, cmd.hostUuid, HEARTBEAT_TAG)
         # lvm.add_vg_tag(cmd.vgUuid, "%s::%s::%s::%s" % (HEARTBEAT_TAG, cmd.hostUuid, time.time(), bash.bash_o('hostname').strip()))

--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -1406,4 +1406,9 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         for t in threads:
             t.join()
 
+
+        if lvm.is_lvmlockd_socket_abnormal():
+            for vgUuid in cmd.vgUuids:
+                rsp.failedVgs.update({vgUuid: "lvmlockd socket is abnormal."})
+
         return jsonobject.dumps(rsp)

--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -1375,7 +1375,6 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
 
             vgUuid = vg_group.pop(0)
             r, o, e = lvm.vgck(vgUuid, 10)
-
             if o is not None and o != "":
                 for es in o.strip().splitlines():
                     if "lock start in progress" in es:
@@ -1385,12 +1384,9 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
                     elif "Reading VG %s without a lock" % vgUuid in es:
                         rsp.failedVgs.update({vgUuid : o})
                         break
-
-            if vgUuid not in rsp.failedVgs:
-                pvs_outs = bash.bash_o(
-                    "timeout -s SIGKILL 10 pvs --noheading --nolocking -t -Svg_name=%s -ouuid,name,missing" % vgUuid).strip()
-                if "missing" in pvs_outs:
-                    rsp.failedVgs.update({vgUuid : "vg %s was missing pv" % vgUuid})
+                    elif 'Volume group "%s" not found' % vgUuid in es or re.search(r"volume group is missing \d physical volumes", es):
+                        rsp.failedVgs.update({vgUuid : o})
+                        break
 
             vgck(vg_group)
 

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -7561,7 +7561,7 @@ class VmPlugin(kvmagent.KvmAgent):
             # type: (str, str, str) -> object
             volume = file.strip().split("'")[1]
             syslog.syslog("deactivating volume %s for vm %s" % (file, vm_uuid))
-            lock_type = bash.bash_o("lvs --noheading --nolocking %s -ovg_lock_type" % volume).strip()
+            lock_type = bash.bash_o("lvs --noheading --nolocking -t %s -ovg_lock_type" % volume).strip()
             if "sanlock" not in lock_type:
                 syslog.syslog("%s has no sanlock, skip to deactive" % file)
                 return

--- a/zstackctl/zstackctl/conf/collect_log_full.yaml
+++ b/zstackctl/zstackctl/conf/collect_log_full.yaml
@@ -132,8 +132,8 @@ sharedblock:
       - {name: lvmlock-logs, dir: /var/log/lvmlock/, file: lvmlockd.log*}
       - {name: sanlock_client_info, exec: 'sanlock client status -D'}
       - {name: sanlock_host_info, exec: 'sanlock client host_status -D'}
-      - {name: lvm_lvs_info, exec: 'lvs --nolocking -oall'}
-      - {name: lvm_vgs_info, exec: 'vgs --nolocking -oall'}
+      - {name: lvm_lvs_info, exec: 'lvs --nolocking -t -oall'}
+      - {name: lvm_vgs_info, exec: 'vgs --nolocking -t -oall'}
       - {name: lvm_config_diff_info, exec: 'lvmconfig --type diff'}
       - {name: lvm-etc, dir: /etc/lvm/, file: }
       - {name: sanlock-etc, dir: /etc/sanlock/, file: }

--- a/zstackctl/zstackctl/conf/collect_log_full_db.yaml
+++ b/zstackctl/zstackctl/conf/collect_log_full_db.yaml
@@ -133,8 +133,8 @@ sharedblock:
       - {name: lvmlock-logs, dir: /var/log/lvmlock/, file: lvmlockd.log*}
       - {name: sanlock_client_info, exec: 'sanlock client status -D'}
       - {name: sanlock_host_info, exec: 'sanlock client host_status -D'}
-      - {name: lvm_lvs_info, exec: 'lvs --nolocking -oall'}
-      - {name: lvm_vgs_info, exec: 'vgs --nolocking -oall'}
+      - {name: lvm_lvs_info, exec: 'lvs --nolocking -t -oall'}
+      - {name: lvm_vgs_info, exec: 'vgs --nolocking -t -oall'}
       - {name: lvm_config_diff_info, exec: 'lvmconfig --type diff'}
       - {name: lvm-etc, dir: /etc/lvm/, file: }
       - {name: sanlock-etc, dir: /etc/sanlock/, file: }

--- a/zstackctl/zstackctl/conf/collect_log_mn_host.yaml
+++ b/zstackctl/zstackctl/conf/collect_log_mn_host.yaml
@@ -62,8 +62,8 @@ sharedblock:
       - {name: lvmlock-logs, dir: /var/log/lvmlock/, file: lvmlockd.log*}
       - {name: sanlock_client_info, exec: 'sanlock client status -D'}
       - {name: sanlock_host_info, exec: 'sanlock client host_status -D'}
-      - {name: lvm_lvs_info, exec: 'lvs --nolocking -oall'}
-      - {name: lvm_vgs_info, exec: 'vgs --nolocking -oall'}
+      - {name: lvm_lvs_info, exec: 'lvs --nolocking -t -oall'}
+      - {name: lvm_vgs_info, exec: 'vgs --nolocking -t -oall'}
       - {name: lvm_config_diff_info, exec: 'lvmconfig --type diff'}
       - {name: lvm-etc, dir: /etc/lvm/, file: }
       - {name: sanlock-etc, dir: /etc/sanlock/, file: }

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -5757,9 +5757,9 @@ class CollectLogCmd(Command):
         command = "sanlock client host_status -D > %s/sanlock_host_info || true" % target_dir
         run_remote_command(command, host_post_info)
 
-        command = "lvs --nolocking -oall > %s/lvm_lvs_info || true" % target_dir
+        command = "lvs --nolocking -t -oall > %s/lvm_lvs_info || true" % target_dir
         run_remote_command(command, host_post_info)
-        command = "vgs --nolocking -oall > %s/lvm_vgs_info || true" % target_dir
+        command = "vgs --nolocking -t -oall > %s/lvm_vgs_info || true" % target_dir
         run_remote_command(command, host_post_info)
         command = "lvmconfig --type diff > %s/lvm_config_diff_info || true" % target_dir
         run_remote_command(command, host_post_info)

--- a/zstackctl/zstackctl/fix_shared_volume.py
+++ b/zstackctl/zstackctl/fix_shared_volume.py
@@ -65,7 +65,7 @@ def do_convert(args):
 
 def do_find_qcow2(vgUuid):
     paths = []
-    raw_paths = bash.bash_o('lvs --nolocking --noheading -Slv_name=~".*%s" -Stags={%s} -opath %s' % (QCOW2_SUFFIX, DONE_TAG, vgUuid)).strip().splitlines()
+    raw_paths = bash.bash_o('lvs --nolocking -t --noheading -Slv_name=~".*%s" -Stags={%s} -opath %s' % (QCOW2_SUFFIX, DONE_TAG, vgUuid)).strip().splitlines()
     for raw_path in raw_paths:
         paths.append(raw_path.strip())
     sys.stdout.write(",".join(paths))

--- a/zstackctl/zstackctl/log_collector.py
+++ b/zstackctl/zstackctl/log_collector.py
@@ -647,9 +647,9 @@ class CollectFromYml(object):
         command = "sanlock client host_status -D > %s/sanlock_host_info || true" % target_dir
         run_remote_command(command, host_post_info)
 
-        command = "lvs --nolocking -oall > %s/lvm_lvs_info || true" % target_dir
+        command = "lvs --nolocking -t -oall > %s/lvm_lvs_info || true" % target_dir
         run_remote_command(command, host_post_info)
-        command = "vgs --nolocking -oall > %s/lvm_vgs_info || true" % target_dir
+        command = "vgs --nolocking -t -oall > %s/lvm_vgs_info || true" % target_dir
         run_remote_command(command, host_post_info)
         command = "lvmconfig --type diff > %s/lvm_config_diff_info || true" % target_dir
         run_remote_command(command, host_post_info)

--- a/zstackctl/zstackctl/reset_mini.py
+++ b/zstackctl/zstackctl/reset_mini.py
@@ -168,7 +168,7 @@ def wipe_fs(disks, expected_vg=None, with_lock=True):
         if r == 0:
             continue
 
-        r, o = bash_ro("pvs --nolocking --noheading -o vg_name %s" % disk)
+        r, o = bash_ro("pvs --nolocking -t --noheading -o vg_name %s" % disk)
         if r == 0 and o.strip() != "":
             exists_vg = o.strip()
 
@@ -251,8 +251,8 @@ def cleanup_storage():
             bash_r("kill -9 %s" % line.split()[1])
 
     def get_mini_pv():
-        vg_name = bash_o("vgs --nolocking -oname,tags | grep zs::ministorage | awk '{print $1}'").strip()
-        pv_names = bash_o("pvs --nolocking -oname -Svg_name=%s | grep -v PV" % vg_name).strip().splitlines()
+        vg_name = bash_o("vgs --nolocking -t -oname,tags | grep zs::ministorage | awk '{print $1}'").strip()
+        pv_names = bash_o("pvs --nolocking -t -oname -Svg_name=%s | grep -v PV" % vg_name).strip().splitlines()
         return [p.strip() for p in pv_names]
 
     bash_r("rm -rf /zstack_bs")

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -1589,13 +1589,19 @@ def find_process_by_cmdline(cmdlines):
 
     return None
 
-def find_process_by_command(comm, cmdlines):
+def find_process_by_command(comm, cmdlines=None):
     pids = [pid for pid in os.listdir('/proc') if pid.isdigit()]
     for pid in pids:
         try:
             comm_path = os.readlink(os.path.join('/proc', pid, 'exe')).split(";")[0]
+            if comm_path.endswith("(deleted)") and not os.path.exists(comm_path):
+                comm_path = comm_path[0:-9].strip()
+
             if comm_path != comm and os.path.basename(comm_path) != comm:
                 continue
+
+            if not cmdlines:
+                return pid
 
             with open(os.path.join('/proc', pid, 'cmdline'), 'r') as fd:
                 cmdline = fd.read().replace('\x00', ' ').strip()

--- a/zstacklib/zstacklib/utils/list_ops.py
+++ b/zstacklib/zstacklib/utils/list_ops.py
@@ -29,3 +29,15 @@ def list_and(list1, list2):
             new_list.append(item)
 
     return new_list
+
+def list_split(list, n):
+    if len(list) == 0:
+        return list
+
+    if n <= 0:
+        raise Exception("num must be positive")
+
+    result = [[] for _ in range(min(n, len(list)))]
+    for i, v in enumerate(list):
+        result[i % n].append(v)
+    return result

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -1459,9 +1459,12 @@ def check_pv_status(vgUuid, timeout):
 
     return True, ""
 
+@bash.in_bash
+def vgck(vgUuid, timeout):
+    return bash.bash_roe('timeout -s SIGKILL %s vgck %s 2>&1' % (timeout, vgUuid))
 
 def lvm_vgck(vgUuid, timeout):
-    health, o, e = bash.bash_roe('timeout -s SIGKILL %s vgck %s 2>&1' % (360 if timeout < 360 else timeout, vgUuid))
+    health, o, e = vgck(vgUuid, 360 if timeout < 360 else timeout)
     check_stuck_vglk()
 
     if health != 0:

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -599,6 +599,28 @@ def start_vg_lock(vgUuid, retry_times_for_checking_vg_lockspace):
     except Exception as e:
         raise e
 
+@bash.in_bash
+def check_missing_pv(vgUuid):
+    pvs_outs = bash.bash_o(
+        "timeout -s SIGKILL 10 pvs --noheading --nolocking -t -Svg_name=%s -ouuid,name,missing" % vgUuid).strip().splitlines()
+    if len(pvs_outs) == 0:
+        return
+
+    @linux.retry(times=3, sleep_time=random.uniform(0.1, 1))
+    def restore_missing_pv(pv_name):
+        r, o, e = bash.bash_roe("vgextend --restoremissing %s %s" % (vgUuid, pv_name))
+        if r != 0:
+            raise Exception("unable to restore missing pv %s for vg %s, stdout:%s, stderr:%s" % (pv_name, vgUuid, str(o), str(e)))
+        logger.debug("restore missing pv[name:%s, uuid:%s] for vg %s successfully" % (pv_name, pv_uuid, vgUuid))
+
+    check_gl_lock()
+    for pvs_out in pvs_outs:
+        pv_uuid = pvs_out.strip().split(" ")[0]
+        pv_name = pvs_out.strip().split(" ")[1]
+        if "missing" in pvs_out:
+            if "unknown" in pv_name:
+                raise Exception("vg %s was missing pv[name:%s, uuid:%s] , unable to restore" % (vgUuid, pv_name, pv_uuid))
+            restore_missing_pv(pv_name)
 
 def stop_vg_lock(vgUuid):
     @linux.retry(times=3, sleep_time=random.uniform(0.1, 1))

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -30,6 +30,7 @@ LVMLOCKD_LOG_FILE_PATH = "/var/log/lvmlockd/lvmlockd.log"
 LVMLOCKD_LOG_RSYSLOG_PATH = "/etc/rsyslog.d/lvmlockd.conf"
 LVMLOCKD_SERVICE_PATH = "/lib/systemd/system/lvm2-lvmlockd.service"
 LVMLOCKD_LOG_LOGROTATE_PATH = "/etc/logrotate.d/lvmlockd"
+LVMLOCKD_ADOPT_FILE = "/run/lvm/lvmlockd.adopt"
 LVM_CONFIG_BACKUP_PATH = "/etc/lvm/zstack-backup"
 LVM_CONFIG_ARCHIVE_PATH = "/etc/lvm/archive"
 SUPER_BLOCK_BACKUP = "superblock.bak"
@@ -298,8 +299,22 @@ def get_lvmlockd_service_name():
         service_name = 'lvmlockd.service'
     return service_name
 
+def get_lvmlockd_version():
+    global LVMLOCKD_VERSION
+    if LVMLOCKD_VERSION is None:
+        LVMLOCKD_VERSION = shell.call("""lvmlockd --version | awk '{print $3}' | awk -F'.' '{print $1"."$2}'""").strip()
+    return LVMLOCKD_VERSION
+
+def get_running_lvmlockd_version():
+    pid = get_lvmlockd_pid()
+    if pid:
+        exe = "/proc/%s/exe" % pid
+        return shell.call("""%s --version | awk '{print $3}' | awk -F'.' '{print $1"."$2}'""" % exe).strip()
+
+def get_lvmlockd_pid():
+    return shell.call("""ps x | awk '/sbin\/lvmlockd/{print $1; exit}'""").strip()
+
 def get_device_info(dev_name):
-    # type: (str) -> SharedBlockCandidateStruct
     s = SharedBlockCandidateStruct()
     r, o, e = bash.bash_roe("lsblk --pair -b -p -o NAME,VENDOR,MODEL,WWN,SERIAL,HCTL,TYPE,SIZE /dev/%s" % dev_name, False)
     if r != 0 or o.strip() == "":
@@ -485,7 +500,7 @@ After=lvm2-lvmetad.service
 [Service]
 Type=simple
 NonBlocking=true
-ExecStart=/sbin/lvmlockd --daemon-debug --sanlock-timeout %s
+ExecStart=/sbin/lvmlockd --daemon-debug --sanlock-timeout %s --adopt 1
 StandardError=syslog
 StandardOutput=syslog
 SyslogIdentifier=lvmlockd
@@ -534,6 +549,10 @@ def start_lvmlockd(io_timeout=40):
         os.mkdir(os.path.dirname(LVMLOCKD_LOG_FILE_PATH))
 
     config_lvmlockd(io_timeout)
+    running_lockd_version = get_running_lvmlockd_version()
+    if running_lockd_version and LooseVersion(running_lockd_version) < LooseVersion(get_lvmlockd_version()):
+        write_lvmlockd_adopt_file()
+        stop_lvmlockd()
     for service in ["sanlock", get_lvmlockd_service_name()]:
         cmd = shell.ShellCmd("timeout 30 systemctl start %s" % service)
         cmd(is_exception=True)
@@ -555,6 +574,62 @@ def start_lvmlockd(io_timeout=40):
         os.fsync(f.fileno())
     os.chmod(LVMLOCKD_LOG_LOGROTATE_PATH, 0644)
 
+def write_lvmlockd_adopt_file():
+    def _get_lockspace_name(line):
+        return line.split()[1].split(":")[0]
+
+    class Lock:
+        def __init__(self, line):
+            ## line format: r lvm_8c8b0ad64b0e42f4a9792db1f2bbacd8:OGDB3v-DKJ9-kdYX-XO7p-7cEp-jK22-jm1sgp:/dev/mapper/8c8b0ad64b0e42f4a9792db1f2bbacd8-lvmlock:70254592:1 p 60836
+            self.line = line
+
+        def get_lockspace(self):
+            return self.line.split()[1].split(":")[0]
+
+        def get_uuid(self):
+            return self.line.split()[1].split(":")[1]
+
+        def get_path(self):
+            return self.line.split()[1].split(":")[2]
+
+        def get_offset(self):
+            return self.line.split()[1].split(":")[3]
+
+        def get_mode(self):
+            return self.line.split()[1].split(":")[4]
+
+
+    def _build_lvmlockd_adopt_file(all_locks):
+        content = ""
+        for lockspace in all_locks:
+            VG_NAME = lockspace.replace("lvm_", "")
+            VG_UUID = get_vg_lvm_uuid(VG_NAME)
+            vg = "VG: %s %s sanlock 1.0.0:lvmlock\n" % (VG_UUID, VG_NAME)
+            content += vg
+            for resource in all_locks.get(lockspace):
+                lv = "LV: %s %s 1.0.0:%s %s 0\n" % (VG_UUID, resource.get_uuid(), resource.get_offset(), "sh "if resource.get_mode() == "SH" else "ex")
+                content += lv
+
+        if len(content) != 0:
+            logger.debug("write sanlock records to %s, content : \n%s" % (LVMLOCKD_ADOPT_FILE, content))
+            linux.write_file(LVMLOCKD_ADOPT_FILE, content, create_if_not_exist=True)
+
+    lines = bash.bash_o("sanlock client status").splitlines()
+    all_locks = {}
+    for line in lines:
+        if line.startswith("s "):
+            all_locks.update({_get_lockspace_name(line) : []})
+        elif line.startswith("r "):
+            all_locks.get(_get_lockspace_name(line)).append(Lock(line))
+
+    _build_lvmlockd_adopt_file(all_locks)
+
+
+@bash.in_bash
+def stop_lvmlockd():
+    pid = get_lvmlockd_pid()
+    if pid:
+        linux.kill_process(pid)
 
 @bash.in_bash
 def start_vg_lock(vgUuid, retry_times_for_checking_vg_lockspace):

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -423,7 +423,7 @@ def config_lvm_filter(files, no_drbd=False, preserve_disks=None):
         return
 
     filter_str = 'filter=["r|\\/dev\\/cdrom|"'
-    vgs = bash.bash_o("vgs --nolocking -oname --noheading").splitlines()
+    vgs = bash.bash_o("vgs --nolocking -t -oname --noheading").splitlines()
     for vg in vgs:
         filter_str += ', "r\\/dev\\/mapper\\/%s.*\\/"' % vg.strip()
     if no_drbd:
@@ -649,7 +649,7 @@ def drop_vg_lock(vgUuid):
 
 @bash.in_bash
 def get_vg_lvm_uuid(vgUuid):
-    return bash.bash_o("vgs --nolocking --noheading -ouuid %s" % vgUuid).strip()
+    return bash.bash_o("vgs --nolocking -t --noheading -ouuid %s" % vgUuid).strip()
 
 
 def get_running_host_id(vgUuid):
@@ -687,7 +687,7 @@ def wipe_fs(disks, expected_vg=None, with_lock=True):
     for disk in disks:
         exists_vg = None
 
-        r, o = bash.bash_ro("pvs --nolocking --noheading -o vg_name %s" % disk)
+        r, o = bash.bash_ro("pvs --nolocking -t --noheading -o vg_name %s" % disk)
         if r == 0 and o.strip() != "":
             exists_vg = o.strip()
 
@@ -747,12 +747,12 @@ def get_disk_holders(disk_names):
 @linux.retry(times=5, sleep_time=random.uniform(0.1, 3))
 def add_pv(vg_uuid, disk_path, metadata_size):
     bash.bash_errorout("vgextend --metadatasize %s %s %s" % (metadata_size, vg_uuid, disk_path))
-    if bash.bash_r("pvs --nolocking --readonly %s | grep %s" % (disk_path, vg_uuid)):
+    if bash.bash_r("pvs --nolocking -t --readonly %s | grep %s" % (disk_path, vg_uuid)):
         raise Exception("disk %s not added to vg %s after vgextend" % (disk_path, vg_uuid))
 
 
 def get_vg_size(vgUuid, raise_exception=True):
-    r, o, _ = bash.bash_roe("vgs --nolocking %s --noheadings --separator : --units b -o vg_size,vg_free,vg_lock_type" % vgUuid, errorout=raise_exception)
+    r, o, _ = bash.bash_roe("vgs --nolocking -t %s --noheadings --separator : --units b -o vg_size,vg_free,vg_lock_type" % vgUuid, errorout=raise_exception)
     if r != 0:
         return None, None
     vg_size, vg_free = o.strip().split(':')[0].strip("B"), o.strip().split(':')[1].strip("B")
@@ -778,7 +778,7 @@ def has_lv_tag(path, tag):
     if tag == "":
         logger.debug("check tag is empty, return false")
         return False
-    o = shell.call("lvs -Stags={%s} %s --nolocking --noheadings 2>/dev/null | wc -l" % (tag, path))
+    o = shell.call("lvs -Stags={%s} %s --nolocking -t --noheadings 2>/dev/null | wc -l" % (tag, path))
     return o.strip() == '1'
 
 
@@ -787,7 +787,7 @@ def has_one_lv_tag_sub_string(path, tags):
     if not tags or len(tags) == 0:
         logger.debug("check tag is empty, return false")
         return False
-    exists_tags = set(shell.call("lvs %s -otags --nolocking --noheadings" % path).strip().split(","))
+    exists_tags = set(shell.call("lvs %s -otags --nolocking -t --noheadings" % path).strip().split(","))
     for tag in tags:
         for exists_tag in exists_tags:
             if tag in exists_tag:
@@ -823,7 +823,7 @@ def delete_image(path, tag, deactive=True):
 
 
 def clean_vg_exists_host_tags(vgUuid, hostUuid, tag):
-    cmd = shell.ShellCmd("vgs %s -otags --nolocking --noheading | tr ',' '\n' | grep %s | grep %s" % (vgUuid, tag, hostUuid))
+    cmd = shell.ShellCmd("vgs %s -otags --nolocking -t --noheading | tr ',' '\n' | grep %s | grep %s" % (vgUuid, tag, hostUuid))
     cmd(is_exception=False)
     exists_tags = [x.strip() for x in cmd.stdout.splitlines()]
     if len(exists_tags) == 0:
@@ -907,10 +907,10 @@ def get_thin_pool_from_vg(vgName):
 
 class ThinPool(object):
     def __init__(self, path):
-        o = bash.bash_o("lvs --nolocking %s --separator ' ' -oname,data_percent,lv_size,pool_lv --noheading --unit B" % path).strip()
+        o = bash.bash_o("lvs --nolocking -t %s --separator ' ' -oname,data_percent,lv_size,pool_lv --noheading --unit B" % path).strip()
         self.name = o.split(" ")[0].strip()
         self.total = float(o.split(" ")[2].strip("B"))
-        self.thin_lvs = [l.strip() for l in bash.bash_o("lvs -Spool_lv=%s --noheadings --nolocking -oname" % self.name).strip().splitlines()]
+        self.thin_lvs = [l.strip() for l in bash.bash_o("lvs -Spool_lv=%s --noheadings --nolocking -t -oname" % self.name).strip().splitlines()]
         if len(self.thin_lvs) == 0 and not is_thin_lv(path):
             self.free = self.total
         else:
@@ -921,7 +921,7 @@ class ThinPool(object):
 
 
 def get_thin_pools_from_vg(vgName):
-    names = bash.bash_o("lvs --nolocking %s -Slayout=pool -oname --noheading" % vgName).strip().splitlines()
+    names = bash.bash_o("lvs --nolocking -t %s -Slayout=pool -oname --noheading" % vgName).strip().splitlines()
     if len(names) == 0:
         return []
     return [ThinPool("/dev/%s/%s" % (vgName, n)) for n in names]
@@ -936,7 +936,7 @@ def dd_zero(path):
 def get_lv_size(path):
     if is_thin_lv(path):
         return get_thin_lv_size(path)
-    cmd = shell.ShellCmd("lvs --nolocking --noheading -osize --units b %s" % path)
+    cmd = shell.ShellCmd("lvs --nolocking -t --noheading -osize --units b %s" % path)
     cmd(is_exception=True, logcmd=False)
     return cmd.stdout.strip().strip("B")
 
@@ -947,7 +947,7 @@ def get_thin_lv_size(path):
 
 
 def is_thin_lv(path):
-    return bash.bash_r("lvs --nolocking --noheadings  -olayout %s | grep 'thin,sparse'" % path) == 0
+    return bash.bash_r("lvs --nolocking -t --noheadings  -olayout %s | grep 'thin,sparse'" % path) == 0
 
 
 @bash.in_bash
@@ -1068,26 +1068,26 @@ def remove_device_map_for_vg(vgUuid):
 
 @bash.in_bash
 def lv_exists(path):
-    r = bash.bash_r("lvs --nolocking %s" % path)
+    r = bash.bash_r("lvs --nolocking -t %s" % path)
     return r == 0
 
 
 @bash.in_bash
 def vg_exists(vgUuid):
-    cmd = shell.ShellCmd("vgs --nolocking %s" % (vgUuid))
+    cmd = shell.ShellCmd("vgs --nolocking -t %s" % (vgUuid))
     cmd(is_exception=False)
     return cmd.return_code == 0
 
 
 def lv_uuid(path):
-    cmd = shell.ShellCmd("lvs --nolocking --noheadings %s -ouuid" % path)
+    cmd = shell.ShellCmd("lvs --nolocking -t --noheadings %s -ouuid" % path)
     cmd(is_exception=False)
     return cmd.stdout.strip()
 
 
 def lv_is_active(lv_path):
     # NOTE(weiw): use readonly to get active may return 'unknown'
-    r = bash.bash_r("lvs --nolocking --noheadings %s -oactive | grep -w active" % lv_path)
+    r = bash.bash_r("lvs --nolocking -t --noheadings %s -oactive | grep -w active" % lv_path)
     if r == 0:
         return True
     return os.path.exists(lv_path)
@@ -1118,7 +1118,7 @@ def lv_rename(old_abs_path, new_abs_path, overwrite=False):
 
 
 def list_local_active_lvs(vgUuid):
-    cmd = shell.ShellCmd("lvs --nolocking %s --noheadings -opath -Slv_active=active" % vgUuid)
+    cmd = shell.ShellCmd("lvs --nolocking -t %s --noheadings -opath -Slv_active=active" % vgUuid)
     cmd(is_exception=False)
     result = []
     for i in cmd.stdout.strip().split("\n"):
@@ -1193,7 +1193,7 @@ def create_lvm_snapshot(absolutePath, remove_oldest=True, snapName=None, size_pe
 
 
 def delete_snapshots(lv_path):
-    all_snaps = bash.bash_o("lvs -oname -Sorigin=%s --nolocking --noheadings | grep _snap_" % lv_path.split("/")[-1]).strip().splitlines()
+    all_snaps = bash.bash_o("lvs -oname -Sorigin=%s --nolocking -t --noheadings | grep _snap_" % lv_path.split("/")[-1]).strip().splitlines()
     if len(all_snaps) == 0:
         return
     for snap in all_snaps:
@@ -1204,7 +1204,7 @@ def get_new_snapshot_name(absolutePath, remove_oldest=True):
     @bash.in_bash
     @lock.file_lock(absolutePath)
     def do_get_new_snapshot_name(name):
-        all_snaps = bash.bash_o("lvs -oname -Sorigin=%s --nolocking --noheadings | grep _snap_" % name).strip().splitlines()
+        all_snaps = bash.bash_o("lvs -oname -Sorigin=%s --nolocking -t --noheadings | grep _snap_" % name).strip().splitlines()
         if len(all_snaps) == 0:
             return name + "_snap_1"
         numbers = map(lambda x: int(x.strip().split("_")[-1]), all_snaps)
@@ -1421,7 +1421,7 @@ def fix_global_lock():
 
 
 def check_pv_status(vgUuid, timeout):
-    r, o , e = bash.bash_roe("timeout -s SIGKILL %s pvs --noheading --nolocking -Svg_name=%s -oname,missing" % (timeout, vgUuid))
+    r, o , e = bash.bash_roe("timeout -s SIGKILL %s pvs --noheading --nolocking -t -Svg_name=%s -oname,missing" % (timeout, vgUuid))
     if len(o) == 0 or r != 0:
         s = "can not find shared block in shared block group %s, detail: [return_code: %s, stdout: %s, stderr: %s]" % (vgUuid, r, o, e)
         logger.warn(s)
@@ -1440,7 +1440,7 @@ def check_pv_status(vgUuid, timeout):
     # if r is False:
     #     return r, s
 
-    health = bash.bash_o('timeout -s SIGKILL %s vgs -oattr --nolocking --noheadings --shared %s ' % (10 if timeout < 10 else timeout, vgUuid)).strip()
+    health = bash.bash_o('timeout -s SIGKILL %s vgs -oattr --nolocking -t --noheadings --shared %s ' % (10 if timeout < 10 else timeout, vgUuid)).strip()
     if health == "":
         logger.warn("can not get proper attr of vg, return false")
         return False, "primary storage %s attr get error, expect 'wz--ns' got %s" % (vgUuid, health)
@@ -1618,21 +1618,21 @@ def check_sanlock_status(lockspace):
 @bash.in_bash
 def get_pv_name_by_uuid(pvUuid):
     return bash.bash_o(
-        "timeout -s SIGKILL 10 pvs --noheading --nolocking -oname -Spv_uuid=%s" % pvUuid).strip()
+        "timeout -s SIGKILL 10 pvs --noheading --nolocking -t -oname -Spv_uuid=%s" % pvUuid).strip()
 
 
 @bash.in_bash
 def get_pv_uuid_by_path(pvPath):
     return bash.bash_o(
-        "timeout -s SIGKILL 10 pvs --noheading --nolocking -ouuid %s" % pvPath).strip()
+        "timeout -s SIGKILL 10 pvs --noheading --nolocking -t -ouuid %s" % pvPath).strip()
 
 
 @bash.in_bash
 def check_lv_on_pv_valid(vgUuid, pvUuid, lv_path=None):
     pv_name = bash.bash_o(
-        "timeout -s SIGKILL 10 pvs --noheading --nolocking -oname -Spv_uuid=%s" % pvUuid).strip()
+        "timeout -s SIGKILL 10 pvs --noheading --nolocking -t -oname -Spv_uuid=%s" % pvUuid).strip()
     one_active_lv = lv_path if lv_path is not None else bash.bash_o(
-        "timeout -s SIGKILL 10 lvs --noheading --nolocking -opath,devices,tags " +
+        "timeout -s SIGKILL 10 lvs --noheading --nolocking -t -opath,devices,tags " +
         "-Sactive=active %s | grep %s | grep %s | awk '{print $1}' | head -n1" % (vgUuid, pv_name, VOLUME_TAG)).strip()
     if one_active_lv == "":
         return True
@@ -1646,7 +1646,7 @@ def check_lv_on_pv_valid(vgUuid, pvUuid, lv_path=None):
 def get_invalid_pv_uuids(vgUuid, checkIo = False):
     invalid_pv_uuids = []
     pvs_outs = bash.bash_o(
-        "timeout -s SIGKILL 10 pvs --noheading --nolocking -Svg_name=%s -ouuid,name,missing" % vgUuid).strip().split("\n")
+        "timeout -s SIGKILL 10 pvs --noheading --nolocking -t -Svg_name=%s -ouuid,name,missing" % vgUuid).strip().split("\n")
     if len(pvs_outs) == 0:
         return
     for pvs_out in pvs_outs:
@@ -1678,7 +1678,7 @@ def is_volume_on_pvs(volume_path, pvUuids, includingMissing=True):
         pv_names.append("unknown")
     for f in files:
         o = bash.bash_o(
-            "timeout -s SIGKILL 10 lvs --noheading --nolocking %s -odevices" % f).strip().lower()  # type: str
+            "timeout -s SIGKILL 10 lvs --noheading --nolocking -t %s -odevices" % f).strip().lower()  # type: str
         logger.debug("volume %s is on pv %s" % (volume_path, o))
         if len(filter(lambda n: o.find(n.lower()) > 0, pv_names)) > 0:
             logger.debug("lv %s on pv %s(%s), return true" % (volume_path, pvUuids, pv_names))
@@ -1766,7 +1766,7 @@ def get_running_vm_root_volume_on_pv(vgUuid, pvUuids, checkIo=True):
 
 @bash.in_bash
 def remove_partial_lv_dm(vgUuid):
-    o = bash.bash_o("lvs --noheading --nolocking %s -opath,tags -Slv_health_status=partial | grep %s" % (vgUuid, COMMON_TAG)).strip().splitlines()
+    o = bash.bash_o("lvs --noheading --nolocking -t %s -opath,tags -Slv_health_status=partial | grep %s" % (vgUuid, COMMON_TAG)).strip().splitlines()
     if len(o) == 0:
         return
 

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -307,6 +307,18 @@ def get_lvmlockd_version():
         LVMLOCKD_VERSION = shell.call("""lvmlockd --version | awk '{print $3}' | awk -F'.' '{print $1"."$2}'""").strip()
     return LVMLOCKD_VERSION
 
+def get_sanlock_patch_version():
+    return bash.bash_o("sanlock get_patch_version").strip()
+
+def get_sanlock_pid():
+    return linux.find_process_by_command('sanlock')
+
+def get_running_sanlock_patch_version():
+    pid = get_sanlock_pid()
+    if pid:
+        exe = "/proc/%s/exe" % pid
+        return bash.bash_o("%s get_patch_version" % exe).strip()
+
 def get_running_lvmlockd_version():
     pid = get_lvmlockd_pid()
     if pid:
@@ -571,7 +583,7 @@ def is_lvmlockd_socket_abnormal():
 
 
 @bash.in_bash
-def start_lvmlockd(io_timeout=40):
+def start_lock_service(io_timeout=40):
     if not os.path.exists(os.path.dirname(LVMLOCKD_LOG_FILE_PATH)):
         os.mkdir(os.path.dirname(LVMLOCKD_LOG_FILE_PATH))
 
@@ -580,7 +592,19 @@ def start_lvmlockd(io_timeout=40):
         running_lockd_version = get_running_lvmlockd_version()
         return running_lockd_version is not None and LooseVersion(running_lockd_version) < LooseVersion(get_lvmlockd_version())
 
-    restart_lvmlockd = is_lvmlockd_upgraded() or (LooseVersion(get_lvmlockd_version()) >= LooseVersion("2.03") and is_lvmlockd_socket_abnormal())
+    def is_sanlock_upgraded():
+        running_patch_version = get_running_sanlock_patch_version()
+        local_patch_version = get_sanlock_patch_version()
+        ## patch version N  ->  patch version >N or non-patch version  ->  patch version N
+        return running_patch_version and local_patch_version.isdigit() and \
+            (not running_patch_version.isdigit() or int(local_patch_version) > int(running_patch_version))
+
+
+    restart_sanlock = is_sanlock_upgraded()
+    restart_lvmlockd = restart_sanlock or is_lvmlockd_upgraded() \
+                       or (LooseVersion(get_lvmlockd_version()) >= LooseVersion("2.03") and is_lvmlockd_socket_abnormal())
+    if restart_sanlock:
+        stop_sanlock()
     if restart_lvmlockd:
         stop_lvmlockd()
         write_lvmlockd_adopt_file()
@@ -662,6 +686,13 @@ def stop_lvmlockd():
     pid = get_lvmlockd_pid()
     if pid:
         linux.kill_process(pid)
+
+@bash.in_bash
+def stop_sanlock():
+    pid = get_sanlock_pid()
+    if pid:
+        linux.kill_process(pid)
+        bash.bash_r("timeout 30 systemctl stop sanlock.service")
 
 @bash.in_bash
 def start_vg_lock(vgUuid, retry_times_for_checking_vg_lockspace):

--- a/zstacklib/zstacklib/utils/sanlock.py
+++ b/zstacklib/zstacklib/utils/sanlock.py
@@ -1,0 +1,17 @@
+from zstacklib.utils import bash
+
+@bash.in_bash
+def dd_check_lockspace(path):
+    return bash.bash_r("dd if=%s of=/dev/null bs=1M count=1 iflag=direct" % path)
+
+@bash.in_bash
+def vertify_delta_lease(vg_uuid, host_id):
+    r, o = bash.bash_ro("sanlock direct read_leader -s lvm_%s:%s:/dev/mapper/%s-lvmlock:0" % (vg_uuid, host_id, vg_uuid))
+    if r != 0:
+        raise Exception("detected sanlock metadata corruption at offset %s length 512 on /dev/mapper/%s-lvmlock, the "
+                        "content read is:\n%s\nsuspected storage failure!!!" % (int(host_id)*512-512, vg_uuid, o))
+
+
+@bash.in_bash
+def vertify_paxos_lease(vg_uuid, resource_name, offset):
+    return bash.bash_roe("sanlock client read -r lvm_%s:%s:/dev/mapper/%s-lvmlock:%s" % (vg_uuid, resource_name, vg_uuid, offset))


### PR DESCRIPTION
add -t on lvs,vgs,pvs with nolocking to prevent them from modifying metadata when different metadata is read in different pvs

Resolves: ZSTAC-48376

Change-Id: ecffd96dae1349aa87b611eaeebd37c9

sync from gitlab !4797