### PR TITLE
<fix>[volume]: support enableing extended l2 entries of qcow2

### DIFF
--- a/zstacklib/zstacklib/utils/qemu_img.py
+++ b/zstacklib/zstacklib/utils/qemu_img.py
@@ -53,5 +53,8 @@ def take_default_backing_fmt_for_convert():
 def resize_backing_before_rebase():
     return LooseVersion(get_release_version()) < LooseVersion("6.2.0-227")
 
+def support_extended_l2():
+    return LooseVersion(get_version()) >= LooseVersion("6.0.0")
+
 
 


### PR DESCRIPTION
support enableing/disabling extended l2 entries of qcow2 for better performance

Resolves: ZSTAC-61808

Change-Id:11A0DB6248E5424D8ABB59D8D55EDE58

sync from gitlab !5056