### PR TITLE
<fix>[zstackctl]: stop keepalived before restart mariadb

### DIFF
--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -178,13 +178,13 @@ if [ $? -ne 0 ]; then
     sed -i "/\[mysqld\]/a tmpdir=$mysql_tmp_path" $mysql_conf
 fi
 
-[ x`systemctl is-enabled zstack-ha 2>/dev/null` == x"enabled" ] && systemctl stop keepalived.service
+([ x`systemctl is-enabled zstack-ha 2>/dev/null` == x"enabled" ] && { systemctl start keepalived.service || true; }) || true
 
 if [ `systemctl is-active mariadb` != "unknown" ]; then 
     systemctl restart mariadb
 fi
 
-[ x`systemctl is-enabled zstack-ha 2>/dev/null` == x"enabled" ] && systemctl start keepalived.service
+([ x`systemctl is-enabled zstack-ha 2>/dev/null` == x"enabled" ] && { systemctl start keepalived.service || true; }) || true
 '''
 
 mysqldump_skip_tables = "--ignore-table=zstack.VmUsageHistoryVO --ignore-table=zstack.RootVolumeUsageHistoryVO " \

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -178,7 +178,7 @@ if [ $? -ne 0 ]; then
     sed -i "/\[mysqld\]/a tmpdir=$mysql_tmp_path" $mysql_conf
 fi
 
-([ x`systemctl is-enabled zstack-ha 2>/dev/null` == x"enabled" ] && { systemctl start keepalived.service || true; }) || true
+([ x`systemctl is-enabled zstack-ha 2>/dev/null` == x"enabled" ] && { systemctl stop keepalived.service || true; }) || true
 
 if [ `systemctl is-active mariadb` != "unknown" ]; then 
     systemctl restart mariadb

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -178,9 +178,13 @@ if [ $? -ne 0 ]; then
     sed -i "/\[mysqld\]/a tmpdir=$mysql_tmp_path" $mysql_conf
 fi
 
+[ x`systemctl is-enabled zstack-ha 2>/dev/null` == x"enabled" ] && systemctl stop keepalived.service
+
 if [ `systemctl is-active mariadb` != "unknown" ]; then 
     systemctl restart mariadb
 fi
+
+[ x`systemctl is-enabled zstack-ha 2>/dev/null` == x"enabled" ] && systemctl start keepalived.service
 '''
 
 mysqldump_skip_tables = "--ignore-table=zstack.VmUsageHistoryVO --ignore-table=zstack.RootVolumeUsageHistoryVO " \


### PR DESCRIPTION
Avoid race condition that mariadb not ready during keepalived's check
interval which will may cause endless mariadb restart loop

Resolves: ZSTAC-66513

Change-Id: I67636b6e7978746c686e75647679726766706969
(cherry picked from commit 5b7a96fcff11c0241eaef2746d8262c5c7e977e5)

sync from gitlab !5353