### PR TITLE
<fix>[mevoco]: fix vm agent push metrics to pushgateway with no auth

### DIFF
--- a/kvmagent/kvmagent/plugins/mevoco.py
+++ b/kvmagent/kvmagent/plugins/mevoco.py
@@ -1003,7 +1003,7 @@ server.max-worker=1
 dir-listing.activate = "enable"
 index-file.names = ( "index.html" )
 
-server.modules += ("mod_proxy", "mod_rewrite", "mod_access", "mod_accesslog","mod_auth",)
+server.modules += ("mod_proxy", "mod_rewrite", "mod_access", "mod_accesslog","mod_auth","mod_setenv")
 accesslog.filename = "/var/log/lighttpd/lighttpd_access.log"
 server.errorlog = "/var/log/lighttpd/lighttpd_error.log"
 
@@ -1012,13 +1012,7 @@ auth.backend.plain.users = ( "admin" => "zstack@123" )
 
 $HTTP["remoteip"] =~ "^(.*)$" {
     $HTTP["url"] =~ "^/metrics/job" {
-        auth.require = ( "/metrics/job" =>
-            (
-                "method"  => "basic",
-                "realm"   => "Restricted Area",
-                "require" => "valid-user"
-            )
-        )
+        setenv.add-request-header = ( "Authorization" => "Basic YWRtaW46enN0YWNrQDEyMw==" )
         proxy.server = ( "" =>
            ( ( "host" => "{{pushgateway_ip}}", "port" => {{pushgateway_port}} ) )
         )


### PR DESCRIPTION
fix vm agent push metrics to pushgateway with no auth

Resolves: ZSTAC-70407

Change-Id: I6d7a7a6b727778637163797462787376766e696c

sync from gitlab !5492