### PR TITLE
<fix>[host]: Skip hygon driver reload and filter smi output

### DIFF
--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -2936,9 +2936,7 @@ sysctl -w vm.nr_hugepages=$pageNum
         return jsonobject.dumps(rsp)
 
     def _reload_gpu_driver(self, addr, vendor_name, rsp):
-        vendor_handler_map = {
-            VendorEnum.HAIGUANG: self._reload_haiguang_gpu_driver,
-        }
+        vendor_handler_map = {}
         handler = vendor_handler_map.get(vendor_name)
         if handler:
             handler(addr, rsp)

--- a/kvmagent/kvmagent/plugins/prometheus.py
+++ b/kvmagent/kvmagent/plugins/prometheus.py
@@ -1872,7 +1872,15 @@ def collect_hy_gpu_status():
         check_gpu_status_and_save_gpu_status("HY", metrics)
         return metrics.values()
 
-    gpu_info_json = json.loads(gpu_info)
+    # gpu_info_json = json.loads(gpu_info)
+    start_idx = gpu_info.find('{')
+    end_idx = gpu_info.rfind('}')
+    if start_idx == -1 or end_idx == -1 or start_idx >= end_idx:
+        logger.info("No valid hygon json found in hy-smi output")
+        return metrics.values()
+
+    json_str = gpu_info[start_idx:end_idx + 1].strip().replace(', ,', '')
+    gpu_info_json = json.loads(json_str)
     for card_name, card_data in gpu_info_json.items():
         gpu_serial = card_data['Serial Number']
         pci_device_address = card_data["PCI Bus"].lower()

--- a/zstacklib/zstacklib/utils/gpu.py
+++ b/zstacklib/zstacklib/utils/gpu.py
@@ -1,4 +1,5 @@
 import os
+import threading
 
 from zstacklib.utils import log, linux
 from zstacklib.utils.bash import *
@@ -278,7 +279,7 @@ def get_huawei_gpu_aios_rank_table_dict(npu_ids, iswindows=False):
 
 
 def reload_hygon_gpu_driver_cmd():
-    cmd = "hy-smi --unloaddriver && hy-smi --loaddriver"
+    cmd = "hy-smi --loaddriver"
     return cmd
 
 


### PR DESCRIPTION
Skip attempting to reload hygon gpu drivers.
Filter out related errors from hygon smi output.

Resolves: ZSTAC-78438

Change-Id: I7277767a776d74736c7666626d77757873756361

sync from gitlab !6233