### PR TITLE
<fix>[vm]: fix driver compatibilty code during vm live migration

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -126,6 +126,7 @@ class DomainVolume(object):
         self.driver_type = ''
         self.dvbs = None
         self.deviceType = ''
+        self.disk_device = ''
 
         self._origin_xml_obj = None
 
@@ -163,7 +164,7 @@ class DomainVolume(object):
 
     @property
     def is_cdrom(self):
-        return self.disk_device is 'cdrom'
+        return self.disk_device == 'cdrom'
 
     def over_incorrect_driver(self):
         return block_device_use_block_type() \
@@ -245,9 +246,9 @@ class DomainVolumeBackingStore(object):
         return block_volume_over_incorrect_driver(self)
 
     def update_backing_store_type_to_block(self):
-        if self.backing_store is None:
-            return
-        self.backing_store.update_backing_store_type_to_block()
+        if self.backing_store is not None:
+            self.backing_store.update_backing_store_type_to_block()
+
         if self._over_incorrect_driver():
             self._update_backing_store_type_to_block()
 
@@ -7839,10 +7840,10 @@ class VmPlugin(kvmagent.KvmAgent):
             if not volume.over_incorrect_driver():
                 return old_disk  # no change
 
-            # vm created by ISO image or storage migrated may not have backing store info
-            if volume.dvbs is not None:
-                volume.dvbs.update_backing_store_type_to_block()
-                block_backing_store = volume.dvbs._origin_xml_obj
+        # vm created by ISO image or storage migrated may not have backing store info
+        if volume.dvbs is not None:
+            volume.dvbs.update_backing_store_type_to_block()
+            block_backing_store = volume.dvbs._origin_xml_obj
 
         driver_type = volume.format if volume.format else 'qcow2'
         volume = file_volume_check(volume)


### PR DESCRIPTION
if disk_device not be set in from_xmlobject(cls, xml_obj) correctly, xml
checker will failed to handle cdrom/disk device properly and as a result
migration of vm with iso will fail.

fix is_cdrom property not returned as expected by use '==' instead of
'is' literal to make sure cdrom disk's wrong driver will be fixed

sperate backing store xml check and fix recursion check of disk xml
to make sure all backing stores with wrong driver will be updated

Resolves: ZSTAC-66811

Change-Id: I7a74696366666f79666d64696a6772666f707062
Signed-off-by: AlanJager <ye.zou@zstack.io>
(cherry picked from commit 985fbc75ead6ca97405e667258a25a973023ec06)

sync from gitlab !5403