### PR TITLE
<fix>[sharedblock]: fix lvmlockctl dump buffer overflow

### DIFF
--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -1,3 +1,4 @@
+import errno
 import functools
 import random
 import os
@@ -2802,6 +2803,18 @@ class LvmlockdStatus(object):
             r, status_line, e = bash.bash_roe("timeout 10 lvmlockctl -i -d")
             if r != 0:
                 raise Exception("dump lvmlockd info failed: retcode %s, error %s" % (r, e))
+
+            if status_line.strip() == "":
+                return
+
+            result_line = status_line.strip().splitlines()[0]
+            if result_line.startswith("result "):
+                rv = int(result_line.split()[-1])
+                if rv == -errno.ENOSPC:
+                    self.failed = True
+                    logger.warn("lvmlockctl dump buffer overflow")
+                    return
+
             for line in filter(lambda l: 'ls_name=lvm_' in l, status_line.splitlines()):
                 ls = self.LockspaceStatus(line)
                 self.ls_status.update({ls.vg_name: ls})


### PR DESCRIPTION
restart lvmlockd when lvmlockctl dump buffer overflow

Resolves/Related: ZSTAC-69011

Change-Id: I72776571697477646d7473786b766e6b62727171

sync from gitlab !6171