### PR TITLE
<fix>[host]: add dependent devices support for PCI device group

### DIFF
--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -806,6 +806,8 @@ class PciDeviceTO(object):
         self.mdevSpecifications = []
         self.rev = ""
         self.addonInfo = {}
+        self.dependentDevices = []
+
 
 class MttyDeviceTO(object):
     def __init__(self):
@@ -2654,6 +2656,7 @@ done
                 to.rev = ids.get('Rev', '')
 
             to.name = "%s_%s" % (subvendor_name if subvendor_name else vendor_name, device_name)
+            to.dependentDevices = pci.collect_pci_devices_with_dependencies(to.pciDeviceAddress)
 
             def _set_pci_to_type():
                 gpu_vendors = ["NVIDIA", "AMD", "Haiguang", "Intel", "Vastai"]

--- a/zstacklib/zstacklib/utils/pci.py
+++ b/zstacklib/zstacklib/utils/pci.py
@@ -213,3 +213,13 @@ def get_pci_device_ids():
 def get_pci_device_names():
     # Get names using -Dmmv (without 'nn' to get full names)
     return bash_roe("lspci -Dmmv")
+
+
+def collect_pci_devices_with_dependencies(pciDeviceAddress):
+    pcis = []
+    device_path = os.path.join("/sys/bus/pci/devices/", pciDeviceAddress)
+    for item in os.listdir(device_path):
+        if item.startswith("consumer:pci:"):
+            dependent_addr = item.replace("consumer:pci:", "")
+            pcis.append(dependent_addr)
+    return pcis


### PR DESCRIPTION
Add `dependentDevices` field to `PciDeviceTO` to
store related device dependencies.

Resolves: ZSTAC-79394

Change-Id: I667667616a796d75676a6c6d6671766c70746375

sync from gitlab !6378