### PR TITLE
<fix>[baremetalpxeserver]: add ldlinux.c32 copy for legacy boot support

### DIFF
--- a/baremetalpxeserver/ansible/baremetalpxeserver.py
+++ b/baremetalpxeserver/ansible/baremetalpxeserver.py
@@ -145,6 +145,7 @@ for AR in $archRelease;do
       fi
     fi
     cp -f /opt/zstack-dvd/$AR/isolinux/pxelinux.0 /var/lib/zstack/baremetal/tftpboot/;
+    cp -f /opt/zstack-dvd/$AR/isolinux/ldlinux.c32 /var/lib/zstack/baremetal/tftpboot/;
     cp -f /opt/zstack-dvd/$AR/EFI/BOOT/grubx64.efi /var/lib/zstack/baremetal/tftpboot/EFI/BOOT/ && chmod 755 /var/lib/zstack/baremetal/tftpboot/EFI/BOOT/grubx64.efi;
     cp -f /opt/zstack-dvd/$AR/EFI/BOOT/grubaa64.efi /var/lib/zstack/baremetal/tftpboot/EFI/BOOT/ && chmod 755 /var/lib/zstack/baremetal/tftpboot/EFI/BOOT/grubaa64.efi;
     cp -f /opt/zstack-dvd/$AR/images/pxeboot/{vmlinuz,initrd.img} /var/lib/zstack/baremetal/tftpboot/zstack/$arch/;


### PR DESCRIPTION
Copy ldlinux.c32 from isolinux to tftp boot directory.
This fix enables legacy BIOS boot support in bm provisioning.

Resolves: ZSTAC-73481

Change-Id: I6b7270676a6d73687074686362647669797a6665

sync from gitlab !6174