### PR TITLE
<fix>[host]: skip retrieving SMART information

### DIFF
--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -3965,6 +3965,13 @@ done
     def get_block_devices(self, req):
         rsp = GetBlockDevicesResponse()
 
+        CDROM_PREFIX = '/dev/sr'
+
+        def skip_get_smart_info(name):
+            if name.startswith(CDROM_PREFIX):
+                return True
+            return False
+
         class BlockDevice:
             def __init__(self, name, type, size, model, serial_number, fs_type, mount_point):
                 self.name = name
@@ -4045,7 +4052,8 @@ done
 
             block_dev.partitionTable = get_partition_table(name)
             block_dev.used, block_dev.available, block_dev.usedRatio = get_size_info(name)
-            block_dev.smartPassed, block_dev.smartMessage = get_smart_passed_and_message(name)
+            if not skip_get_smart_info(name):
+                block_dev.smartPassed, block_dev.smartMessage = get_smart_passed_and_message(name)
 
             return block_dev
 


### PR DESCRIPTION
skip retrieving SMART information for optical drives

Resolves: ZSV-9552

Change-Id: I6a70776864786870757961726c746f6f6e797568

sync from gitlab !6355