### PR TITLE
<fix>[zstacklib]: bypass execution policy when qga executes powershell

### DIFF
--- a/zstacklib/zstacklib/utils/qga.py
+++ b/zstacklib/zstacklib/utils/qga.py
@@ -349,7 +349,7 @@ class VmQga(object):
         cmd = "& '{}'".format("' '".join([part for part in cmd_parts]))
 
         ret = self.guest_exec(
-            {"path": "powershell.exe", "arg": ["-Command", cmd], "capture-output": output})
+            {"path": "powershell.exe", "arg": ["-ExecutionPolicy", "Bypass", "-Command", cmd], "capture-output": output})
         if ret and "pid" in ret:
             pid = ret["pid"]
         else:


### PR DESCRIPTION
Resolves: ZSV-5868

Change-Id: I63686a616f64647462627976656668656b757677

sync from gitlab !5242