### PR TITLE
<fix>[zstackbuild]: add arch param to fit huawei-native

### DIFF
--- a/zstackbuild/build.properties
+++ b/zstackbuild/build.properties
@@ -104,16 +104,26 @@ agent.collectd.bin=${agent.source}/target/collectd.bin
 imagestorebackupstorage.source=${zstack_build_root}/zstack-utility/imagestorebackupstorage
 imagestore.source=${zstack_build_root}/zstack-store
 imagestore.bin=${imagestore.source}/target/package/zstore/zstack-store.bin
+imagestore.goroot=/usr/lib/golang1.18/
+imagestore.arch=amd64 arm64 mips64le loong64
 
 vyos.source=${zstack_build_root}/zstack-vyos
+vyos.goroot=/usr/lib/golang1.18
+vyos.arch=amd64 arm64 loong64
 
 zstacknetwork.source=${zstack_build_root}/zstack-network
+zstacknetwork.goroot=/usr/lib/golang
+zstacknetwork.arch=
 zsnansibleplaybook.source=${zstack_build_root}/zstack-utility/zstacknetwork
 
 zstackzwatch.source=${zstack_build_root}/zstack-zwatch
+zstackzwatch.goroot=/usr/lib/golang1.18
+zstackzwatch.arch=amd64 arm64 freebsd_amd64 loong64
 agent.version.generator=${zstack_build_root}/zstack-utility/zstackbuild/scripts/agnet_version_generator_py2.py
 
 zstacksharedblock.source=${zstack_build_root}/zstack-sharedblock
+zstacksharedblock.goroot=/usr/lib/golang1.18
+zstacksharedblock.arch=amd64 arm64 mips64le loong64
 zsblkansibleplaybook.source=${zstack_build_root}/zstack-utility/zstacksharedblock
 
 build.zstack.war.script=${zstackbuild.scripts}/build_zstack_war.sh

--- a/zstackbuild/projects/zstack-network.xml
+++ b/zstackbuild/projects/zstack-network.xml
@@ -11,17 +11,20 @@
         <checkFile file="${zstacknetwork.source}" />
 
         <exec executable="make" dir="${zstacknetwork.source}" failonerror="true">
+            <env key="GOROOT" value="${zstacknetwork.goroot}" />
             <arg value="clean" />
         </exec>
 
         <exec executable="make" dir="${zstacknetwork.source}" failonerror="true">
+            <env key="GOROOT" value="${zstacknetwork.goroot}" />
             <arg value="package" />
         </exec>
 
         <copy todir="${zsn.bdir}/">
             <fileset dir="${zstacknetwork.source}/target/package/zsn-agent">
-                <include name="zsn-agent.bin" />
-                <include name="zsn-agent.aarch64.bin" />
+                <include name="*.bin" />
+                <!-- <include name="zsn-agent.bin" />
+                <include name="zsn-agent.aarch64.bin" /> -->
             </fileset>
         </copy>
     </target>

--- a/zstackbuild/projects/zstack-sharedblock.xml
+++ b/zstackbuild/projects/zstack-sharedblock.xml
@@ -15,8 +15,9 @@
         </exec>
 
         <exec executable="make" dir="${zstacksharedblock.source}" failonerror="true">
+            <env key="GOROOT" value="${zstacksharedblock.goroot}" />
             <arg value="package" />
-            <arg value="ARCH= amd64 arm64 mips64le loong64" />
+            <arg value="ARCH=${zstacksharedblock.arch}" />
         </exec>
 
         <copy todir="${zsblk.bdir}/">

--- a/zstackbuild/projects/zstack-store.xml
+++ b/zstackbuild/projects/zstack-store.xml
@@ -17,9 +17,10 @@
         </exec>
 
         <exec executable="make" dir="${imagestore.source}" failonerror="true">
+            <env key="GOROOT" value="${imagestore.goroot}" />
             <arg value="package" />
-            <arg value="ARCH=amd64 arm64 mips64le loong64" />
-        </exec>
+            <arg value="ARCH=${imagestore.arch}" />
+        </exec> 
 
         <copy todir="${imagestore.bdir}/">
             <fileset dir="${imagestore.source}/target/package">

--- a/zstackbuild/projects/zstack-vyos.xml
+++ b/zstackbuild/projects/zstack-vyos.xml
@@ -17,8 +17,9 @@
         </exec>
 
         <exec executable="make" dir="${vyos.source}" failonerror="true">
+            <env key="GOROOT" value="${vyos.goroot}" />
             <arg value="package" />
-            <arg value="ARCH=amd64 arm64 loong64" />
+            <arg value="ARCH=${vyos.arch}" />
         </exec>
 
         <copy todir="${vyos.bdir}/">

--- a/zstackbuild/projects/zstack-zwatch.xml
+++ b/zstackbuild/projects/zstack-zwatch.xml
@@ -14,12 +14,14 @@
         <checkFile file="${zstackzwatch.source}" />
 
         <exec executable="make" dir="${zstackzwatch.source}" failonerror="true">
+            <env key="GOROOT" value="${zstackzwatch.goroot}" />
             <arg value="clean" />
         </exec>
 
         <exec executable="make" dir="${zstackzwatch.source}" failonerror="true">
+            <env key="GOROOT" value="${zstackzwatch.goroot}" />
             <arg value="all" />
-            <arg value="ARCH=amd64 arm64 freebsd_amd64 loong64" />
+            <arg value="ARCH=${zstackzwatch.arch}" />
         </exec>
         <copy todir="${zsw.bdir}">
             <fileset dir="${zstackzwatch.source}/target/zwatch_bin">


### PR DESCRIPTION
Huawei-native task asks for arm compiling environment, in which
no cross-compile is needed, so arch param is necessary.

Resolves: ZSV-6648

Change-Id: I7276616b6d616b746a7a6373776c7273616b736d


(cherry picked from commit d2e951c2988462d06b85ac4d0852ec82064c8949)

sync from gitlab !5133