### PR TITLE
<fix>[vm]: fix no backing store vm migration xml format

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -7798,8 +7798,11 @@ class VmPlugin(kvmagent.KvmAgent):
             volume = DomainVolume.from_xmlobject(old_disk)
             if not volume.over_incorrect_driver():
                 return old_disk  # no change
-            volume.dvbs.update_backing_store_type_to_block()
-            block_backing_store = volume.dvbs._origin_xml_obj
+
+            # vm created by ISO image or storage migrated may not have backing store info
+            if volume.dvbs is not None:
+                volume.dvbs.update_backing_store_type_to_block()
+                block_backing_store = volume.dvbs._origin_xml_obj
 
         driver_type = volume.format if volume.format else 'qcow2'
         volume = file_volume_check(volume)


### PR DESCRIPTION
Consider that vm created from ISO image or
storage migrated without keeping its backing
chains only have a empty backing store, so
there is no need to update its driver type

Resolves: ZSTAC-61406
Related: TIC-2826

Change-Id: I74616174787973796b71677166647a756a66656b
Signed-off-by: AlanJager <ye.zou@zstack.io>

sync from gitlab !4847