### PR TITLE
<fix>[host]: Fix failed to boot after update kernel

### DIFF
--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -1610,6 +1610,13 @@ if __name__ == "__main__":
         upgrade_os_cmd = "export YUM0={};yum --disablerepo=* --enablerepo=zstack-mn,qemu-kvm-ev-mn{} {} update {} -y"
         yum_cmd = yum_cmd + upgrade_os_cmd.format(releasever, ',zstack-experimental-mn' if cmd.enableExpRepo else '', exclude, updates)
 
+        if "kernel" in updates or (cmd.releaseVersion != '' and "kernel" not in exclude):
+            dracut_conf_path = '/etc/dracut.conf.d/no_lvmconf.conf'
+            if not os.path.exists(dracut_conf_path):
+                linux.mkdir(os.path.dirname(dracut_conf_path))
+                with open(dracut_conf_path, 'w') as f:
+                    f.write('lvmconf=no')
+
         rsp = UpdateHostOSRsp()
         if shell.run("which yum") != 0:
             rsp.success = False


### PR DESCRIPTION
The system may go failed if using non-default lvm configuration after
upgrade kernel and generate a new initramfs.
Therefore, append 'lvmconf = no' to dracut configuration files, to make
sure the initramfs always using default lvm configurations.

Resolves: ZSTAC-66544

Change-Id: I6a6a75706f77786a6972747771686a6663696975

sync from gitlab !4820