### PR TITLE
<fix>[volume]: support enableing extended l2 entries of qcow2

### DIFF
--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -998,6 +998,13 @@ def get_fmt_from_magic(magic):
         return 'raw'
 
 
+def remove_invalid_opt_if_not_support(opt):
+    if "extended_l2" in opt and not qemu_img.support_extended_l2():
+        pattern = re.compile("\-o\ extended_l2\=\w+ ")
+        opt = re.sub(pattern, " ", opt)
+    return opt
+
+
 def qcow2_clone(src, dst, size=""):
     fmt = get_img_fmt(src)
     shell.check_run('/usr/bin/qemu-img create -F %s -b %s -f qcow2 %s %s' % (fmt, src, dst, size))
@@ -1014,6 +1021,8 @@ def qcow2_clone_with_option(src, dst, opt="", size=""):
     # NOTE(weiw): qcow2 doesn't support specify backing file and preallocation at same time
     pattern = re.compile("\-o\ preallocation\=\w+ ")
     opt = re.sub(pattern, " ", opt)
+
+    opt = remove_invalid_opt_if_not_support(opt)
 
     fmt = get_img_fmt(src)
     shell.check_run('/usr/bin/qemu-img create -F %s %s -b %s -f qcow2 %s %s' % (fmt, opt, src, dst, size))
@@ -1039,8 +1048,10 @@ def qcow2_create_with_cmd(dst, size, cmd=None, discard_on_metadata=True):
         qcow2_create_with_option(dst, size, cmd.kvmHostAddons.qcow2Options, discard_on_metadata)
 
 def qcow2_create_with_option(dst, size, opt="", discard_on_metadata=True):
+    opt = remove_invalid_opt_if_not_support(opt)
+
     shell.check_run('/usr/bin/qemu-img create -f qcow2 %s %s %s' % (opt, dst, size))
-    if 'preallocation=metadata' in opt and discard_on_metadata:
+    if discard_on_metadata and 'preallocation=metadata' in opt and 'extended_l2=on' not in opt:
         qcow2_discard(dst)
     os.chmod(dst, 0o660)
 
@@ -1061,6 +1072,8 @@ def qcow2_create_with_backing_file_and_option(backing_file, dst, opt="", size=""
     # NOTE(weiw): qcow2 doesn't support specify backing file and preallocation at same time
     pattern = re.compile("\-o\ preallocation\=\w+ ")
     opt = re.sub(pattern, " ", opt)
+
+    opt = remove_invalid_opt_if_not_support(opt)
 
     shell.call('/usr/bin/qemu-img create -F %s -f qcow2 %s -b %s %s %s' % (fmt, opt, backing_file, dst, size))
     os.chmod(dst, 0o660)

--- a/zstacklib/zstacklib/utils/qemu_img.py
+++ b/zstacklib/zstacklib/utils/qemu_img.py
@@ -53,5 +53,8 @@ def take_default_backing_fmt_for_convert():
 def resize_backing_before_rebase():
     return LooseVersion(get_release_version()) < LooseVersion("6.2.0-227")
 
+def support_extended_l2():
+    return LooseVersion(get_version()) >= LooseVersion("6.0.0")
+
 
 


### PR DESCRIPTION
support enableing/disabling extended l2 entries of qcow2 for better performance

Resolves: ZSTAC-61808

Change-Id:11A0DB6248E5424D8ABB59D8D55EDE58


(cherry picked from commit ed4fb27c38bc317fca081e9335a5bac72d06b2ba)

sync from gitlab !5050