### PR TITLE
<fix>[vhost]:fix start vm failed

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -3039,6 +3039,20 @@ class Vm(object):
             return
         e(volume_xml_obj, 'serial', vol_uuid)
 
+
+    def validate_vhost_attach_requirements(self):
+        hugepage_enabled = False
+        mem_shared = False
+        if self.domain_xmlobject.has_element("memoryBacking"):
+            memory_backing = self.domain_xmlobject.memoryBacking
+            hugepage_enabled = memory_backing.has_element("hugepages")
+            mem_shared = memory_backing.has_element("access") and memory_backing.access.mode_ == "shared"
+
+        if not hugepage_enabled or not mem_shared:
+            raise Exception("unable to attach the vhost volume online: memory access mode is not shared or hugepage not enabled. "
+                            "Please shutdown and try again.")
+
+
     def _attach_data_volume(self, volume, addons):
         Vm.check_device_exceed_limit(volume.deviceId)
 
@@ -3256,6 +3270,7 @@ class Vm(object):
         elif volume.deviceType == 'spool':
             disk_element = spool_volume()
         elif volume.deviceType == 'vhost':
+            self.validate_vhost_attach_requirements()
             disk_element = vhost_volume()
         elif volume.deviceType == 'cbd':
             disk_element = cbd_volume()


### PR DESCRIPTION
1.When the cluster where the vm is located has attached vhost primary storage, regardless of whether vhost volume is currently attached for vm, we will enable hugepage memory and set the memory access mode to shared.
2.Check hugepage and shared memory before attaching vhost volume to vm online.

Resolves/Related: ZSTAC-80546

Change-Id: I74716b65706f6f717a6d626a62757265796c7875

sync from gitlab !6485