### PR TITLE
<fix>[host]: Don't uninstall dependencies during reinstall libvirt

### DIFF
--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -72,7 +72,7 @@ BOND_MODE_ACTIVE_5 = "balance-tlb"
 BOND_MODE_ACTIVE_6 = "balance-alb"
 
 DISTRO_USING_DNF = ['rl84', 'h84r', 'ky10sp1', 'ky10sp2', 'ky10sp3',
-                    'oe2203sp1', 'h2203sp1o']
+                    'ky10sp3.2403', 'oe2203sp1', 'h2203sp1o']
 
 class VendorEnum:
     INTEL = "Intel"


### PR DESCRIPTION
Do not uninstall dependencies during reinstall libvirt on kylin OS to
preventing iscsi configuration changed.

Resolves: ZSTAC-75364

Change-Id: I797477796a6b757175787771746b6a706b6b656b


(cherry picked from commit 5cc85008659a4c9f71e2b74142751a19c3a585c2)

sync from gitlab !6020