### PR TITLE
<fix>[zstackbuild]: fix zwatch & store to fit huawei-native

### DIFF
--- a/zstackbuild/projects/zstack-zwatch.xml
+++ b/zstackbuild/projects/zstack-zwatch.xml
@@ -14,6 +14,7 @@
         <checkFile file="${zstackzwatch.source}" />
 
         <exec executable="make" dir="${zstackzwatch.source}" failonerror="true">
+            <env key="GOROOT" value="${zstackzwatch.goroot}" />
             <arg value="clean" />
         </exec>
 


### PR DESCRIPTION
zstack-zwatch workspace check step fails make clean,
zstack-store has no GOPROXY which leads to slow download.

Resolves: ZSTAC-66727

Change-Id: I71727765766a7662746e6a626569647379666175

sync from gitlab !4856