### PR TITLE
<fix>[plugin.py]: Change method TaskDaemon._exit() to a non abstract method

### DIFF
--- a/zstacklib/zstacklib/test/plugin/task_plugin1.py
+++ b/zstacklib/zstacklib/test/plugin/task_plugin1.py
@@ -42,6 +42,19 @@ class TaskPlugin1(plugin.Plugin):
         except:
             exception_catched.add(task_name)
 
+        class FakeTaskDaemon2(plugin.TaskDaemon):
+            def __init__(self):
+                super(FakeTaskDaemon2, self).__init__(cmd, task_name)
+                self.percent = 0
+
+            def _get_percent(self):
+                self.percent = self.percent + 1
+
+            def _cancel(self):
+                pass
+        with FakeTaskDaemon2():
+            print "FakeTaskDaemon2"
+
     def start(self):
         pass
 

--- a/zstacklib/zstacklib/utils/plugin.py
+++ b/zstacklib/zstacklib/utils/plugin.py
@@ -135,7 +135,6 @@ class TaskDaemon(object):
         logger.debug('It is going to cancel %s.' % self.task_name)
         self._cancel()
 
-    @abc.abstractmethod
     def _exit(self, exc_type, exc_val, exc_tb):
         # returning true means ignoring exception
         pass


### PR DESCRIPTION
Change method TaskDaemon._exit() to a non abstract method

Resolves: ZSTAC-68898

Change-Id: I6a7370646e767467716d63717962717a686a677a

sync from gitlab !5115