### PR TITLE
<fix>[sblk]: ignore sanlock max_sectors_kb setting

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -522,6 +522,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             lvm.modify_sanlock_config("renewal_read_extend_sec", 24)
             lvm.modify_sanlock_config("debug_renew", 1)
             lvm.modify_sanlock_config("use_watchdog", 0)
+            lvm.modify_sanlock_config("max_sectors_kb", "ignore")
             lvm.modify_sanlock_config("zstack_vglock_timeout", 0)
             lvm.modify_sanlock_config("use_zstack_vglock_timeout", 0)
             lvm.modify_sanlock_config("zstack_vglock_large_delay", 8)

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -593,15 +593,24 @@ def start_lock_service(io_timeout=40):
         running_lockd_version = get_running_lvmlockd_version()
         return running_lockd_version is not None and LooseVersion(running_lockd_version) < LooseVersion(get_lvmlockd_version())
 
-    def is_sanlock_upgraded():
+    def need_restart_sanlock():
         running_patch_version = get_running_sanlock_patch_version()
         local_patch_version = get_sanlock_patch_version()
-        ## patch version N  ->  patch version >N or non-patch version  ->  patch version N
-        return running_patch_version and local_patch_version.isdigit() and \
-            (not running_patch_version.isdigit() or int(local_patch_version) > int(running_patch_version))
+        if not running_patch_version:
+            # sanlock not running
+            return False
+        elif not local_patch_version.isdigit():
+            return False
+        elif not running_patch_version.isdigit() or int(local_patch_version) > int(running_patch_version):
+            # patch version N  ->  patch version >N or other version  ->  patch version N
+            return True
+        if sanlock.SanlockClientStatusParser().get_config("max_sectors_kb_ignore") == "0":
+            logger.debug("need restarting sanlock to reload config")
+            return True
+        return False
 
 
-    restart_sanlock = is_sanlock_upgraded()
+    restart_sanlock = need_restart_sanlock()
     restart_lvmlockd = restart_sanlock or is_lvmlockd_upgraded() \
                        or (LooseVersion(get_lvmlockd_version()) >= LooseVersion("2.03") and is_lvmlockd_socket_abnormal())
     if restart_sanlock:

--- a/zstacklib/zstacklib/utils/sanlock.py
+++ b/zstacklib/zstacklib/utils/sanlock.py
@@ -1,4 +1,162 @@
 from zstacklib.utils import bash
+from zstacklib.utils import log
+from zstacklib.utils import linux
+from string import whitespace
+
+import re
+
+GLLK_BEGIN = 65
+VGLK_BEGIN = 66
+SMALL_ALIGN_SIZE = 1*1024**2
+SECTOR_SIZE_512 = 512
+SECTOR_SIZE_4K = 8*512
+BIG_ALIGN_SIZE = 8*1024**2
+
+
+logger = log.get_logger(__name__)
+
+class SanlockHostStatus(object):
+    def __init__(self, record):
+        lines = record.strip().splitlines()
+        hid, s, ts = lines[0].split()
+        if s != 'timestamp':
+            raise Exception('unexpected sanlock host status: ' + record)
+        self.host_id = int(hid)
+        self.timestamp = int(ts)
+
+        for line in lines[1:]:
+            try:
+                k, v = line.strip().split('=', 2)
+                if k == 'io_timeout': self.io_timeout = int(v)
+                elif k == 'last_check': self.last_check = int(v)
+                elif k == 'last_live': self.last_live = int(v)
+            except ValueError:
+                logger.warn("unexpected sanlock status: %s" % line)
+
+        if not all([self.io_timeout, self.last_check, self.last_live]):
+            raise Exception('unexpected sanlock host status: ' + record)
+
+    def get_timestamp(self):
+        return self.timestamp
+
+    def get_io_timeout(self):
+        return self.io_timeout
+
+    def get_last_check(self):
+        return self.last_check
+
+    def get_last_live(self):
+        return self.last_live
+
+
+class SanlockHostStatusParser(object):
+    def __init__(self, status):
+        self.status = status
+
+    def is_timed_out(self, hostId):
+        r = self.get_record(hostId)
+        if r is None:
+            return None
+
+        return r.get_timestamp() == 0 or r.get_last_check() - r.get_last_live() > 10 * r.get_io_timeout()
+
+    def is_alive(self, hostId):
+        r = self.get_record(hostId)
+        if r is None:
+            return None
+
+        return r.get_timestamp() != 0 and r.get_last_check() - r.get_last_live() < 2 * r.get_io_timeout()
+
+    def get_record(self, hostId):
+        m = re.search(r"^%d\b" % hostId, self.status, re.M)
+        if not m:
+            return None
+
+        substr = self.status[m.end():]
+        m = re.search(r"^\d+\b", substr, re.M)
+        remainder = substr if not m else substr[:m.start()]
+        return SanlockHostStatus(str(hostId) + remainder)
+
+
+class SanlockClientStatus(object):
+    def __init__(self, status_lines):
+        self.lockspace = status_lines[0].split()[1]
+        self.is_adding = ':0 ADD' in status_lines[0]
+
+        for line in status_lines[1:]:
+            try:
+                k, v = line.strip().split('=', 2)
+                if k == 'renewal_last_result': self.renewal_last_result = int(v)
+                elif k == 'renewal_last_attempt': self.renewal_last_attempt = int(v)
+                elif k == 'renewal_last_success': self.renewal_last_success = int(v)
+            except ValueError:
+                logger.warn("unexpected sanlock client status: %s" % line)
+
+    def get_lockspace(self):
+        return self.lockspace
+
+    def get_renewal_last_result(self):
+        return self.renewal_last_result
+
+    def get_renewal_last_attempt(self):
+        return self.renewal_last_attempt
+
+    def get_renewal_last_success(self):
+        return self.renewal_last_success
+
+
+class SanlockClientStatusParser(object):
+    def __init__(self, status=None):
+        self.status = status
+        self.lockspace_records = None  # type: list[SanlockClientStatus]
+
+    def get_lockspace_records(self):
+        if self.lockspace_records is None:
+            self.lockspace_records = self._do_get_lockspace_records()
+        return self.lockspace_records
+
+    def get_lockspace_record(self, needle):
+        for r in self.get_lockspace_records():
+            if needle in r.get_lockspace():
+                return r
+        return None
+
+    @linux.retry(3, 1)
+    def _get_sanlock_status(self):
+        return bash.bash_errorout("sanlock client status -D")
+
+    def _do_get_lockspace_records(self):
+        records = []
+        current_lines = []
+
+        for line in self.status.splitlines():
+            if len(line) == 0:
+                continue
+
+            if line[0] in whitespace and len(current_lines) > 0:
+                current_lines.append(line)
+                continue
+
+            # found new records - check whether to complete last record.
+            if len(current_lines) > 0:
+                records.append(SanlockClientStatus(current_lines))
+                current_lines = []
+
+            if line.startswith("s "):
+                current_lines.append(line)
+
+        if len(current_lines) > 0:
+            records.append(SanlockClientStatus(current_lines))
+
+        return records
+
+    def get_config(self, config_key):
+        if self.status is None:
+            self.status = self._get_sanlock_status()
+        for line in self.status.splitlines():
+            if config_key in line:
+                return line.strip().split("=")[-1]
+
 
 @bash.in_bash
 def dd_check_lockspace(path):


### PR DESCRIPTION
When using multipath, if the value of queue/max_sector_size in lvmlock lv is smaller than that in pv, it will cause multipath failure, so without configuring max_sector_size, we cannot set it to the default value of 1024.

Resolves/Related: ZSTAC-66736

Change-Id: I716e6f687468706d74787267616279626962677b

sync from gitlab !4862