### PR TITLE
<fix>[vm]: qemu-4.1-ky do not support non-file migration

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -8489,8 +8489,8 @@ class VmPlugin(kvmagent.KvmAgent):
             job_over = True
             if shell_cmd.return_code != 0:
                 if 'non-file destination not supported' in shell_cmd.stderr:
-                    shell_cmd.stderr = 'the current libvirt does not support migrating storage to ceph ' \
-                                       'from the same host. Please upgrade to libvirt-4.9.0-22.gef3a393 or higher'
+                    shell_cmd.stderr = 'the current libvirt / qemu does not support migrating storage to ceph ' \
+                                       'from the same host. Please upgrade to libvirt-4.9.0-22.gef3a393 / qemu-4.2.0 or higher'
                 logger.debug("block copy failed from %s:%s to %s: %s" % (vmUuid, disk_name, task_spec.newVolume.installPath, shell_cmd.stderr))
                 return False, shell_cmd.stderr
             valid, errText = check_volume()


### PR DESCRIPTION
qemu should support rbd blockdev

Resolves: ZSTAC-67395

Change-Id: I7272616d767867727178636d6c73796d6d676574


(cherry picked from commit 734fad2f53175f3dbc239c791ba4a09f25a16a61)

sync from gitlab !5406