### PR TITLE
<fix>[zstackctl]: stop keepalived before restart mariadb

### DIFF
--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -178,9 +178,13 @@ if [ $? -ne 0 ]; then
     sed -i "/\[mysqld\]/a tmpdir=$mysql_tmp_path" $mysql_conf
 fi
 
+([ x`systemctl is-enabled zstack-ha 2>/dev/null` == x"enabled" ] && { systemctl stop keepalived.service || true; }) || true
+
 if [ `systemctl is-active mariadb` != "unknown" ]; then 
     systemctl restart mariadb
 fi
+
+([ x`systemctl is-enabled zstack-ha 2>/dev/null` == x"enabled" ] && { systemctl start keepalived.service || true; }) || true
 '''
 
 mysqldump_skip_tables = "--ignore-table=zstack.VmUsageHistoryVO --ignore-table=zstack.RootVolumeUsageHistoryVO " \


### PR DESCRIPTION
Avoid race condition that mariadb not ready during keepalived's check
interval which will may cause endless mariadb restart loop.

Ignore return code if no keepalived

Resolves: ZSV-9720

Change-Id: I6c636878657276776f7a6f6e6f6d666f6f646562

sync from gitlab !6289