### PR TITLE
<fix>[host_plugin]: add cpuFeatureMd5 to detect CPU feature changes

### DIFF
--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -108,6 +108,7 @@ class HostFactResponse(kvmagent.AgentResponse):
         self.virtualizerInfo = vm_plugin.VirtualizerInfoTO()
         self.iscsiInitiatorName = None
         self.deployMode = None
+        self.cpuFeatureMd5 = None
 
 class SetupMountablePrimaryStorageHeartbeatCmd(kvmagent.AgentCommand):
     def __init__(self):
@@ -1336,6 +1337,12 @@ class HostPlugin(kvmagent.KvmAgent):
         rsp.virtualizerInfo.uuid = self.config.get(kvmagent.HOST_UUID)
         rsp.virtualizerInfo.virtualizer = "qemu-kvm"
         rsp.virtualizerInfo.version = qemu.get_version_from_exe_file(qemu.get_path())
+
+        # get CPU feature MD5 for migration compatibility check
+        sh_cmd = shell.ShellCmd('virsh capabilities | virsh cpu-baseline /dev/stdin')
+        sh_cmd(False)
+        if sh_cmd.return_code == 0 and sh_cmd.stdout.strip():
+            rsp.cpuFeatureMd5 = hashlib.md5(sh_cmd.stdout.strip().encode()).hexdigest()
 
         return jsonobject.dumps(rsp)
 


### PR DESCRIPTION
Add cpuFeatureMd5 field to HostFactResponse, computed from
virsh cpu-baseline output. This enables MN to detect CPU feature
changes even when cpuModelName remains unchanged.

Resolves: ZSTAC-76397

Change-Id: I627261656676777171616d66666577656d697775

sync from gitlab !6560