### PR TITLE
<fix>[zstacklib]: fix bash traceable

### DIFF
--- a/cephbackupstorage/cephbackupstorage/cephagent.py
+++ b/cephbackupstorage/cephbackupstorage/cephagent.py
@@ -1046,9 +1046,9 @@ class CephAgent(object):
 
             logger.debug("content-length is: %s" % total)
 
-            _, _, err = shell.bash_progress_1('set -o pipefail;wget --no-check-certificate -O - %s 2>%s| rbd import '
+            _, _, err = shell.bash_progress_1('wget --no-check-certificate -O - %s 2>%s| rbd import '
                                               '--image-format 2 - %s/%s ' % (cmd.url, PFILE, pool, tmp_image_name)
-                                              , _getProgress)
+                                              , _getProgress, pipe_fail=True)
             if err:
                 raise err
             actual_size = linux.get_file_size_by_http_head(cmd.url)
@@ -1086,8 +1086,9 @@ class CephAgent(object):
 
             get_content_from_pipe_cmd = "pv -s %s -n %s 2>%s" % (actual_size, pipe_path, PFILE)
             import_from_pipe_cmd = "rbd import --image-format 2 - %s/%s" % (pool, tmp_image_name)
-            _, _, err = shell.bash_progress_1('set -o pipefail; %s & %s | %s' %
-                                        (scp_to_pipe_cmd, get_content_from_pipe_cmd, import_from_pipe_cmd), _get_progress)
+            _, _, err = shell.bash_progress_1('%s & %s | %s' %
+                                        (scp_to_pipe_cmd, get_content_from_pipe_cmd, import_from_pipe_cmd),
+                                              _get_progress, pipe_fail=True)
 
             if ssh_pswd_file:
                 linux.rm_file_force(ssh_pswd_file)

--- a/cephprimarystorage/cephprimarystorage/cephagent.py
+++ b/cephprimarystorage/cephprimarystorage/cephagent.py
@@ -1295,11 +1295,11 @@ class CephAgent(plugin.TaskManager):
         traceable_bash = traceable_shell.get_shell(cmd)
         ssh_cmd, tmp_file = linux.build_sshpass_cmd(dst_mon_addr, dst_mon_passwd, "tee >(md5sum >/tmp/%s_dst_md5) | rbd import-diff - %s"
                                                     % (resource_uuid, dst_install_path), dst_mon_user, dst_mon_port)
-        r, _, e = traceable_bash.bash_roe('set -o pipefail; rbd export-diff {FROM_SNAP} {SRC_INSTALL_PATH} - | tee >(md5sum >/tmp/{RESOURCE_UUID}_src_md5) | {SSH_CMD}'.format(
+        r, _, e = traceable_bash.bash_roe('rbd export-diff {FROM_SNAP} {SRC_INSTALL_PATH} - | tee >(md5sum >/tmp/{RESOURCE_UUID}_src_md5) | {SSH_CMD}'.format(
             RESOURCE_UUID=resource_uuid,
             SSH_CMD=ssh_cmd,
             SRC_INSTALL_PATH=src_install_path,
-            FROM_SNAP='--from-snap ' + parent_uuid if parent_uuid != '' else ''))
+            FROM_SNAP='--from-snap ' + parent_uuid if parent_uuid != '' else ''), pipe_fail=True)
         linux.rm_file_force(tmp_file)
         if r != 0:
             logger.error('failed to migrate volume %s: %s' % (src_install_path, e))

--- a/zstacklib/zstacklib/utils/bash.py
+++ b/zstacklib/zstacklib/utils/bash.py
@@ -101,12 +101,12 @@ def bash_errorout(cmd, code=0, pipe_fail=False):
     _, o, _ = bash_roe(cmd, errorout=True, ret_code=code, pipe_fail=pipe_fail)
     return o
 
-def bash_progress_1(cmd, func, errorout=True):
+def bash_progress_1(cmd, func, errorout=True, pipe_fail=False):
     logger.debug(cmd)
     watch_thread = WatchThread_1(func)
     try:
         watch_thread.start()
-        r, o, e = bash_roe(cmd, errorout)
+        r, o, e = bash_roe(cmd, errorout=errorout, pipe_fail=pipe_fail)
         return r, o, e
     except Exception as ex:
         logger.debug(linux.get_exception_stacktrace())

--- a/zstacklib/zstacklib/utils/shell.py
+++ b/zstacklib/zstacklib/utils/shell.py
@@ -47,6 +47,10 @@ class ShellCmd(object):
         self.return_code = None
 
     def raise_error(self, err=()):
+        """
+        :param err: extend error message
+        :return:
+        """
         if err is ():
             err = []
         err.append('failed to execute shell command: %s' % self.cmd.split(' ', 1)[0])

--- a/zstacklib/zstacklib/utils/traceable_shell.py
+++ b/zstacklib/zstacklib/utils/traceable_shell.py
@@ -36,17 +36,17 @@ class TraceableShell(object):
             return s.return_code
         self.raise_error(s, cmd)
 
-    def bash_progress_1(self, cmd, func, errorout=True):
-        cmd = self.wrap_cmd(cmd)
-        return bash.bash_progress_1(cmd, func=func, errorout=errorout)
+    def bash_progress_1(self, cmd, func, errorout=True, pipe_fail=False):
+        cmd = self.wrap_bash_cmd(cmd)
+        return bash.bash_progress_1(cmd, func=func, errorout=errorout, pipe_fail=pipe_fail)
 
     def bash_roe(self, cmd, errorout=False, ret_code=0, pipe_fail=False):
-        cmd = self.wrap_cmd(cmd)
+        cmd = self.wrap_bash_cmd(cmd)
         return bash.bash_roe(cmd, errorout=errorout, ret_code=ret_code, pipe_fail=pipe_fail)
 
     def bash_errorout(self, cmd, code=0, pipe_fail=False):
-        cmd = self.wrap_cmd(cmd)
-        _, o, _ = self.bash_roe(cmd, errorout=True, ret_code=code, pipe_fail=pipe_fail)
+        cmd = self.wrap_bash_cmd(cmd)
+        _, o, _ = bash.bash_roe(cmd, errorout=True, ret_code=code, pipe_fail=pipe_fail)
         return o
 
     def wrap_cmd(self, cmd):
@@ -57,6 +57,10 @@ class TraceableShell(object):
         if self.id:
             cmd = _build_id_cmd(self.id) + "; " + cmd
         return cmd
+
+    def wrap_bash_cmd(self, cmd):
+        cmd = cmd.replace("'", "'\\''")
+        return "bash -c '%s'" % self.wrap_cmd(cmd) if self.id else cmd
 
     def raise_error(self, s, origin_cmd):
         # type: (shell.ShellCmd, str) -> None


### PR DESCRIPTION
if bash use input to execute shell command, it will not
be saved in process cmdline, so pkill by api id will do not
work. revert wrap_bash_cmd back.

escape quote for wrap_bash_cmd.

add more case for traceable_shell.

use arguments pip_fail to controll pipe fail to prevent from wrong
command like "timeout 1800 set -o pipefail".

Resolves: ZSTAC-71535

Change-Id: I646766677972616e736e68716a6c7173756f6569


(cherry picked from commit 445ae423c13b1794e1c3d2746b76042add27eece)

sync from gitlab !5433