### PR TITLE
<fix>[vm]: fix lv lock not released after internal shutdown of vm

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -11241,13 +11241,12 @@ host side snapshot files chian:
 
         @thread.AsyncThread
         @bash.in_bash
-        def deactivate_volume(event_str, file, vm_uuid):
+        def deactivate_volume(event_str, volume, vm_uuid):
             # type: (str, str, str) -> object
-            volume = file.strip().split("'")[1]
-            syslog.syslog("deactivating volume %s for vm %s" % (file, vm_uuid))
+            syslog.syslog("deactivating volume %s for vm %s" % (volume, vm_uuid))
             lock_type = bash.bash_o("lvs --noheading --nolocking -t %s -ovg_lock_type" % volume).strip()
             if "sanlock" not in lock_type:
-                syslog.syslog("%s has no sanlock, skip to deactive" % file)
+                syslog.syslog("%s has no sanlock, skip to deactive" % volume)
                 return
             try:
                 wait_volume_unused(volume)
@@ -11275,10 +11274,13 @@ host side snapshot files chian:
                 logger.info("expected event for zstack op %s, ignore event %s on vm %s" % (vm_op_judger.op, event_str, vm_uuid))
                 return
 
-            out = bash.bash_o("virsh dumpxml %s | grep \"source file='/dev/\"" % vm_uuid).strip().splitlines()
+            out = bash.bash_o("virsh dumpxml %s" % vm_uuid).strip()
             if len(out) != 0:
-                for file in out:
-                    deactivate_volume(event_str, file, vm_uuid)
+                tree = etree.ElementTree(etree.fromstring(out))
+                for disk in tree.iterfind('devices/disk'):
+                    volume = DomainVolume.from_xmlobject(disk)
+                    if volume.source.startswith("/dev/"):
+                        deactivate_volume(event_str, volume.source, vm_uuid)
 
             out = bash.bash_o('virsh dumpxml %s | grep -E "(active|hidden) file="' % vm_uuid).strip().splitlines()
             if len(out) != 0:


### PR DESCRIPTION
when using qemu6, the description for block type disks changes to "source dev=", which causes the original search for block type disks to fail, as a result, the lock cannot be released

Resolves/Related: ZSTAC-67424

Change-Id: I9971717a7a686f6465646a6466646a7768696e68


(cherry picked from commit e80153df2f9cae0f976c5563b30aecdec094d673)

sync from gitlab !4991