### PR TITLE
<fix>[sharedblock]: support enabling/disabling sblk discard lv

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -944,20 +944,20 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         if cmd.folder:
             raise Exception("not support this operation")
 
-        self.do_delete_bits(cmd.path)
+        self.do_delete_bits(cmd.path, discard=cmd.issueDiscards)
 
         rsp.totalCapacity, rsp.availableCapacity = lvm.get_vg_size(cmd.vgUuid)
         rsp.lunCapacities = lvm.get_lun_capacities_from_vg(cmd.vgUuid, self.vgs_path_and_wwid)
         return jsonobject.dumps(rsp)
 
-    def do_delete_bits(self, path):
+    def do_delete_bits(self, path, discard=lvm.LvDiscardStrategy.NEVER):
         install_abs_path = translate_absolute_path_from_install_path(path)
         if lvm.has_lv_tag(install_abs_path, IMAGE_TAG):
             logger.info('deleting lv image: ' + install_abs_path)
             lvm.delete_image(install_abs_path, IMAGE_TAG)
         else:
             logger.info('deleting lv volume: ' + install_abs_path)
-            lvm.delete_lv(install_abs_path)
+            lvm.delete_lv(install_abs_path, discard=discard)
 
     @staticmethod
     def get_total_required_size(abs_path):

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -111,6 +111,11 @@ class VmStruct(object):
                                 load_source(e3)
                         return
 
+class LvDiscardStrategy(object):
+    NEVER = "never"
+    ALWAYS = "always"
+    AUTO = "auto"
+
 class LvmlockdLockType(object):
     NULL = 0
     SHARE = 1
@@ -1592,9 +1597,12 @@ def _deactive_lv(path, raise_exception=True):
             logger.warn("find lv used by other process:\n%s" % str(o))
         raise
 
+def get_lv_discard_options(path, discard):
+    discard = discard == LvDiscardStrategy.ALWAYS or (discard == LvDiscardStrategy.AUTO and not is_slow_discard_lv(path))
+    return " --config 'devices {issue_discards=%s}' " % ("1" if discard else "0")
 
 @bash.in_bash
-def delete_lv(path, raise_exception=True, deactive=True):
+def delete_lv(path, raise_exception=True, deactive=True, discard=LvDiscardStrategy.NEVER):
     logger.debug("deleting lv %s" % path)
     if deactive:
         _deactive_lv(path, False)
@@ -1604,9 +1612,9 @@ def delete_lv(path, raise_exception=True, deactive=True):
     if not lv_exists(path):
         return
     if raise_exception:
-        o = bash.bash_errorout("%s -y %s" % (subcmd("lvremove"), path))
+        o = bash.bash_errorout("%s -y %s %s" % (subcmd("lvremove"), path, get_lv_discard_options(path, discard)))
     else:
-        o = bash.bash_o("%s -y %s" % (subcmd("lvremove"), path))
+        o = bash.bash_o("%s -y %s %s " % (subcmd("lvremove"), path, get_lv_discard_options(path, discard)))
     return o
 
 


### PR DESCRIPTION
support enabling/disabling sblk discard lv, which is controlled by global config(default value is never) and requires storage to support discard

Resolves: ZSTAC-73387
Resolves: ZSV-8769

Change-Id: I6b6c6461776e71797567627a6766796176756879

sync from gitlab !6441