### PR TITLE
<fix>[qga]: fix guest ssh add/remove auth key

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -12549,7 +12549,7 @@ host side snapshot files chian:
         if LooseVersion(ga_version) < LooseVersion('2.5'):
             raise Exception(('The guest agent version %s less '
                              'than minimum requirement 2.5.0') % ga_version)
-        elif LooseVersion(ga_version) >= LooseVersion('5.2'):
+        elif LooseVersion('100.0') > LooseVersion(ga_version) >= LooseVersion('5.2'):
             ga_add_authorized_keys()
         else:
             leagacy_add_authorized_keys()
@@ -12584,7 +12584,7 @@ host side snapshot files chian:
         if LooseVersion(ga_version) < LooseVersion('2.5'):
             raise Exception(('The guest agent version %s less than '
                              'minimum requirement version 2.5') % ga_version)
-        elif LooseVersion(ga_version) >= LooseVersion('5.2'):
+        elif LooseVersion('100.0') > LooseVersion(ga_version) >= LooseVersion('5.2'):
             ga_remove_authorized_keys()
         else:
             leagacy_remove_authorized_keys()

--- a/zstacklib/zstacklib/utils/qga.py
+++ b/zstacklib/zstacklib/utils/qga.py
@@ -624,7 +624,7 @@ class VmQga(object):
             'username': 'root',
             'keys': [public_key]
         }
-        ret = self.call_qga_command('guest-ssh-add-authorized_keys', args)
+        ret = self.call_qga_command('guest-ssh-add-authorized-keys', args)
         return ret
 
     def guest_ssh_remove_authorized_keys(self, public_key):
@@ -632,5 +632,5 @@ class VmQga(object):
             'username': 'root',
             'keys': [public_key]
         }
-        ret = self.call_qga_command('guest-ssh-remove-authorized_keys', args)
+        ret = self.call_qga_command('guest-ssh-remove-authorized-keys', args)
         return ret


### PR DESCRIPTION
typo error

Resolves: ZSV-9757

Change-Id: I6868776c60741d65af9544759aa7e3a508571a2f
(cherry picked from commit 7e12b78c9779c02a106a545cf7cd4d07bf28f523)

(cherry picked from commit 5ce0bf3547a6d46c41ffbb2d612765140d4e8321)

sync from gitlab !6371