### PR TITLE
<fix>[migration]: fix vm migration was not canceled after it failed.

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -4111,7 +4111,15 @@ class Vm(object):
 
             def _cancel(self):
                 logger.debug('cancelling vm[uuid:%s] migration' % cmd.vmUuid)
-                vm_block_job_cancel(self.uuid)
+                if storage_migration_required:
+                    try:
+                        vm_block_job_cancel(self.uuid)
+                    except Exception as e:
+                        logger.debug("cancel domain[uuid:%s] blockjob exception: %s" % (cmd.vmUuid, str(e)))
+                try:
+                    self.domain.abortJob()
+                except Exception as e:
+                    logger.debug("cancel domain[uuid:%s] migration exception: %s" % (cmd.vmUuid, str(e)))
 
             def __exit__(self, exc_type, exc_val, exc_tb):
                 super(MigrateDaemon, self).__exit__(exc_type, exc_val, exc_tb)


### PR DESCRIPTION
for live migration of vm, call `domain.abortJob` to terminate the migration after calling `qmp block-job-cancel`

Resolves/Related: ZSTAC-77772
Resolves/Related: ZSTAC-9819

Change-Id: I7a6b6d6a7777706f707978707a636871726d7864

sync from gitlab !6185