### PR TITLE
<fix>[sblk]: fix vgchange invalid param for sanlock

### DIFF
--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -889,6 +889,7 @@ def start_vg_lock(vgUuid, hostId, retry_times_for_checking_vg_lockspace):
             vg_lock_exists(vgUuid)
         except Exception:
             check_lockspace()
+            sanlock.init_gllk_if_need(vgUuid)
             raise
     try:
         vg_lock_exists(vgUuid)


### PR DESCRIPTION
fix vgchange invalid param for sanlock

Resolves: ZSV-6739

Change-Id:C950C4084E6E482ABBAC7EA1587D8AA1


(cherry picked from commit fe7604afa8e658032ab898fa55de876e2592381b)

sync from gitlab !5142