### PR TITLE
<fix>[cephdriver]: fix zstone create volume hung

### DIFF
--- a/zstacklib/zstacklib/utils/ceph.py
+++ b/zstacklib/zstacklib/utils/ceph.py
@@ -23,6 +23,7 @@ QEMU_NBD_SOCKET_DIR = "/var/lock/"
 QEMU_NBD_SOCKET_PREFIX = "qemu-nbd-nbd"
 NBD_DEV_PREFIX = "/dev/nbd"
 SUPPORT_DEFER_DELETING = None
+from distutils.version import LooseVersion
 
 def get_fsid(conffile='/etc/ceph/ceph.conf'):
     import rados
@@ -402,3 +403,10 @@ class DefaultCephPoolCapacityGetter:
 pool_capacity_getter_mapping = {
     "zstone":ZStoneCephPoolCapacityGetter()
 }
+
+def get_version():
+    return shell.call("ceph version").split(" ")[2]
+
+def rbd_create_support_byte():
+    # ceph hammer not support in bytes
+    return get_ceph_manufacturer() != "open-source" or LooseVersion(get_version()) >= LooseVersion("10.0.0")


### PR DESCRIPTION
creating an image using the python RBD interface may be hung on zstone, so we try to use shell commands to create it as much as possible.

Resolves: ZSTAC-68775

Change-Id: I6c6a6a7765686d647061676c6e736a6e616c7473


(cherry picked from commit 2f3f551266e59212b517897fd39e331ae7479d88)

sync from gitlab !5317