### PR TITLE
<fix>[sblk]: add lock to func 'check_vg_state'

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -1720,6 +1720,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror
+    @lock.lock('check_vg')
     def check_vg_state(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = AgentRsp()


### PR DESCRIPTION
When checking the vg state, if the thread gets stuck and causes timeout, the check will be restarted and new threads will be continuously generated

Resolves/Related: ZSTAC-69924

Change-Id: I717063786f646f796764647172797073756e717a

sync from gitlab !5756