### PR TITLE
<fix>[sblk]: update sblk default preallocation to none

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -1282,8 +1282,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             if cmd.volumeFormat != 'raw':
                 qcow2_options = self.calc_qcow2_option(self, cmd.kvmHostAddons, False, cmd.provisioning)
                 with lvm.OperateLv(install_abs_path, shared=False, delete_when_exception=True):
-                    discard = 'preallocation=metadata' in qcow2_options and not lvm.is_slow_discard_lv(install_abs_path)
-                    linux.qcow2_create_with_option(install_abs_path, cmd.size, qcow2_options, discard_on_metadata=discard)
+                    linux.qcow2_create_with_option(install_abs_path, cmd.size, qcow2_options, discard_on_metadata=False)
                     linux.qcow2_fill(0, 1048576, install_abs_path)
                     rsp.size = linux.qcow2_virtualsize(install_abs_path)
 


### PR DESCRIPTION
1、update sblk default preallocation to none
2、disable discard on metadata

Resolves/Related: ZSTAC-66340

Change-Id: I636f6570657a65767978646d6d6e7365796e7964


(cherry picked from commit 5ce2a158166dcdbf5d9779dd302423f8004ddcf0)

sync from gitlab !4838