### PR TITLE
<fix>[kvmagent]: add pci device types

### DIFF
--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -2650,10 +2650,18 @@ done
                     to.type = "USB_Controller"
                 elif 'Serial controller' in to.type:
                     to.type = "Serial_Controller"
-                elif 'Moxa Technologies' in to.type:
-                    to.type = "Moxa_Device"
+                elif 'RAID bus controller' in to.type:
+                    to.type = "RAID_Controller"
+                elif 'SATA controller' in to.type:
+                    to.type = "SATA_Controller"
                 elif 'Memory controller' in to.type:
                     to.type = "Memory_Controller"
+                elif 'Non-Volatile memory controller' in to.type:
+                    to.type = "Non_Volatile_Memory_Controller"
+                elif 'Fibre Channel' in to.type:
+                    to.type = "Fibre_Channel"
+                elif 'Moxa Technologies' in to.type:
+                    to.type = "Moxa_Device"
                 elif 'System peripheral' in to.type:
                     to.type = "System_Peripheral"
                 elif 'ISA bridge' in to.type:


### PR DESCRIPTION
add disabled pass-through pci device types:
RAID controller,
SATA controller,
Non-Volatile memory controller,
Fibre Channel

Resolves: ZSV-7114

Change-Id: I6868717073726f6361716e667a6577716d786673
(cherry picked from commit fd1ab38c5c36cbe88df7fc206d96e0f2fd037999)

sync from gitlab !5325