### PR TITLE
<fix>[vm]: add q35 ide address reservation config list

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -4882,6 +4882,15 @@ class Vm(object):
         if cmd.architecture and cmd.architecture != HOST_ARCH:
             raise kvmagent.KvmError("Image architecture[{}] not matched host architecture[{}].".format(cmd.architecture, HOST_ARCH))
         default_bus_type = ('ide', 'sata', 'scsi')[max(machine_type == 'q35', (HOST_ARCH in ['aarch64', 'mips64el', 'loongarch64']) * 2)]
+        image_platform_in_lower = cmd.imagePlatform.lower()
+
+        # platform support use no virtio for ide/sata disk on other platform vms
+        # in this case we need to deduplicate the device address because cdrom and disk can't share the same address
+        # and the default address is hd[a-z] for ide/sata disk logically
+        hd_device_address_deduplicate = False
+        if default_bus_type in ('ide', 'sata') and image_platform_in_lower == 'other':
+            hd_device_address_deduplicate = True
+
         elements = {}
 
         def make_root():
@@ -5479,11 +5488,20 @@ class Vm(object):
             volumes = [cmd.rootVolume]
             volumes.extend(cmd.dataVolumes)
             #When platform=other and default_bus_type=ide, the maximum number of volume is three
-            volume_ide_configs = [
-                VolumeIDEConfig('0', '0'),
-                VolumeIDEConfig('1', '1'),
-                VolumeIDEConfig('1', '0')
-            ]
+            if machine_type == 'pc':
+                volume_hd_configs = [
+                    VolumeIDEConfig('0', '0'),
+                    VolumeIDEConfig('1', '1'),
+                    VolumeIDEConfig('1', '0')
+                ]
+            elif machine_type == 'q35':
+                volume_hd_configs = [
+                    VolumeIDEConfig('0', '0'),
+                    VolumeIDEConfig('0', '4'),
+                    VolumeIDEConfig('0', '5')
+                ]
+            else:
+                raise Exception("unexpected machine type %s" % machine_type)
 
             def quorumbased_volume(_dev_letter, _v):
                 def make_backingstore(volume_path):
@@ -5527,8 +5545,8 @@ class Vm(object):
                 else:
                     dev_format = Vm._get_disk_target_dev_format(default_bus_type)
                     e(disk, 'target', None, {'dev': dev_format % _dev_letter, 'bus': default_bus_type})
-                    if default_bus_type == "ide" and cmd.imagePlatform.lower() == "other":
-                        allocat_ide_config(disk, _v)
+                    if hd_device_address_deduplicate:
+                        preserve_hd_device_config(disk, _v)
 
                 return disk
 
@@ -5563,8 +5581,8 @@ class Vm(object):
                 else:
                     dev_format = Vm._get_disk_target_dev_format(default_bus_type)
                     e(disk, 'target', None, {'dev': dev_format % _dev_letter, 'bus': default_bus_type})
-                    if default_bus_type == "ide" and cmd.imagePlatform.lower() == "other":
-                        allocat_ide_config(disk, _v)
+                    if hd_device_address_deduplicate:
+                        preserve_hd_device_config(disk, _v)
                 return disk
 
             def iscsibased_volume(_dev_letter, _v):
@@ -5628,8 +5646,8 @@ class Vm(object):
                 else:
                     dev_format = Vm._get_disk_target_dev_format(default_bus_type)
                     e(disk, 'target', None, {'dev': dev_format % _dev_letter, 'bus': default_bus_type})
-                    if default_bus_type == "ide" and cmd.imagePlatform.lower() == "other":
-                        allocat_ide_config(disk, _v)
+                    if hd_device_address_deduplicate:
+                        preserve_hd_device_config(disk, _v)
                 return disk
 
             def ceph_volume(_dev_letter, _v):
@@ -5663,8 +5681,8 @@ class Vm(object):
                         return ceph_virtio()
                     else:
                         disk = ceph_blk()
-                        if default_bus_type == "ide" and cmd.imagePlatform.lower() == "other":
-                            allocat_ide_config(disk, _v)
+                        if hd_device_address_deduplicate:
+                            preserve_hd_device_config(disk, _v)
                         return disk
 
                 d = build_ceph_disk()
@@ -5704,8 +5722,8 @@ class Vm(object):
                 else:
                     dev_format = Vm._get_disk_target_dev_format(default_bus_type)
                     e(disk, 'target', None, {'dev': dev_format % _dev_letter, 'bus': default_bus_type})
-                    if default_bus_type == "ide" and cmd.imagePlatform.lower() == "other":
-                        allocat_ide_config(disk, _v)
+                    if hd_device_address_deduplicate:
+                        preserve_hd_device_config(disk, _v)
 
                 return disk
 
@@ -5736,8 +5754,8 @@ class Vm(object):
                 else:
                     dev_format = Vm._get_disk_target_dev_format(default_bus_type)
                     e(disk, 'target', None, {'dev': dev_format % _dev_letter, 'bus': default_bus_type})
-                    if default_bus_type == "ide" and cmd.imagePlatform.lower() == "other":
-                        allocat_ide_config(disk, _v)
+                    if hd_device_address_deduplicate:
+                        preserve_hd_device_config(disk, _v)
                 return disk
 
             def cbd_volume(_dev_letter, _v):
@@ -5806,16 +5824,16 @@ class Vm(object):
                 qs = dict(urlparse.parse_qsl(u.query))
                 return qs.get("r")
 
-            def allocat_ide_config(_disk, _volume):
+            def preserve_hd_device_config(_disk, _volume):
                 if _volume.deviceAddress:
-                    e(_disk, 'address', None, {'type': 'drive', 'bus': _volume.deviceAddress.bus, 'unit': _volume.deviceAddress.unit})
-                    volume_ide_configs.pop(0)
+                    # just pop config and deviceAddress will be set in the next step
+                    volume_hd_configs.pop(0)
                 else:
-                    if len(volume_ide_configs) == 0:
+                    if len(volume_hd_configs) == 0:
                         err = "insufficient IDE address."
                         logger.warn(err)
                         raise kvmagent.KvmError(err)
-                    volume_ide_config = volume_ide_configs.pop(0)
+                    volume_ide_config = volume_hd_configs.pop(0)
                     e(_disk, 'address', None, {'type': 'drive', 'bus': volume_ide_config.bus, 'unit': volume_ide_config.unit})
 
             def make_volume(dev_letter, v, r, dataSourceOnly=False):

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -5488,20 +5488,18 @@ class Vm(object):
             volumes = [cmd.rootVolume]
             volumes.extend(cmd.dataVolumes)
             #When platform=other and default_bus_type=ide, the maximum number of volume is three
-            if machine_type == 'pc':
-                volume_hd_configs = [
-                    VolumeIDEConfig('0', '0'),
-                    VolumeIDEConfig('1', '1'),
-                    VolumeIDEConfig('1', '0')
-                ]
-            elif machine_type == 'q35':
+            if machine_type == 'q35':
                 volume_hd_configs = [
                     VolumeIDEConfig('0', '0'),
                     VolumeIDEConfig('0', '4'),
                     VolumeIDEConfig('0', '5')
                 ]
             else:
-                raise Exception("unexpected machine type %s" % machine_type)
+                volume_hd_configs = [
+                    VolumeIDEConfig('0', '0'),
+                    VolumeIDEConfig('1', '1'),
+                    VolumeIDEConfig('1', '0')
+                ]
 
             def quorumbased_volume(_dev_letter, _v):
                 def make_backingstore(volume_path):

--- a/kvmagent/kvmagent/test/vm_plugin_testsuite/test_start_vm_stop_vm_destroy_vm.py
+++ b/kvmagent/kvmagent/test/vm_plugin_testsuite/test_start_vm_stop_vm_destroy_vm.py
@@ -1,7 +1,7 @@
 import pytest
 
 from kvmagent.plugins import vm_plugin
-from kvmagent.test.utils import vm_utils, network_utils, pytest_utils
+from kvmagent.test.utils import vm_utils, network_utils, pytest_utils, volume_utils
 from kvmagent.test.utils.stub import *
 from zstacklib.test.utils import misc
 from zstacklib.utils import linux
@@ -50,3 +50,88 @@ class TestVmLifeCycle(TestCase, vm_utils.VmPluginTestStub):
         vm_utils.destroy_vm(TestVmLifeCycle.vm_uuid)
         pid = linux.find_vm_pid_by_uuid(TestVmLifeCycle.vm_uuid)
         self.assertTrue(not pid, 'vm[%s] vm still running' % TestVmLifeCycle.vm_uuid)
+
+    @pytest.mark.run(order=4)
+    @pytest_utils.ztest_decorater
+    def test_start_uefi_iso_with_data_volume(self):
+        vm = vm_utils.create_startvm_body_jsonobject()
+        vm.machineType = 'q35'
+        vm.rootVolume.useVirtio = False
+
+        vol_uuid, vol_path = volume_utils.create_empty_volume()
+
+        iso = {
+            "bootOrder": 0,
+            "imageUuid": vol_uuid,
+            "isEmpty": False,
+            "deviceId": 0,
+            "resourceUuid": vol_uuid,
+            "path": vol_path,
+            # "deviceAddress":
+            #     {
+            #         "bus": "0",
+            #         "controller": "0",
+            #         "type": "drive",
+            #         "target": "0",
+            #         "unit": "1"
+            #     }
+        }
+
+        vm.cdRoms = [iso]
+
+        vol_uuid1, vol_path1 = volume_utils.create_empty_volume()
+        volume1 = {
+            "resourceUuid": vol_uuid1,
+            "primaryStorageType": "NFS",
+            "volumeUuid": vol_uuid1,
+            "installPath": vol_path1,
+            "useVirtio": False,
+            "format": "qcow2",
+            "ioThreadId": 0,
+            "cacheMode": "none",
+            "useVirtioSCSI": False,
+            "deviceType": "file",
+            "deviceId": 3,
+            "bootOrder": 0,
+            "physicalBlockSize": 0,
+            "shareable": False,
+            "controllerIndex": 0,
+            "wwn": "0x000f9d3e8f07f623",
+            "type": "Data"
+        }
+
+        vol_uuid2, vol_path2 = volume_utils.create_empty_volume()
+        volume2 = {
+            "resourceUuid": vol_uuid2,
+            "primaryStorageType": "NFS",
+            "volumeUuid": vol_uuid2,
+            "installPath": vol_path2,
+            "useVirtio": False,
+            "format": "qcow2",
+            "ioThreadId": 0,
+            "cacheMode": "none",
+            "useVirtioSCSI": False,
+            "deviceType": "file",
+            "deviceId": 4,
+            "bootOrder": 0,
+            "physicalBlockSize": 0,
+            "shareable": False,
+            "controllerIndex": 0,
+            "wwn": "0x000f9d3e8f07f623",
+            "type": "Data"
+        }
+
+        vm.dataVolumes = [volume1, volume2]
+        vm_utils.create_vm(vm)
+        TestVmLifeCycle.vm_uuid = vm.vmInstanceUuid
+
+        r, output = bash.bash_ro("virsh dumpxml %s" % vm.vmInstanceUuid)
+        self.assertEqual(r, 0, "failed to dumpxml of vm %s" % vm.vmInstanceUuid)
+
+        if 'virt-6.2' in output:
+            sata_disk_list_alias = ['sata0']
+        else:
+            sata_disk_list_alias = ['sata0-0-0', 'sata0-0-0', 'sata0-0-4', 'sata0-0-5']
+
+        for alias in sata_disk_list_alias:
+            self.assertIn(alias, output, "failed to find %s in dumpxml output, vm xml dump %s" % (alias, output))


### PR DESCRIPTION
use hd_device_address_deduplicate and preserve_hd_device_config
 to help explain the address reservation for vm with other
 platform

q35 use address and skip cdrom's hardcode address to avoid
 data volume use same address with cdrom

Resolves: ZSTAC-64171
Resolves: ZSV-9344

Change-Id: I6d7764686e6372707a656f7863726e697475656b
Signed-off-by: AlanJager <ye.zou@zstack.io>

sync from gitlab !5990