### PR TITLE
<fix>[zstacklib]: modified the pkill sinal

### DIFF
--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -1343,7 +1343,7 @@ def support_blkdiscard(path):
 
 
 def pkill_by_pattern(*args):
-    command = "pkill -9 -f '%s'" % "' '".join(str(arg) for arg in args)
+    command = "pkill -15 -f '%s'" % "' '".join(str(arg) for arg in args)
     return shell.run(command)
 
 


### PR DESCRIPTION
modified the pkill_by_patternfunction
to use SIGTERM (-15) instead of SIGKILL (-9)

Resolves: ZSV-9785
Resolves: ZSV-9989

Change-Id: I74616b756c696962766a6174626462616c756366

sync from gitlab !6338