### PR TITLE
<fix>[zstacklib]: block job cancel ignore error

### DIFF
--- a/zstacklib/zstacklib/utils/qmp.py
+++ b/zstacklib/zstacklib/utils/qmp.py
@@ -55,7 +55,7 @@ def query_block_jobs_by_device(vm):
     return {job['device']: job for job in jobs}
 
 def block_job_cancel(vm, device):
-    execute_qmp_command(vm, "block-job-cancel", device=device)
+    execute_qmp_command(vm, "block-job-cancel", raise_exception=False, device=device)
 
 
 def migrate_set_speed(vm, bandwidth):


### PR DESCRIPTION
use query block job return to check canceling result.

Resolves: ZSTAC-72128

Change-Id: I727867737771616c757876666b68746d7a66797a

sync from gitlab !5512