### PR TITLE
<fix>[zstacklib]: no need to set bridge alias when update l2 vlan/vni

### DIFF
--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -1597,7 +1597,6 @@ def detach_interface_from_bridge(interface, bridge_name):
 
 def attach_interface_to_bridge(interface, bridge_name, l2_network_uuid):
     ip_link_set_net_device_master(interface, bridge_name)
-    set_bridge_alias_using_phy_nic_name(bridge_name, interface)
     set_device_uuid_alias(interface, l2_network_uuid)
 
 


### PR DESCRIPTION
Resolves: ZSV-7539

Change-Id: I6e757a6c6275686277787871756379757079797a

sync from gitlab !5415