### PR TITLE
<fix>[plugin]: method TaskDaemon.__exit__ cannot be overridden

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -6371,8 +6371,8 @@ def get_vm_migration_caps(domain_id, cap_key):
         return None
 
     for cap in caps:
-        if cap.capability == cap_key:
-            return cap.state
+        if cap["capability"] == cap_key:
+            return cap["state"]
     return None
 
 


### PR DESCRIPTION
1、add check for method TaskDaemon.__exit__, it cannot be overridden
2、the newly added _exit method can be overridden
3、wrap qmp command result

Resolves/Related: ZSTAC-66100

Change-Id: I707a6e78696662796a667973796e776f62786876

sync from gitlab !5163