### PR TITLE
<fix>[cephprimarystorage]: xsky snapshot actual size 1

### DIFF
--- a/cephprimarystorage/cephprimarystorage/cephagent.py
+++ b/cephprimarystorage/cephprimarystorage/cephagent.py
@@ -560,8 +560,12 @@ class CephAgent(plugin.TaskManager):
     #TODO: check that ceph supports json versions
     @in_bash
     def _get_snapshot_actual_size(self, path):
-        # if no fast-diff supported and not xsky ceph skip actual size check
-        if not self._fast_diff_enabled(path) and not ceph.is_xsky():
+        if ceph.is_xsky():
+            # xsky can not separate snapshot size, return a minimum value
+            return 1
+
+        # if no fast-diff supported skip actual size check
+        if not self._fast_diff_enabled(path):
             return None
 
         r, jstr = bash.bash_ro("rbd du %s --format json" % path)
@@ -572,19 +576,10 @@ class CephAgent(plugin.TaskManager):
         if result.images is None:
             return None
 
-        snapshot_size = None
         snapshot = path.split('@')[-1]
-
-        if ceph.is_xsky():
-            for item in result.images:
-                if item.name is not None and snapshot in item.name:
-                    snapshot_size = int(item.used_size)
-            return snapshot_size
-
         for item in result.images:
             if item.snapshot == snapshot:
-                snapshot_size = int(item.used_size)
-        return snapshot_size
+                return int(item.used_size)
 
     def _get_file_size(self, path):
         o = shell.call('rbd --format json info %s' % path)


### PR DESCRIPTION
xsky cannot get snapshot actual size. it will return
the whole image size, so set 1 to avoid repeated calculation

Resolves: ZSTAC-65697

Change-Id: I72766b6a6a65686379796c777163706169677071


(cherry picked from commit 0fb953022d22fda3482dff15b4db71e1e27310ef)

sync from gitlab !5760