### PR TITLE
<fix>[ovnha]: ovn-controller need to clear it's cache connect to new cluster

### DIFF
--- a/kvmagent/kvmagent/plugins/ovn.py
+++ b/kvmagent/kvmagent/plugins/ovn.py
@@ -498,6 +498,16 @@ class OvnNetworkPlugin(kvmagent.KvmAgent):
         if r != 0:
             rsp.success = False
             rsp.error = "Failed to set ovn-remote connection"
+            return jsonobject.dumps(rsp)
+
+        if cmd["refreshCache"] is True:
+            controllerCtl = ovn.ControllerCtl()
+            r = controllerCtl.resetOvnControllerClusterIndex()
+            if r != 0:
+                rsp.success = False
+                rsp.error = "Failed to clear ovn-controller cache"
+                return jsonobject.dumps(rsp)
+
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror

--- a/zstacklib/zstacklib/utils/ovn.py
+++ b/zstacklib/zstacklib/utils/ovn.py
@@ -24,6 +24,7 @@ from zstacklib.utils.lvm import lvm_check_operation
 
 logger = log.get_logger(__name__)
 
+AppCtlBin = "/usr/bin/ovn-appctl"
 CtlBin = "/usr/bin/ovs-vsctl "
 DevBindBin = "/usr/bin/dpdk-devbind.py "
 OVS_DPDK_SRC_PATH = "/var/run/openvswitch/"
@@ -226,6 +227,23 @@ def restoreNicDriver(pciAddressList):
 
 
     return 0, ""
+
+class ControllerCtl(object):
+    def __init__(self):
+        pass
+
+    @bash.in_bash
+    def resetOvnControllerClusterIndex(self):
+        ret = 0
+        try:
+            cmd = '{cmd} -t ovn-controller sb-cluster-state-reset'.format(cmd=AppCtlBin)
+            ret = bash.bash_r(cmd)
+        except Exception as err:
+            logger.error("ovn controller reset idl cache error when switching "
+                         "to new database, %s", str(err))
+            ret = 1
+        finally:
+            return ret
 
 class VsCtl(object):
     def __init__(self):


### PR DESCRIPTION
when switch to a new cluster, ovn-controller force clear it's cache.

Resolves/Related: ZSTAC-80312
Change-Id: a5bc9797-b151-4ca3-b786-d04def30da94

sync from gitlab !6467