### PR TITLE
<fix>[sblk]: add timeout for lvm command with locking

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -618,11 +618,12 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         def config_lvm(host_id, enableLvmetad=False):
             lvm.backup_lvm_config()
             config = lvm.get_lvm_default_config()
+            lvmlockd_lock_retries = 6
             config.modify({
                 "use_lvmlockd": 1,
                 "host_id": host_id,
                 "sanlock_lv_extend": DEFAULT_SANLOCK_LV_SIZE,
-                "lvmlockd_lock_retries": 6,
+                "lvmlockd_lock_retries": lvmlockd_lock_retries,
                 "issue_discards": 0,
                 "reserved_stack": 256,
                 "reserved_memory": 131072,
@@ -642,7 +643,10 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
                 linux.write_file(lvm.LVM_CONFIG_FILE, new_config, create_if_not_exist=True)
                 linux.write_file(lvm.LVM_LOCAL_CONFIG_FILE, new_config, create_if_not_exist=True)
                 logger.debug("lvm config has changed:\n %s" % '\n'.join(diff))
+                lvm.report_config_changed()
 
+            # max lock retries times = (external lvmlockd_lock_retries + 1) * (internal lock_retries + 1 after a lock conflict)
+            lvm.lvm_cmd_timeout_with_locking = ((lvmlockd_lock_retries + 1) * 6) * 5
             lvm.modify_sanlock_config("sh_retries", 20)
             lvm.modify_sanlock_config("logfile_priority", 7)
             lvm.modify_sanlock_config("renewal_read_extend_sec", 24)

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -55,6 +55,13 @@ thinProvisioningInitializeSize = "thinProvisioningInitializeSize"
 PV_DISCARD_MIN_SIZE_IN_BYTES = 1*1024**3
 ONE_HOUR_IN_SEC = 60 * 60
 LV_UUID_REFRESH_INTERVAL_IN_SEC = 60 * 30
+LVM_CONFIG_CHANGED_FILE = "/var/run/zstack/lvmConfigChanged"
+'''
+If the lvm command with locking is hung, it will always occupy the lock and cannot be released.
+And in scenarios where storage IO is slow and lock contention occurs, it may take longer to execute, 
+so we need to set a timeout that can tolerate this scenario.
+'''
+lvm_cmd_timeout_with_locking = 210
 
 lv_offset = TTLCache(maxsize=100, ttl=ONE_HOUR_IN_SEC)
 continue_lockspace_track = {}  # type: dict[str, bool]
@@ -657,7 +664,7 @@ def config_lvm_filter(files, no_drbd=False, preserve_disks=None):
         return
 
     filter_str = 'filter=["r|\\/dev\\/cdrom|"'
-    vgs = bash.bash_o("vgs --nolocking -t -oname --noheading").splitlines()
+    vgs = bash.bash_o("%s -oname --noheading" % subcmd("vgs")).splitlines()
     for vg in vgs:
         filter_str += ', "r\\/dev\\/mapper\\/%s.*\\/"' % vg.strip()
     if no_drbd:
@@ -970,7 +977,7 @@ def start_vg_lock(vgUuid, hostId, retry_times_for_checking_vg_lockspace):
 @bash.in_bash
 def check_missing_pv(vgUuid):
     pvs_outs = bash.bash_o(
-        "timeout -s SIGKILL 10 pvs --noheading --nolocking -t -Svg_name=%s -ouuid,name,missing" % vgUuid).strip().splitlines()
+        "timeout -s SIGKILL 10 %s --noheading -Svg_name=%s -ouuid,name,missing" % (subcmd("pvs"), vgUuid)).strip().splitlines()
     if len(pvs_outs) == 0:
         return
 
@@ -1040,7 +1047,7 @@ def drop_vg_lock(vgUuid):
 
 @bash.in_bash
 def get_vg_lvm_uuid(vgUuid):
-    return bash.bash_o("vgs --nolocking -t --noheading -ouuid %s" % vgUuid).strip()
+    return bash.bash_o("%s --noheading -ouuid %s" % (subcmd("vgs"), vgUuid)).strip()
 
 
 def get_running_host_id(vgUuid):
@@ -1078,7 +1085,7 @@ def wipe_fs(disks, expected_vg=None, with_lock=True):
     for disk in disks:
         exists_vg = None
 
-        r, o = bash.bash_ro("pvs --nolocking -t --noheading -o vg_name %s" % disk)
+        r, o = bash.bash_ro("%s --noheading -o vg_name %s" % (subcmd("pvs"), disk))
         if r == 0 and o.strip() != "":
             exists_vg = o.strip()
 
@@ -1162,12 +1169,12 @@ def get_disk_holders(disk_names):
 @linux.retry(times=5, sleep_time=random.uniform(0.1, 3))
 def add_pv(vg_uuid, disk_path, metadata_size):
     bash.bash_errorout("vgextend --metadatasize %s %s %s" % (metadata_size, vg_uuid, disk_path))
-    if bash.bash_r("pvs --nolocking -t --readonly %s | grep %s" % (disk_path, vg_uuid)):
+    if bash.bash_r("%s --readonly %s | grep %s" % (subcmd("pvs"), disk_path, vg_uuid)):
         raise Exception("disk %s not added to vg %s after vgextend" % (disk_path, vg_uuid))
 
 
 def get_vg_size(vgUuid, raise_exception=True):
-    r, o, _ = bash.bash_roe("vgs --nolocking -t %s --noheadings --separator : --units b -o vg_size,vg_free,vg_lock_type" % vgUuid, errorout=raise_exception)
+    r, o, _ = bash.bash_roe("%s %s --noheadings --separator : --units b -o vg_size,vg_free,vg_lock_type" % (subcmd("vgs"), vgUuid), errorout=raise_exception)
     if r != 0:
         return None, None
     vg_size, vg_free = o.strip().split(':')[0].strip("B"), o.strip().split(':')[1].strip("B")
@@ -1187,7 +1194,7 @@ def get_all_vg_size():
     # type: () -> dict[str, tuple[int, int]]
     d = {}
 
-    o = bash.bash_o("vgs --nolocking -t %s --noheadings --separator : --units b -o name,vg_size,vg_free,vg_lock_type")
+    o = bash.bash_o("%s %s --noheadings --separator : --units b -o name,vg_size,vg_free,vg_lock_type" % (subcmd("vgs")))
     if not o:
         return d
 
@@ -1223,7 +1230,7 @@ def has_lv_tag(path, tag):
     if tag == "":
         logger.debug("check tag is empty, return false")
         return False
-    o = shell.call("lvs -Stags={%s} %s --nolocking -t --noheadings 2>/dev/null | wc -l" % (tag, path))
+    o = shell.call("%s -Stags={%s} %s --noheadings 2>/dev/null | wc -l" % (subcmd("lvs"), tag, path))
     return o.strip() == '1'
 
 
@@ -1232,7 +1239,7 @@ def has_one_lv_tag_sub_string(path, tags):
     if not tags or len(tags) == 0:
         logger.debug("check tag is empty, return false")
         return False
-    exists_tags = set(shell.call("lvs %s -otags --nolocking -t --noheadings" % path).strip().split(","))
+    exists_tags = set(shell.call("%s %s -otags --noheadings" % (subcmd("lvs"), path)).strip().split(","))
     for tag in tags:
         for exists_tag in exists_tags:
             if tag in exists_tag:
@@ -1242,12 +1249,12 @@ def has_one_lv_tag_sub_string(path, tags):
 
 def clean_lv_tag(path, tag):
     if has_lv_tag(path, tag):
-        shell.run('lvchange --deltag %s %s' % (tag, path))
+        shell.run('%s --deltag %s %s' % (subcmd("lvchange"), tag, path))
 
 
 def add_lv_tag(path, tag):
     if not has_lv_tag(path, tag):
-        shell.run('lvchange --addtag %s %s' % (tag, path))
+        shell.run('%s --addtag %s %s' % (subcmd("lvchange"), tag, path))
 
 
 def get_meta_lv_path(path):
@@ -1259,7 +1266,7 @@ def delete_image(path, tag, deactive=True):
         if deactive:
             _active_lv(f, shared=False)
         backing = linux.qcow2_get_backing_file(f)
-        shell.check_run("lvremove -y -Stags={%s} %s" % (tag, f))
+        shell.check_run("%s -y -Stags={%s} %s" % (subcmd("lvremove"), tag, f))
         return backing
 
     fpath = path
@@ -1268,7 +1275,7 @@ def delete_image(path, tag, deactive=True):
 
 
 def clean_vg_exists_host_tags(vgUuid, hostUuid, tag):
-    cmd = shell.ShellCmd("vgs %s -otags --nolocking -t --noheading | tr ',' '\n' | grep %s | grep %s" % (vgUuid, tag, hostUuid))
+    cmd = shell.ShellCmd("%s %s -otags --noheading | tr ',' '\n' | grep %s | grep %s" % (subcmd("vgs"), vgUuid, tag, hostUuid))
     cmd(is_exception=False)
     exists_tags = [x.strip() for x in cmd.stdout.splitlines()]
     if len(exists_tags) == 0:
@@ -1300,8 +1307,8 @@ def create_lv_from_absolute_path(path, size, tag="zs::sharedblock::volume", lock
 
     exact_size |= tag == IMAGE_TAG
     size = round_to(int(size), 512) if exact_size else round_to(calcLvReservedSize(size), 512)
-    r, o, e = bash.bash_roe("lvcreate -ay --wipesignatures y -y --addtag %s --size %sb --name %s %s %s" %
-                         (tag, size, lvName, vgName, pe_range))
+    r, o, e = bash.bash_roe("%s -ay --wipesignatures y -y --addtag %s --size %sb --name %s %s %s" %
+                         (subcmd("lvcreate"), tag, size, lvName, vgName, pe_range))
 
     if not lv_exists(path):
         raise Exception("can not find lv %s after create, lvcreate return: %s, %s, %s" % (path, r, o, e))
@@ -1347,8 +1354,8 @@ def create_thin_lv_from_absolute_path(path, size, tag, lock=False):
     thin_pool = get_thin_pool_from_vg(vgName)
     assert thin_pool != ""
 
-    r, o, e = bash.bash_roe("lvcreate --wipesignatures y -y --addtag %s -n %s -V %sb --thinpool %s %s" %
-                  (tag, lvName, round_to(calcLvReservedSize(size), 512), thin_pool, vgName))
+    r, o, e = bash.bash_roe("%s --wipesignatures y -y --addtag %s -n %s -V %sb --thinpool %s %s" %
+                  (subcmd("lvcreate"), tag, lvName, round_to(calcLvReservedSize(size), 512), thin_pool, vgName))
     if not lv_exists(path):
         raise Exception("can not find lv %s after create, lvcreate return : %s, %s, %s" %
                         (path, r, o, e))
@@ -1373,10 +1380,10 @@ def get_thin_pool_from_vg(vgName):
 
 class ThinPool(object):
     def __init__(self, path):
-        o = bash.bash_o("lvs --nolocking -t %s --separator ' ' -oname,data_percent,lv_size,pool_lv --noheading --unit B" % path).strip()
+        o = bash.bash_o("%s %s --separator ' ' -oname,data_percent,lv_size,pool_lv --noheading --unit B" % (subcmd("lvs"), path)).strip()
         self.name = o.split(" ")[0].strip()
         self.total = float(o.split(" ")[2].strip("B"))
-        self.thin_lvs = [l.strip() for l in bash.bash_o("lvs -Spool_lv=%s --noheadings --nolocking -t -oname" % self.name).strip().splitlines()]
+        self.thin_lvs = [l.strip() for l in bash.bash_o("%s -Spool_lv=%s --noheadings -oname" % (subcmd("lvs"), self.name)).strip().splitlines()]
         if len(self.thin_lvs) == 0 and not is_thin_lv(path):
             self.free = self.total
         else:
@@ -1387,7 +1394,7 @@ class ThinPool(object):
 
 
 def get_thin_pools_from_vg(vgName):
-    names = bash.bash_o("lvs --nolocking -t %s -Slayout=pool -oname --noheading" % vgName).strip().splitlines()
+    names = bash.bash_o("%s %s -Slayout=pool -oname --noheading" % (subcmd("lvs"), vgName)).strip().splitlines()
     if len(names) == 0:
         return []
     return [ThinPool("/dev/%s/%s" % (vgName, n)) for n in names]
@@ -1402,7 +1409,7 @@ def dd_zero(path):
 def get_lv_size(path):
     if is_thin_lv(path):
         return get_thin_lv_size(path)
-    cmd = shell.ShellCmd("lvs --nolocking -t --noheading -osize --units b %s" % path)
+    cmd = shell.ShellCmd("%s --noheading -osize --units b %s" % (subcmd("lvs"), path))
     cmd(is_exception=True, logcmd=False)
     return cmd.stdout.strip().strip("B")
 
@@ -1413,13 +1420,13 @@ def get_thin_lv_size(path):
 
 
 def is_thin_lv(path):
-    return bash.bash_r("lvs --nolocking -t --noheadings  -olayout %s | grep 'thin,sparse'" % path) == 0
+    return bash.bash_r("%s --noheadings  -olayout %s | grep 'thin,sparse'" % (subcmd("lvs"), path)) == 0
 
 
 @bash.in_bash
 def resize_lv(path, size, force=False):
     _force = "" if force is False else " --force "
-    r, o, e = bash.bash_roe("lvresize %s --size %sb %s" % (_force, calcLvReservedSize(size), path))
+    r, o, e = bash.bash_roe("%s %s --size %sb %s" % (subcmd("lvresize"), _force, calcLvReservedSize(size), path))
     if r == 0:
         logger.debug("successfully resize lv %s size to %s" % (path, size))
         return
@@ -1438,7 +1445,7 @@ def extend_lv(path, extend_size, skip_if_sufficient=False):
     if skip_if_sufficient and int(get_lv_size(path)) >= final_size:
         return
 
-    r, o, e = bash.bash_roe("lvextend --size %sb %s" % (final_size, path))
+    r, o, e = bash.bash_roe("%s --size %sb %s" % (subcmd("lvextend"), final_size, path))
     if r == 0:
         logger.debug("successfully extend lv %s size to %s" % (path, extend_size))
         return
@@ -1551,7 +1558,7 @@ def deactive_lv(path, raise_exception=True):
 def _active_lv(path, shared=False):
     @linux.retry(times=10, sleep_time=random.uniform(0.1, 3))
     def active():
-        bash.bash_errorout("lvchange %s %s" % (flag, path))
+        bash.bash_errorout("%s %s %s" % (subcmd("lvchange"), flag, path))
         if lv_is_active(path) is False:
             raise Exception("active lv %s with %s failed" % (path, flag))
 
@@ -1564,7 +1571,7 @@ def _active_lv(path, shared=False):
 
     # if lv does not have a lock, we will try to reactivate it
     if os.path.exists(path) and lv_lock_not_exists():
-        bash.bash_r("lvchange -an %s" % path)
+        bash.bash_r("%s -an %s" % (subcmd("lvchange"), path))
 
     active()
 
@@ -1581,9 +1588,9 @@ def _deactive_lv(path, raise_exception=True):
         r = 0
         e = None
         if raise_exception:
-            o = bash.bash_errorout("lvchange -an %s" % path)
+            o = bash.bash_errorout("%s -an %s" % (subcmd("lvchange"), path))
         else:
-            r, o, e = bash.bash_roe("lvchange -an %s" % path)
+            r, o, e = bash.bash_roe("%s -an %s" % (subcmd("lvchange"), path))
         if lv_is_active(path):
             raise RetryException("lv %s is still active after lvchange -an, returns code: %s, stdout: %s, stderr: %s"
                                  % (path, r, o, e))
@@ -1609,13 +1616,14 @@ def delete_lv(path, raise_exception=True, deactive=True, discard=LvDiscardStrate
         _deactive_lv(path, False)
     # remove meta-lv if any
     if lv_exists(get_meta_lv_path(path)):
-        shell.run("lvremove -y %s" % get_meta_lv_path(path))
+        shell.run("%s -y %s" % (subcmd("lvremove"), get_meta_lv_path(path)))
     if not lv_exists(path):
         return
     if raise_exception:
-        o = bash.bash_errorout("lvremove -y %s %s" % (path, get_lv_discard_options(path, discard)))
+        o = bash.bash_errorout("%s -y %s %s" % (subcmd("lvremove"), path, get_lv_discard_options(path, discard)))
     else:
-        o = bash.bash_o("lvremove -y %s %s " % (path, get_lv_discard_options(path, discard)))
+        o = bash.bash_o("%s -y %s %s " % (subcmd("lvremove"), path, get_lv_discard_options(path, discard)))
+
     return o
 
 
@@ -1626,9 +1634,9 @@ def delete_lv_meta(path, raise_exception=True):
     if not lv_exists(meta_path):
         return
     if raise_exception:
-        o = bash.bash_errorout("lvremove -y %s" % meta_path)
+        o = bash.bash_errorout("%s -y %s" % (subcmd("lvremove"), meta_path))
     else:
-        o = bash.bash_o("lvremove -y %s" % meta_path)
+        o = bash.bash_o("%s -y %s" % (subcmd("lvremove"), meta_path))
     return o
 
 
@@ -1643,13 +1651,13 @@ def remove_device_map_for_vg(vgUuid):
 
 @bash.in_bash
 def lv_exists(path):
-    r = bash.bash_r("lvs --nolocking -t %s" % path)
+    r = bash.bash_r("%s %s" % (subcmd("lvs"), path))
     return r == 0
 
 
 @bash.in_bash
 def vg_exists(vgUuid):
-    cmd = shell.ShellCmd("vgs --nolocking -t %s" % vgUuid)
+    cmd = shell.ShellCmd("%s %s" % (subcmd("vgs"), vgUuid))
     cmd(is_exception=False)
     return cmd.return_code == 0
 
@@ -1660,7 +1668,7 @@ def refresh_lv_uuid_cache_if_need():
         return
 
     lv_uuid_cache.clear()
-    cmd = shell.ShellCmd("lvs -olv_path,uuid,lv_tags --nolocking -t --noheading | grep %s" % COMMON_TAG)
+    cmd = shell.ShellCmd("%s -olv_path,uuid,lv_tags --noheading | grep %s" % (subcmd("lvs"), COMMON_TAG))
     cmd(is_exception=False)
     if cmd.return_code != 0:
         logger.debug("refresh lv uuid cache error: %s" % cmd.stderr)
@@ -1674,7 +1682,7 @@ def refresh_lv_uuid_cache_if_need():
 
 
 def lv_uuid(path):
-    cmd = shell.ShellCmd("lvs --nolocking -t --noheadings %s -ouuid" % path)
+    cmd = shell.ShellCmd("%s --noheadings %s -ouuid" % (subcmd("lvs"), path))
     cmd(is_exception=False)
     uuid = cmd.stdout.strip()
     if cmd.return_code == 0 and uuid != '':
@@ -1683,14 +1691,14 @@ def lv_uuid(path):
 
 def lv_is_active(lv_path):
     # NOTE(weiw): use readonly to get active may return 'unknown'
-    r = bash.bash_r("lvs --nolocking -t --noheadings %s -oactive | grep -w active" % lv_path)
+    r = bash.bash_r("%s --noheadings %s -oactive | grep -w active" % (subcmd("lvs"), lv_path))
     if r == 0:
         return True
     return os.path.exists(lv_path)
 
 
 def get_lv_attr(lv_path, *attr):
-    o = bash.bash_o("lvs --nolocking -t --noheadings %s -o%s --reportformat json" % (lv_path, ",".join(attr)))
+    o = bash.bash_o("%s --noheadings %s -o%s --reportformat json" % (subcmd("lvs"), lv_path, ",".join(attr)))
     o = simplejson.loads(o)
     return o["report"][0]["lv"][0]
 
@@ -1698,7 +1706,7 @@ def get_lv_attr(lv_path, *attr):
 @bash.in_bash
 def lv_rename(old_abs_path, new_abs_path, overwrite=False):
     if not lv_exists(new_abs_path):
-        return bash.bash_roe("lvrename %s %s" % (old_abs_path, new_abs_path))
+        return bash.bash_roe("%s %s %s" % (subcmd("lvrename"), old_abs_path, new_abs_path))
 
     if overwrite is False:
         raise Exception("lv with name %s is already exists, can not rename lv %s to it" %
@@ -1712,7 +1720,7 @@ def lv_rename(old_abs_path, new_abs_path, overwrite=False):
 
     r, o, e = lv_rename(old_abs_path, new_abs_path)
     if r != 0:
-        bash.bash_errorout("lvrename %s %s" % (tmp_path, new_abs_path))
+        bash.bash_errorout("%s %s %s" % (subcmd("lvrename"), tmp_path, new_abs_path))
         raise Exception("rename lv %s to tmp name %s failed: stdout: %s, stderr: %s" %
                         (old_abs_path, new_abs_path, o, e))
 
@@ -1720,7 +1728,7 @@ def lv_rename(old_abs_path, new_abs_path, overwrite=False):
 
 
 def list_local_active_lvs(vgUuid):
-    cmd = shell.ShellCmd("lvs --nolocking -t %s --noheadings -opath -Slv_active=active" % vgUuid)
+    cmd = shell.ShellCmd("%s %s --noheadings -opath -Slv_active=active" % (subcmd("lvs"), vgUuid))
     cmd(is_exception=False)
     result = []
     for i in cmd.stdout.strip().split("\n"):
@@ -1790,12 +1798,12 @@ def create_lvm_snapshot(absolutePath, remove_oldest=True, snapName=None, size_pe
     bash.bash_errorout("blockdev --flushbufs %s; lvcreate --snapshot -n %s %s %s" % (absolutePath, snapName, absolutePath, size_command))
     path = "/".join(absolutePath.split("/")[:-1]) + "/" + snapName
     if size_command == "":
-        bash.bash_r("lvchange -ay -K %s" % path)
+        bash.bash_r("%s -ay -K %s" % (subcmd("lvchange"), path))
     return path
 
 
 def delete_snapshots(lv_path):
-    all_snaps = bash.bash_o("lvs -oname -Sorigin=%s --nolocking -t --noheadings | grep _snap_" % lv_path.split("/")[-1]).strip().splitlines()
+    all_snaps = bash.bash_o("%s -oname -Sorigin=%s --noheadings | grep _snap_" % (subcmd("lvs"), lv_path.split("/")[-1])).strip().splitlines()
     if len(all_snaps) == 0:
         return
     for snap in all_snaps:
@@ -1806,7 +1814,7 @@ def get_new_snapshot_name(absolutePath, remove_oldest=True):
     @bash.in_bash
     @lock.file_lock(absolutePath)
     def do_get_new_snapshot_name(name):
-        all_snaps = bash.bash_o("lvs -oname -Sorigin=%s --nolocking -t --noheadings | grep _snap_" % name).strip().splitlines()
+        all_snaps = bash.bash_o("%s -oname -Sorigin=%s --noheadings | grep _snap_" % (subcmd("lvs"), name)).strip().splitlines()
         if len(all_snaps) == 0:
             return name + "_snap_1"
         numbers = map(lambda x: int(x.strip().split("_")[-1]), all_snaps)
@@ -2116,7 +2124,7 @@ def fix_vglk(vg_uuid):
 
 
 def list_pvs(vgUuid, timeout=10):
-    r, o = bash.bash_ro("timeout -s SIGKILL %s pvs --noheading --nolocking -t -Svg_name=%s -oname" % (timeout, vgUuid))
+    r, o = bash.bash_ro("timeout -s SIGKILL %s %s --noheading -Svg_name=%s -oname" % (timeout, subcmd("pvs"), vgUuid))
     if r != 0:
         return None
 
@@ -2124,7 +2132,7 @@ def list_pvs(vgUuid, timeout=10):
     return filter(bool, paths)
 
 def check_pv_status(vgUuid, timeout):
-    r, o, e = bash.bash_roe("timeout -s SIGKILL %s pvs --noheading --nolocking -t -Svg_name=%s -oname,missing" % (timeout, vgUuid))
+    r, o, e = bash.bash_roe("timeout -s SIGKILL %s %s --noheading -Svg_name=%s -oname,missing" % (timeout, subcmd("pvs"), vgUuid))
     if len(o) == 0 or r != 0:
         s = "can not find shared block in shared block group %s, detail: [return_code: %s, stdout: %s, stderr: %s]" % (vgUuid, r, o, e)
         logger.warn(s)
@@ -2143,7 +2151,7 @@ def check_pv_status(vgUuid, timeout):
     # if r is False:
     #     return r, s
 
-    health = bash.bash_o('timeout -s SIGKILL %s vgs -oattr --nolocking -t --noheadings --shared %s ' % (10 if timeout < 10 else timeout, vgUuid)).strip()
+    health = bash.bash_o('timeout -s SIGKILL %s %s -oattr --noheadings --shared %s ' % (10 if timeout < 10 else timeout, subcmd("vgs"), vgUuid)).strip()
     if health == "":
         logger.warn("can not get proper attr of vg, return false")
         return False, "primary storage %s attr get error, expect 'wz--ns' got '%s'" % (vgUuid, health)
@@ -2337,21 +2345,21 @@ def check_sanlock_status(lockspace):
 @bash.in_bash
 def get_pv_name_by_uuid(pvUuid):
     return bash.bash_o(
-        "timeout -s SIGKILL 10 pvs --noheading --nolocking -t -oname -Spv_uuid=%s" % pvUuid).strip()
+        "timeout -s SIGKILL 10 %s --noheading -oname -Spv_uuid=%s" % (subcmd("pvs"), pvUuid)).strip()
 
 
 @bash.in_bash
 def get_pv_uuid_by_path(pvPath):
     return bash.bash_o(
-        "timeout -s SIGKILL 10 pvs --noheading --nolocking -t -ouuid %s" % pvPath).strip()
+        "timeout -s SIGKILL 10 %s --noheading -ouuid %s" % (subcmd("pvs"), pvPath)).strip()
 
 
 @bash.in_bash
 def check_lv_on_pv_valid(vgUuid, pvUuid, lv_path=None):
     pv_name = bash.bash_o(
-        "timeout -s SIGKILL 10 pvs --noheading --nolocking -t -oname -Spv_uuid=%s" % pvUuid).strip()
+        "timeout -s SIGKILL 10 %s --noheading -oname -Spv_uuid=%s" % (subcmd("pvs"), pvUuid)).strip()
     one_active_lv = lv_path if lv_path is not None else bash.bash_o(
-        "timeout -s SIGKILL 10 lvs --noheading --nolocking -t -opath,devices,tags " +
+        "timeout -s SIGKILL 10 %s --noheading -opath,devices,tags " % subcmd("lvs") +
         "-Sactive=active %s | grep %s | grep %s | awk '{print $1}' | head -n1" % (vgUuid, pv_name, VOLUME_TAG)).strip()
     if one_active_lv == "":
         return True
@@ -2365,7 +2373,7 @@ def check_lv_on_pv_valid(vgUuid, pvUuid, lv_path=None):
 def get_invalid_pv_uuids(vgUuid, checkIo = False, timeout=10):
     invalid_pv_uuids = []
     pvs_outs = bash.bash_o(
-        "timeout -s SIGKILL %s pvs --noheading --nolocking -t -Svg_name=%s -ouuid,name,missing" % (timeout, vgUuid)).strip().splitlines()
+        "timeout -s SIGKILL %s %s --noheading -Svg_name=%s -ouuid,name,missing" % (timeout, subcmd("pvs"), vgUuid)).strip().splitlines()
     if len(pvs_outs) == 0:
         return invalid_pv_uuids, "vg %s not found" % vgUuid
     for pvs_out in pvs_outs:
@@ -2402,7 +2410,7 @@ def is_volume_on_pvs(volume_path, pvUuids, includingMissing=True):
         pv_names.append("unknown")
     for f in files:
         o = bash.bash_o(
-            "timeout -s SIGKILL 10 lvs --noheading --nolocking -t %s -odevices" % f).strip().lower()  # type: str
+            "timeout -s SIGKILL 10 %s --noheading %s -odevices" % (subcmd("lvs"), f)).strip().lower()  # type: str
         logger.debug("volume %s is on pv %s" % (volume_path, o))
         if len(filter(lambda n: o.find(n.lower()) > 0, pv_names)) > 0:
             logger.debug("lv %s on pv %s(%s), return true" % (volume_path, pvUuids, pv_names))
@@ -2483,7 +2491,7 @@ def get_running_vm_root_volume_on_pv(vgUuid, pvUuids, checkIo=True):
 
 @bash.in_bash
 def remove_partial_lv_dm(vgUuid):
-    o = bash.bash_o("lvs --noheading --nolocking -t %s -opath,tags -Slv_health_status=partial | grep %s" % (vgUuid, COMMON_TAG)).strip().splitlines()
+    o = bash.bash_o("%s --noheading %s -opath,tags -Slv_health_status=partial | grep %s" % (subcmd("lvs"), vgUuid, COMMON_TAG)).strip().splitlines()
     if len(o) == 0:
         return
 
@@ -2554,7 +2562,7 @@ def get_allocated_pvs(vg_name):
 
 @bash.in_bash
 def get_lv_location(lv_path):
-    r, o = bash.bash_ro('''lvs --nolocking -t --noheadings -o devices %s | awk -F '(' '!pv[$1]++{printf " "$1}' ''' % lv_path)
+    r, o = bash.bash_ro('''%s --noheadings -o devices %s | awk -F '(' '!pv[$1]++{printf " "$1}' ''' % (subcmd("lvs"), lv_path))
     if r == 0:
         return o.strip().split()
     return []
@@ -2576,10 +2584,10 @@ def get_lv_affinity_sorted_pvs(lv_path, cmd=None):
 
 @bash.in_bash
 def get_volume_lv_sorted_pvs(vg_name):
-    cmd = '''pvs --segments --noheadings --nolocking -t \
+    cmd = '''%s --segments --noheadings \
 -S 'vg_name=%s,seg_type!=free,lv_tags!=%s,lv_tags!=""' \
 -o pv_name,lv_name -O pv_name,lv_name | uniq | awk '{count[$1]++;} END {for(pv in count) {print pv" "count[pv]}}' \
-''' % (vg_name, IMAGE_TAG)
+''' % (subcmd("pvs"), vg_name, IMAGE_TAG)
 
     r, o = bash.bash_ro(cmd)
     all_pvs = list_pvs(vg_name)
@@ -2593,7 +2601,7 @@ def get_volume_lv_sorted_pvs(vg_name):
 
 @bash.in_bash
 def get_free_sorted_pvs(vg_name):
-    r, o = bash.bash_ro("pvs --nolocking -t --noheadings -S 'vg_name=%s' -o pv_name -O-pv_free --rows" % vg_name)
+    r, o = bash.bash_ro("%s --noheadings -S 'vg_name=%s' -o pv_name -O-pv_free --rows" % (subcmd("pvs"), vg_name))
     if r == 0:
         return o.strip().split()
     return []
@@ -2608,8 +2616,8 @@ class LunWwidAndCapacity(object):
 
 @bash.in_bash
 def get_lun_capacities_from_vg(vg_uuid, vgs_path_and_wwid):
-    r, pvs_out, _ = bash.bash_roe("timeout -s SIGKILL 10 pvs --noheading --nolocking -t --nosuffix"
-                                  " -S 'vg_name=%s' -o 'pv_name,pv_size,pv_free' --units b" % vg_uuid)
+    r, pvs_out, _ = bash.bash_roe("timeout -s SIGKILL 10 %s --noheading --nosuffix"
+                                  " -S 'vg_name=%s' -o 'pv_name,pv_size,pv_free' --units b" % (subcmd("pvs"), vg_uuid))
     if r != 0:
         return None
 
@@ -2721,3 +2729,14 @@ class LvmlockdStatus(object):
         except Exception as e:
             logger.warn(str(e))
             self.failed = True
+
+def report_config_changed():
+    shell.run("touch %s" % LVM_CONFIG_CHANGED_FILE)
+
+
+def subcmd(cmd, timeout=lvm_cmd_timeout_with_locking):
+    if cmd in ["lvs", "pvs", "vgs"]:
+        return "%s --nolocking -t" % cmd
+    elif cmd in ["lvchange", "lvcreate", "lvrename", "lvresize", "lvextend", "lvremove"]:
+        return "timeout -s SIGKILL %s %s"% (timeout, cmd)
+    return cmd


### PR DESCRIPTION
add timeout for lvm command with locking to prevent the VG lock from being occupied due to other command blocking, like lvcreate/lvresize/lvremove..
If the lvm command with locking is hung, it will always occupy the lock and cannot be released.
And in scenarios where storage IO is slow and lock contention occurs, it may take longer to execute,
so we need to set a timeout that can tolerate this scenario.

Resolves/Related: ZSTAC-66089

Change-Id: I99e06f687468706d74787267616279626962679c

sync from gitlab !5316