### PR TITLE
<fix>[plugin]: method TaskDaemon.__exit__ cannot be overridden

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -1893,8 +1893,7 @@ class MergeSnapshotDaemon(plugin.TaskDaemon):
                 break
         return expected
 
-    def __exit__(self, exc_type, ex, exc_tb):
-        super(MergeSnapshotDaemon, self).__exit__(exc_type, ex, exc_tb)
+    def _exit(self, exc_type, ex, exc_tb):
         if exc_type is None:
             return
 
@@ -1916,6 +1915,7 @@ class MergeSnapshotDaemon(plugin.TaskDaemon):
             logger.debug("libvirt return live merge snapshot failure, but it succeed actually! "
                          "expected volume[install path: %s] backing file is %s. "
                          "check the vm xml meets expectations" % (self.base, current_backing))
+            return True
         else:
             logger.debug("live merge snapshot failed. expected backing %s, actually backing %s. "
                          "check the vm xml does not meet expectations" % (self.base, current_backing))
@@ -3239,15 +3239,12 @@ class Vm(object):
 
                     @linux.retry(times=10, sleep_time=30)
                     def do_clean_orphan_block_nodes(node):
-                        r, o, err = execute_qmp_command(self.uuid, '{ "execute": "blockdev-del", "arguments": { "node-name": "%s" } }' % node)
-                        if r == 0:
-                            libvirtError = LibvirtError(jsonobject.loads(o.strip()))
-                            if libvirtError.error is not None:
-                                logger.debug("failed to execute blockdev-del, because %s", libvirtError.error_desc)
-                                raise Exception("failed to execute blockdev-del, because %s", libvirtError.error_desc)
-                            logger.debug("delete vm[%s] orphan block node[%s] success" % (self.uuid, node))
+                        _, err = execute_qmp_command(self.uuid, '{ "execute": "blockdev-del", "arguments": { "node-name": "%s" } }' % node)
+                        if err:
+                            logger.debug(err)
+                            raise Exception(err)
                         else:
-                            logger.debug("failed to delete vm[%s] orphan block node[%s], because %s" % (self.uuid, node, str(err)))
+                            logger.debug("delete vm[%s] orphan block node[%s] success" % (self.uuid, node))
 
                     for block_node in orphan_block_nodes:
                         try:
@@ -3963,8 +3960,7 @@ class Vm(object):
                 logger.debug('cancelling vm[uuid:%s] migration' % cmd.vmUuid)
                 vm_block_job_cancel(self.uuid)
 
-            def __exit__(self, exc_type, exc_val, exc_tb):
-                super(MigrateDaemon, self).__exit__(exc_type, exc_val, exc_tb)
+            def _exit(self, exc_type, exc_val, exc_tb):
                 if exc_type == libvirt.libvirtError:
                     err = str(exc_val)
                     logger.warn('unable to migrate vm[uuid:%s] to %s, %s' % (cmd.vmUuid, destUrl, err))
@@ -4053,8 +4049,8 @@ class Vm(object):
 
         # node-name : libvirt-10-format
         pattern = r'libvirt\-[0-9]+\-format'
-        r, o, e = execute_qmp_command(self.uuid, '{ "execute": "query-named-block-nodes" }')
-        if r != 0:
+        block_nodes, err = execute_qmp_command(self.uuid, '{ "execute": "query-named-block-nodes" }')
+        if err:
             logger.warn("query-named-block-nodes failed of vm[uuid: %s]" % self.uuid)
             return True
 
@@ -4069,7 +4065,7 @@ class Vm(object):
             return True
 
         #Deduplicate and verify that both contain the same elements
-        qmp_node_names = list(set(re.findall(pattern, o)))
+        qmp_node_names = list(set(re.findall(pattern, str(block_nodes))))
         qemu_command_node_names = list(set(re.findall(pattern, qemu_command)))
         if dict(Counter(qmp_node_names)) == dict(Counter(qemu_command_node_names)):
             return False
@@ -4639,8 +4635,7 @@ class Vm(object):
                 super(DriveBackupDaemon, self).__init__(task_spec, 'TakeVolumeBackup')
                 self.domain_uuid = domain_uuid
 
-            def __exit__(self, exc_type, exc_val, exc_tb):
-                super(DriveBackupDaemon, self).__exit__(exc_type, exc_val, exc_tb)
+            def _exit(self, exc_type, exc_val, exc_tb):
                 os.unlink(tmp_workspace)
 
             def _cancel(self):
@@ -6333,11 +6328,10 @@ def execute_qmp_command(domain_id, command):
     return qmp.execute_qmp_command(domain_id, command)
 
 def get_vm_blocks(domain_id):
-    r, o, e = execute_qmp_command(domain_id, '{ "execute": "query-block" }')
-    if r != 0:
-        raise kvmagent.KvmError("Failed to query blocks on vm[uuid:{}], libvirt error:{}".format(domain_id, e))
+    blocks, err = execute_qmp_command(domain_id, '{ "execute": "query-block" }')
+    if err:
+        raise kvmagent.KvmError(err)
 
-    blocks = json.loads(o)["return"]
     if not blocks:
         raise kvmagent.KvmError("No blocks found on vm[uuid:{}]".format(domain_id))
 
@@ -6353,11 +6347,10 @@ def get_block_node_name_by_disk_name(domain_id, disk_name):
     return block["inserted"]['node-name']
 
 def get_vm_block_nodes(domain_uuid):
-    r, o, err = execute_qmp_command(domain_uuid, '{ "execute": "query-named-block-nodes" }')
-    if r != 0:
-        raise kvmagent.KvmError("failed to query block nodes on vm[uuid:{}], libvirt error:{}".format(domain_uuid, err))
+    block_nodes, err = execute_qmp_command(domain_uuid, '{ "execute": "query-named-block-nodes" }')
+    if err:
+        raise kvmagent.KvmError(err)
 
-    block_nodes = json.loads(o)["return"]
     if not block_nodes:
         raise kvmagent.KvmError("no block nodes found on vm[uuid:{}]".format(domain_uuid))
 
@@ -6372,13 +6365,11 @@ def get_block_node_name_and_file(domain_id):
 
 
 def get_vm_migration_caps(domain_id, cap_key):
-    r, o, e = execute_qmp_command(domain_id, '{"execute": "query-migrate-capabilities"}')
-    if r != 0:
-        logger.warn("query-migrate-capabilities: %s: %s" % (domain_id, e))
+    caps, err = execute_qmp_command(domain_id, '{"execute": "query-migrate-capabilities"}')
+    if err:
+        logger.warn("query-migrate-capabilities: %s: %s" % (domain_id, err))
         return None
 
-    jobj = jsonobject.loads(o)
-    caps = getattr(jobj, 'return')
     for cap in caps:
         if cap.capability == cap_key:
             return cap.state
@@ -7894,10 +7885,9 @@ class VmPlugin(kvmagent.KvmAgent):
             def _get_detail(self):
                 try:
                     result = jsonobject.JsonObject()
-                    r, o, err = execute_qmp_command(vmUuid, '{"execute":"query-block-jobs"}')
+                    block_jobs, err = execute_qmp_command(vmUuid, '{"execute":"query-block-jobs"}')
                     if err:
                         return
-                    block_jobs = json.loads(o)['return']
 
                     job = next((job for job in block_jobs if job['status'] == 'running'), None)
                     if not job:
@@ -7940,8 +7930,8 @@ class VmPlugin(kvmagent.KvmAgent):
         def _touch_qmp_socket():
             if job_over:
                 return
-            r, o, e = execute_qmp_command(vmUuid, '{ "execute": "query-named-block-nodes" }')
-            if r == 0 and task_spec.newVolume.installPath in o:
+            block_nodes, err = execute_qmp_command(vmUuid, '{ "execute": "query-named-block-nodes" }')
+            if not err and task_spec.newVolume.installPath in str(block_nodes):
                 logger.debug("touch qmp socket for block[diskName: %s, vmUuid: %s] migration" % (disk_name, vmUuid))
                 touchQmpSocketWhenExists(vmUuid)
                 return
@@ -8685,7 +8675,7 @@ host side snapshot files chian:
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = kvmagent.AgentResponse()
         for i in range(0, 6):
-            r, o, err = execute_qmp_command(cmd.vmUuid, '{"execute":"query-block-jobs"}')
+            _, err = execute_qmp_command(cmd.vmUuid, '{"execute":"query-block-jobs"}')
             if err:
                 rsp.success = False
                 rsp.error = "Failed to query block jobs, report error"
@@ -9738,11 +9728,10 @@ host side snapshot files chian:
             if not vm:
                 raise Exception('vm[uuid:%s] not exists, failed' % cmd.vmInstanceUuid)
 
-            r, o, err = execute_qmp_command(cmd.vmInstanceUuid, '{"execute":"query-colo-status"}')
+            colo_status, err = execute_qmp_command(cmd.vmInstanceUuid, '{"execute":"query-colo-status"}')
             if err:
                 raise Exception('Failed to check vm[uuid:%s] colo status by query-colo-status' % cmd.vmInstanceUuid)
 
-            colo_status = json.loads(o)['return']
             mode = colo_status['mode']
             return mode == 'secondary'
 
@@ -9763,13 +9752,12 @@ host side snapshot files chian:
             rsp.state = state
             return jsonobject.dumps(rsp)
 
-        r, o, err = execute_qmp_command(cmd.vmInstanceUuid, '{"execute":"query-colo-status"}')
+        colo_status, err = execute_qmp_command(cmd.vmInstanceUuid, '{"execute":"query-colo-status"}')
         if err:
             rsp.success = False
             rsp.error = "Failed to check vm colo status"
             return jsonobject.dumps(rsp)
 
-        colo_status = json.loads(o)['return']
         rsp.mode = colo_status['mode']
 
         return jsonobject.dumps(rsp)
@@ -9832,12 +9820,12 @@ host side snapshot files chian:
 
         @linux.retry(times=3, sleep_time=0.5)
         def add_nbd_client_to_quorum(alias_name, count):
-            r, stdout, err = execute_qmp_command(cmd.vmInstanceUuid, '{"execute": "x-blockdev-change","arguments":'
+            ret, err = execute_qmp_command(cmd.vmInstanceUuid, '{"execute": "x-blockdev-change","arguments":'
                                                 '{"parent": "%s","node": "replication%s" } }' % (alias_name, count))
 
             if err:
                 return False
-            elif 'does not support adding a child' in stdout:
+            elif 'does not support adding a child' in str(ret):
                 raise RetryException("failed to add child to %s" % alias_name)
             else:
                 return True
@@ -9851,13 +9839,12 @@ host side snapshot files chian:
                                     % (alias_name, cmd.secondaryVmHostIp, cmd.nbdServerPort, count))
                 while True:
                     time.sleep(3)
-                    r, o, err = execute_qmp_command(cmd.vmInstanceUuid, '{"execute":"query-block-jobs"}')
+                    block_jobs, err = execute_qmp_command(cmd.vmInstanceUuid, '{"execute":"query-block-jobs"}')
                     if err:
                         rsp.success = False
                         rsp.error = "Failed to get zs-ft-resync job, report error"
                         return jsonobject.dumps(rsp)
 
-                    block_jobs = json.loads(o)['return']
 
                     job = next((job for job in block_jobs if job['device'] == 'zs-ft-resync'), None)
 
@@ -9877,13 +9864,12 @@ host side snapshot files chian:
 
                 while True:
                     time.sleep(1)
-                    r, o, err = execute_qmp_command(cmd.vmInstanceUuid, '{"execute":"query-block-jobs"}')
+                    block_jobs, err = execute_qmp_command(cmd.vmInstanceUuid, '{"execute":"query-block-jobs"}')
                     if err:
                         rsp.success = False
                         rsp.error = "Failed to query block jobs, report error"
                         return jsonobject.dumps(rsp)
 
-                    block_jobs = json.loads(o)['return']
                     job = next((job for job in block_jobs if job['device'] == 'zs-ft-resync'), None)
                     if job:
                         continue
@@ -9984,14 +9970,13 @@ host side snapshot files chian:
         # wait primary vm migrate job finished
         failure = 0
         while True:
-            r, o, err = execute_qmp_command(cmd.vmInstanceUuid, '{"execute": "query-migrate"}')
+            migrate_info, err = execute_qmp_command(cmd.vmInstanceUuid, '{"execute": "query-migrate"}')
             if err:
                 rsp.success = False
                 rsp.error = "Failed to query migrate info, because %s" % err
                 colo_qemu_object_cleanup()
                 break
 
-            migrate_info = json.loads(o)['return']
             if migrate_info['status'] == 'colo':
                 logger.debug("migrate finished")
                 break
@@ -10054,7 +10039,7 @@ host side snapshot files chian:
         execute_qmp_command(cmd.vmInstanceUuid, '{"execute": "qmp_capabilities"}')
 
         ft.cleanup_vm_before_setup_colo_primary_vm(cmd.vmInstanceUuid)
-        r, o, err = execute_qmp_command(cmd.vmInstanceUuid, '{"execute":"query-chardev"}')
+        char_devices, err = execute_qmp_command(cmd.vmInstanceUuid, '{"execute":"query-chardev"}')
         if err:
             rsp.success = False
             rsp.error = "Failed to check qemu config, report error"
@@ -10066,7 +10051,6 @@ host side snapshot files chian:
 
         is_origin_secondary = 'filter-rewriter' in domain_xml
 
-        char_devices = json.loads(o)['return']
         mirror_device_nums = [int(dev['label'][-1]) for dev in char_devices if dev['label'].startswith('zs-mirror')]
         logger.debug("get mirror char device of vm[uuid:%s] devices: %s" % (cmd.vmInstanceUuid, mirror_device_nums))
         if len(mirror_device_nums) == len(cmd.configs):

--- a/sftpbackupstorage/sftpbackupstorage/sftpbackupstorage.py
+++ b/sftpbackupstorage/sftpbackupstorage/sftpbackupstorage.py
@@ -465,8 +465,7 @@ class SftpBackupStorageAgent(object):
                 def _get_percent(self):
                     return os.stat(install_path).st_size / (total_size / 100) if os.path.exists(install_path) else 0
 
-                def __exit__(self, exc_type, exc_val, exc_tb):
-                    super(SftpDownloadDaemon, self).__exit__(exc_type, exc_val, exc_tb)
+                def _exit(self, exc_type, exc_val, exc_tb):
                     if ssh_pass_file:
                         linux.rm_file_force(ssh_pass_file)
                     if exc_val is not None:

--- a/zstacklib/zstacklib/utils/plugin.py
+++ b/zstacklib/zstacklib/utils/plugin.py
@@ -67,6 +67,8 @@ class TaskDaemon(object):
     '''
 
     def __init__(self, task_spec, task_name, timeout=0):
+        if self.__class__.__name__ != TaskDaemon.__name__ and self.__class__.__dict__.has_key("__exit__"):
+            raise Exception("method __exit__ cannot be overridden")
         self.api_id = get_api_id(task_spec)
         self.task_name = task_name
         self.stage = get_task_stage(task_spec)
@@ -94,6 +96,13 @@ class TaskDaemon(object):
             self.close()
         except:
             pass
+
+        try:
+            return self._exit(exc_type, exc_val, exc_tb)
+        except Exception:
+            if exc_type is not None:
+                raise
+            logger.warning("ignoring an exception when exiting the task daemon:\n%s" % traceback.format_exc())
 
     def start(self):
         if self.api_id:
@@ -135,6 +144,10 @@ class TaskDaemon(object):
     def cancel(self):
         logger.debug('It is going to cancel %s.' % self.task_name)
         self._cancel()
+
+    def _exit(self, exc_type, exc_val, exc_tb):
+        # returning true means ignoring exception
+        pass
 
     @abc.abstractmethod
     def _cancel(self):

--- a/zstacklib/zstacklib/utils/qcow2.py
+++ b/zstacklib/zstacklib/utils/qcow2.py
@@ -19,8 +19,7 @@ def create_template_with_task_daemon(src, dst, task_spec, dst_format='qcow2', op
             self.dst_path = dst_path
             self.__dict__.update(daemonargs)
 
-        def __exit__(self, exc_type, exc_val, exc_tb):
-            super(ConvertTaskDaemon, self).__exit__(exc_type, exc_val, exc_tb)
+        def _exit(self, exc_type, exc_val, exc_tb):
             linux.rm_file_force(p_file)
 
         def _cancel(self):


### PR DESCRIPTION
1、add check for method TaskDaemon.__exit__, it cannot be overridden
2、the newly added _exit method can be overridden

Resolves/Related: ZSTAC-66100

Change-Id: I707a6e78696662796a667973796e776f62786876

sync from gitlab !5130