### PR TITLE
<fix>[vm]: MergeSnapshotDaemon __exit__ fails to swallow exceptions as expected

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -2013,6 +2013,7 @@ class MergeSnapshotDaemon(plugin.TaskDaemon):
             logger.debug("libvirt return live merge snapshot failure, but it succeed actually! "
                          "expected volume[install path: %s] backing file is %s. "
                          "check the vm xml meets expectations" % (self.base, current_backing))
+            return True
         else:
             logger.debug("live merge snapshot failed. expected backing %s, actually backing %s. "
                          "check the vm xml does not meet expectations" % (self.base, current_backing))


### PR DESCRIPTION
The logic in the MergeSnapshotDaemon.__exit__method
is intended to swallow exceptions, but it currently does not.
A return Truestatement must be added.

Resolves: ZSV-10042

Change-Id: I7972636b6a68627161626762736c757a79736472

sync from gitlab !6267