### PR TITLE
<fix>[zstacklib]: fix syntax in linux.ignore_error_retry

### DIFF
--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -211,6 +211,9 @@ def ignore_error_retry(times=3, sleep_time=3, return_after_exception=None):
             logger.warn(str(orig_except))
             return return_after_exception
 
+        return inner
+    return wrap
+
 def retry_with_check(handler=None):
     def wrap(f):
         @functools.wraps(f)


### PR DESCRIPTION
This patch is for zsv_4.10.28

Resolves: ZSV-10598

Change-Id: I61797877706c7767717779786a6c796862636d69

sync from gitlab !6444