### PR TITLE
<fix>[kvmagent]: improving dump threads and objects

### DIFF
--- a/zstacklib/zstacklib/utils/debug.py
+++ b/zstacklib/zstacklib/utils/debug.py
@@ -145,6 +145,7 @@ def dump_threads():
                 thread_info.append("Locals: {}".format(simplified_locals))
             except Exception as e:
                 logger.debug("Error dumping thread {}: {}".format(th.name, str(e)))
+                logger.warning(traceback.format_exc())
 
         output.append("\n".join(thread_info))
 


### PR DESCRIPTION
1、skip host ping when dumping kvmagent
2、improving dump threads and objects

Resolves/Related: ZSTAC-72551

Change-Id: I676f656f6f6d6b6565656e737677666667767172

sync from gitlab !5553