### PR TITLE
<fix>[host]: fix enflame s60 gpu monitor

### DIFF
--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -2761,15 +2761,16 @@ done
         for info in gpu.parse_enflame_gpu_output(o):
             if to.pciDeviceAddress not in info.get("pciAddress"):
                 continue
-            mem = info.get("memory")
-            power = info.get("powerCap")
-            serial = info.get("serialNumber")
 
-            if mem and re.match(r"^\d+$", mem.replace('MiB', '').strip()):
-                to.addonInfo["memory"] = mem
+            mem = info.get("memory", "")
+            power = info.get("powerCap", "")
+            serial = info.get("serialNumber", "")
 
-            if power and re.match(r"^\d+(\.\d+)?$", power.strip()):
-                to.addonInfo["power"] = power
+            if mem and re.match(r"^\s*\d+\s*MiB\s*$", mem, re.IGNORECASE):
+                to.addonInfo["memory"] = mem.strip()
+
+            if power and re.match(r"^\s*\d+(\.\d+)?\s*W\s*$", power, re.IGNORECASE):
+                to.addonInfo["power"] = power.strip()
 
             if serial and serial.strip():
                 to.addonInfo["serialNumber"] = serial

--- a/kvmagent/kvmagent/plugins/prometheus.py
+++ b/kvmagent/kvmagent/plugins/prometheus.py
@@ -1773,23 +1773,23 @@ def collect_enflame_gpu_status():
         memory_total = info.get("memory", "0MiB").strip().rstrip("MiB")
         memory_utilization = calculate_percentage(memory_usage, memory_total)
 
-        power = info.get("power", "0W").strip().rstrip("W")
-        temperature = info.get("temperature", "0C").strip().rstrip("C")
-        gcu_usage = info.get("gcuUsage", "0%").strip().rstrip("%")
+        power = info.get("power", "0W").replace(" ", "").strip().rstrip("W")
+        temperature = info.get("temperature", "0C").replace(" ", "").strip().rstrip("C")
+        gcu_usage = info.get("gcuUsage", "0%").replace(" ", "").strip().rstrip("%")
 
         add_gpu_pci_device_address("ENFLAME", pci_device_address, serial_number)
 
         if is_number(power):
-            add_metrics('host_gpu_power_draw', power, [pci_device_address, serial_number], metrics)
+            add_metrics('host_gpu_power_draw', float(power), [pci_device_address, serial_number], metrics)
 
         if is_number(temperature):
-            add_metrics('host_gpu_temperature', temperature, [pci_device_address, serial_number], metrics)
+            add_metrics('host_gpu_temperature', float(temperature), [pci_device_address, serial_number], metrics)
 
         if is_number(gcu_usage):
-            add_metrics('host_gpu_utilization', gcu_usage, [pci_device_address, serial_number], metrics)
+            add_metrics('host_gpu_utilization', float(gcu_usage), [pci_device_address, serial_number], metrics)
 
         if is_number(memory_utilization):
-            add_metrics('host_gpu_memory_utilization', memory_utilization, [pci_device_address, serial_number], metrics)
+            add_metrics('host_gpu_memory_utilization', float(memory_utilization), [pci_device_address, serial_number], metrics)
 
     check_gpu_status_and_save_gpu_status("ENFLAME", metrics)
     return metrics.values()


### PR DESCRIPTION
1. fix regex match incorrectly when collect enflame gpu
2. parse data to number in prometheus when monitor enflame gpu

Resolves: ZSTAC-74913,ZSTAC-74912

Change-Id: I666f696c6a6b796a686b7a747168647175697370

sync from gitlab !5841