### PR TITLE
<feature>[agent]: support agent memory monitoring and alarm

### DIFF
--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -1057,7 +1057,8 @@ class HostPlugin(kvmagent.KvmAgent):
     @kvmagent.replyerror
     def ping(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
-        kvmagent.configs = cmd.configs
+        if cmd.configs:
+            kvmagent.configs = cmd.configs.__dict__
         rsp = PingResponse()
         rsp.hostUuid = self.host_uuid
         rsp.sendCommandUrl = self.config.get(kvmagent.SEND_COMMAND_URL)


### PR DESCRIPTION
fix "'NoneType' object is not callable" on collect_kvmagent_memory_statistics

Resolves/Related: ZSTAC-71000

Change-Id: I676f656f6f6d6b6565656e737677666667767171

sync from gitlab !5633