### PR TITLE
<fix>[vm]: cache vm states during reboot lifecycle

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -2226,6 +2226,32 @@ def get_all_vm_states():
 def get_all_vm_sync_states():
     return get_active_vm_uuids_states()
 
+vm_state_cache = {}
+def get_vm_states_from_cache():
+    return vm_state_cache
+
+def put_vm_state_to_cache(uuid, state):
+    vm_state_cache[uuid] = state
+
+def remove_vm_state_from_cache(uuid):
+    if uuid in vm_state_cache:
+        del vm_state_cache[uuid]
+
+def get_all_vm_states_with_process():
+    states = {}
+
+    # Occasionally, virsh might not be able to list all VM instances with
+    # uri=qemu://system.  To prevend this situation, we double check the
+    # 'rsp.states' agaist QEMU process lists.
+    output = bash.bash_o("ps -ef | grep -P -o '(qemu-kvm|qemu-system).*?-name\s+(guest=)?\K.*?,' | sed 's/.$//'").splitlines()
+    for guest in output:
+        if guest.lower() == "ZStack Management Node VM".lower()\
+                or guest.startswith("guestfs-"):
+            continue
+        states[guest] = Vm.VM_STATE_RUNNING
+
+    return states
+
 def get_running_vms():
     @LibvirtAutoReconnect
     def get_all_ids(conn):
@@ -7604,6 +7630,33 @@ class VmPlugin(kvmagent.KvmAgent):
         for vm in no_qemu_process_running_vms:
             rsp.states[vm] = Vm.VM_STATE_SHUTDOWN
 
+        states_from_qemu_process = get_all_vm_states_with_process()
+        for guest, state in states_from_qemu_process.items():
+            if guest not in rsp.states:
+                logger.warn('guest [%s] not found in virsh list' % guest)
+                rsp.states[guest] = state
+
+        states_from_cache = get_vm_states_from_cache()
+        for guest, state in states_from_cache.items():
+            if guest not in rsp.states:
+                logger.warn('guest [%s] not found in virsh list and qemu process, load from cache' % guest)
+                rsp.states[guest] = state
+
+        libvirt_running_vms = rsp.states.keys()
+        no_qemu_process_running_vms = list(set(libvirt_running_vms).difference(set(states_from_qemu_process.keys())))
+        state_cached_vms = states_from_cache.keys()
+        # if vm cached means kvmagent manually control the sync result, should be used 
+        # as filter.
+        # if vm not have qemu process means libvirt and qemu is inconsistent use filter
+        # to make sure the vm state is correct.
+        # vm meet both the above conditions should be shutdown
+        for vm in no_qemu_process_running_vms:
+            if vm in state_cached_vms:
+                logger.warn('guest [%s] not found in qemu process, but in cache, keep the state' % vm)
+                continue
+
+            rsp.states[vm] = Vm.VM_STATE_SHUTDOWN
+
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror
@@ -11443,6 +11496,9 @@ host side snapshot files chian:
             else:
                 return
 
+            # use vm cache to avoid vmsync get empty vm state
+            # because we known vm will be started after destroy
+            put_vm_state_to_cache(vm_uuid, Vm.VM_STATE_RUNNING)
             try:
                 dom.destroy()
             except:
@@ -11456,6 +11512,8 @@ host side snapshot files chian:
         except:
             content = traceback.format_exc()
             logger.warn(content)
+        finally:
+            remove_vm_state_from_cache(vm_uuid)
 
     # update the boot order of the root volume to 1, rely on the make_volumes() function
     def update_root_volume_boot_order(self, domain_xml):

--- a/kvmagent/kvmagent/test/vm_plugin_testsuite/test_vm_sync.py
+++ b/kvmagent/kvmagent/test/vm_plugin_testsuite/test_vm_sync.py
@@ -3,6 +3,12 @@ from kvmagent.test.utils import vm_utils, network_utils, pytest_utils
 from kvmagent.test.utils.stub import *
 from zstacklib.test.utils import misc
 from unittest import TestCase
+from zstacklib.utils import bash
+from zstacklib.utils import linux
+from zstacklib.utils import jsonobject
+from zstacklib.utils.libvirt_singleton import LibvirtSingleton
+import time
+import mock
 
 init_kvmagent()
 vm_utils.init_vm_plugin()
@@ -33,6 +39,130 @@ class TestVmPlugin(TestCase, vm_utils.VmPluginTestStub):
 
         self._destroy_vm(vm_uuid)
 
+        rsp = vm_utils.vm_sync()
+        states = rsp.states
+        self.assertEqual(0, len(states))
+
+    def hang_virsh(self, cmd, pipe_fail=False):
+        if "virsh" in cmd:
+            return 1, "virsh hang"
+
+        ret, o, _ = bash.bash_roe(cmd, pipe_fail=pipe_fail)
+        return ret, o
+
+    @pytest_utils.ztest_decorater
+    def test_vm_sync_when_virsh_hang(self):
+        vm_uuid, vm = self._create_vm()
+
+        bash.bash_ro = mock.Mock(side_effect=self.hang_virsh)
+
+        r, _ = bash.bash_ro("virsh list")
+        self.assertEqual(1, r)
+
+        rsp = vm_utils.vm_sync()
+        states = rsp.states
+
+        self.assertEqual(1, len(states))
+        self.assertEqual(vm_plugin.Vm.VM_STATE_RUNNING, states[vm_uuid])
+
+        pid = linux.find_vm_pid_by_uuid(vm_uuid)
+        linux.kill_process(pid)
+        rsp = vm_utils.vm_sync()
+        states = rsp.states
+        self.assertEqual(0, len(states))
+
+    @pytest_utils.ztest_decorater
+    @bash.in_bash
+    def test_vm_sync_when_vm_rebooted(self):
+        vm = vm_utils.create_startvm_body_jsonobject()
+        vm.bootDev = "cdrom"
+        vm.rootVolume.bootOrder = None
+
+        linux.qcow2_create("/root/.zguest/cdrom.qcow2", 1 * 1024 * 1024 * 1024)
+        class CdromTO(object):
+            def __init__(self):
+                self.path = "/root/.zguest/cdrom.qcow2"
+                self.deviceId = 0
+                self.bootOrder = 1
+                self.isEmpty = False
+                self.type = None
+
+        vm.cdRoms = [CdromTO()]
+
+        vm_utils.create_vm(vm)
+        vm_uuid = vm.vmInstanceUuid
+
+        rsp = vm_utils.vm_sync()
+        states = rsp.states
+
+        self.assertEqual(1, len(states))
+        self.assertEqual(vm_plugin.Vm.VM_STATE_RUNNING, states[vm_uuid])
+
+        # mock put_vm_state_to_cache to check its called
+        with mock.patch.object(vm_plugin, 'get_vm_states_from_cache') as get_vm_states_from_cache:
+            rsp = vm_utils.vm_sync()
+            states = rsp.states
+            self.assertEqual(1, len(states))
+            get_vm_states_from_cache.assert_called_once()
+
+        with mock.patch.object(vm_plugin, 'put_vm_state_to_cache') as put_vm_state_to_cache:
+            libvirt_singleton = LibvirtSingleton()
+            conn = libvirt_singleton.conn
+            domain = conn.lookupByName(vm_uuid)
+            vm_utils.VM_PLUGIN.config[kvmagent.SEND_COMMAND_URL] = "http://localhost:7070"
+            vm_utils.VM_PLUGIN._vm_reboot_event(conn, domain, None)
+
+            # wait for put_vm_state_to_cache called
+            for i in range(0, 10):
+                try:
+                    put_vm_state_to_cache.assert_called_once()
+                except AssertionError:
+                    time.sleep(1)
+                    continue
+
+                if put_vm_state_to_cache.call_args[0][1] == vm_plugin.Vm.VM_STATE_RUNNING:
+                    break
+
+            rsp = vm_utils.vm_sync()
+            states = rsp.states
+            self.assertEqual(1, len(states))
+            put_vm_state_to_cache.assert_called_once()
+
+        vm_utils.destroy_vm(vm_uuid)
+        # recreate to let vm boot from cdrom again
+        vm_utils.create_vm(vm)
+        with mock.patch.object(vm_plugin, 'remove_vm_state_from_cache') as remove_vm_state_from_cache:
+            libvirt_singleton = LibvirtSingleton()
+            conn = libvirt_singleton.conn
+            domain = conn.lookupByName(vm_uuid)
+            vm_utils.VM_PLUGIN.config[kvmagent.SEND_COMMAND_URL] = "http://localhost:7070"
+            vm_utils.VM_PLUGIN._vm_reboot_event(conn, domain, None)
+
+            # wait for remove_vm_state_from_cache called
+            for i in range(0, 10):
+                try:
+                    remove_vm_state_from_cache.assert_called_once()
+                except AssertionError:
+                    time.sleep(1)
+                    continue
+
+                if remove_vm_state_from_cache.call_args[0] == vm_uuid:
+                    break
+
+            rsp = vm_utils.vm_sync()
+            states = rsp.states
+            self.assertEqual(1, len(states))
+            remove_vm_state_from_cache.assert_called_once()
+
+        vm_plugin.put_vm_state_to_cache(vm_uuid, vm_plugin.Vm.VM_STATE_RUNNING)
+        vm_utils.destroy_vm(vm_uuid)
+
+        rsp = vm_utils.vm_sync()
+        states = rsp.states
+        self.assertEqual(1, len(states))
+        self.assertEqual(vm_plugin.Vm.VM_STATE_RUNNING, states[vm_uuid])
+
+        vm_plugin.remove_vm_state_from_cache(vm_uuid)
         rsp = vm_utils.vm_sync()
         states = rsp.states
         self.assertEqual(0, len(states))


### PR DESCRIPTION
Whlie vm reboot inside, libvirt will fire a reboot event.And if the vm
is set to boot from cdrom before, kvmagent will change its  boot order
from cdrom to disk (to make sure the guest won't boot from cdrom again
after install from iso) and the code just destroy the domain and create
the domain again with changed xml

There will be a race condition that vm sync may not get vm's state
during the period that destroy vm but not start. And which we think
should be really quick.

Do not involve control plane because destroy and start is done by
kvmagent itself, just add a vm state cache to help the reboot hook keep
vm's state as running during the reboot lifecycle.

Tests: test_vm_sync.py test reboot lifecycle hook and vm_sync request

Resolves: ZSTAC-67098

Change-Id: I75647a6971626a72617966656466667067706f6a
Signed-off-by: AlanJager <ye.zou@zstack.io>
(cherry picked from commit 608be14126f591ba3a42546ac83b4a758ffaf44d)
(cherry picked from commit 403bcf2033f3da7925947755023728138f6c4684)

sync from gitlab !5178