### PR TITLE
<fix>[zstackbuild]: use go1.18 version build zsblk

### DIFF
--- a/zstackbuild/projects/zstack-sharedblock.xml
+++ b/zstackbuild/projects/zstack-sharedblock.xml
@@ -15,6 +15,7 @@
         </exec>
 
         <exec executable="make" dir="${zstacksharedblock.source}" failonerror="true">
+            <env key="GOROOT" value="/usr/lib/golang1.18" />
             <arg value="package" />
         </exec>
 


### PR DESCRIPTION
Resolves: ZSTAC-65024

Change-Id: I6661777369747a6f6f6174796d7477786968716c


(cherry picked from commit 5280ca92385a11cbff19b85e53763bbc6e8674a3)

sync from gitlab !5089