### PR TITLE
<fix>[zstackctl]: fix typo when stop keepalived before restart mariadb

### DIFF
--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -178,7 +178,7 @@ if [ $? -ne 0 ]; then
     sed -i "/\[mysqld\]/a tmpdir=$mysql_tmp_path" $mysql_conf
 fi
 
-([ x`systemctl is-enabled zstack-ha 2>/dev/null` == x"enabled" ] && { systemctl start keepalived.service || true; }) || true
+([ x`systemctl is-enabled zstack-ha 2>/dev/null` == x"enabled" ] && { systemctl stop keepalived.service || true; }) || true
 
 if [ `systemctl is-active mariadb` != "unknown" ]; then 
     systemctl restart mariadb


### PR DESCRIPTION
Resolves: ZSTAC-69511

Change-Id: I63766472736e71706264676f777268736b686c68

sync from gitlab !5184