### PR TITLE
<fix>[prometheus]: skip ipmi_exporter in virtual env

### DIFF
--- a/kvmagent/kvmagent/plugins/prometheus.py
+++ b/kvmagent/kvmagent/plugins/prometheus.py
@@ -22,6 +22,7 @@ from zstacklib.utils.bash import *
 from zstacklib.utils.ip import get_host_physicl_nics
 from zstacklib.utils.ip import get_nic_supported_max_speed
 from zstacklib.utils.ipmitool import get_sensor_info_from_ipmi
+from zstacklib.utils.linux import is_virtual_machine
 
 logger = log.get_logger(__name__)
 collector_dict = {}  # type: Dict[str, threading.Thread]
@@ -1876,7 +1877,11 @@ modules:
             if "collectd_exporter" in cmd.binaryPath:
                 start_collectd_exporter(cmd)
             elif "ipmi_exporter" in cmd.binaryPath:
-                start_ipmi_exporter(cmd)
+                if not is_virtual_machine():
+                    start_ipmi_exporter(cmd)
+                else:
+                    logger.info("Current environment is a virtualized environment, skipping ipmi_exporter startup")
+                    continue
             else:
                 start_exporter(cmd)
 

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -57,6 +57,8 @@ from zstacklib.utils import image
 from zstacklib.utils import iproute
 from zstacklib.utils import ovs
 from zstacklib.utils import drbd
+from zstacklib.utils.jsonobject import JsonObject
+from zstacklib.utils.linux import is_virtual_machine
 from zstacklib.utils.qga import *
 from zstacklib.utils import jsonobject
 from zstacklib.utils.report import *
@@ -1266,10 +1268,6 @@ def is_kylin402():
 def is_spiceport_driver_supported():
     # qemu-system-aarch64 not supported char driver: spiceport
     return shell.run("%s -h | grep 'chardev spiceport'" % kvmagent.get_qemu_path()) == 0
-
-def is_virtual_machine():
-    product_name = shell.call("dmidecode -s system-product-name").strip()
-    return product_name == "KVM Virtual Machine" or product_name == "KVM"
 
 def get_domain_type():
     return "qemu" if HOST_ARCH == "aarch64" and is_virtual_machine() else "kvm"

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -3287,3 +3287,7 @@ def compare_segmented_xxhash(src_path, dst_path, total_size, raise_exception=Fal
 
 def check_unixsock_connection(socket_path, timeout=10):
     return shell.run("nc -z -U %s -w %s" % (socket_path, timeout))
+
+def is_virtual_machine():
+    product_name = shell.call("dmidecode -s system-product-name").strip()
+    return product_name == "KVM Virtual Machine" or product_name == "KVM"


### PR DESCRIPTION
update is_virtual_machine method, skip start
ipmi_exporter in virtual environment

Resolves: ZSV-7721
Related: ZSTAC-68925

Change-Id: I7979626f626d6977636a6d6a6e6b6a7a74647070
(cherry picked from commit 0fa60736df70fb7dfd29d20efad5d5796b1b17cf)

sync from gitlab !5484