### PR TITLE
<fix>[zstacklib]: add taskUuid to log context for full-link tracing

### DIFF
--- a/kvmagent/kvmagent/plugins/ha_plugin.py
+++ b/kvmagent/kvmagent/plugins/ha_plugin.py
@@ -169,9 +169,8 @@ class AbstractHaFencer(object):
         threads = []
         for fencer in self.run_fencer_list:
             if fencer in self.ha_fencer:
-                thread = threading.Thread(target=self.ha_fencer[fencer].exec_fencer)
-                thread.start()
-                threads.append(thread)
+                thread_obj = thread.ThreadFacade.run_in_thread(target=self.ha_fencer[fencer].exec_fencer)
+                threads.append(thread_obj)
 
         for t in threads:
             t.join()

--- a/kvmagent/kvmagent/plugins/physical_bond_monitor.py
+++ b/kvmagent/kvmagent/plugins/physical_bond_monitor.py
@@ -9,6 +9,7 @@ from zstacklib.utils import jsonobject
 from zstacklib.utils import log
 from zstacklib.utils import linux
 from zstacklib.utils import bash
+from zstacklib.utils import thread
 
 try:
     unicode
@@ -395,7 +396,14 @@ class PhysicalBondMonitor(kvmagent.KvmAgent):
         if self._worker and self._worker.is_alive():
             return
         self._stop_event.clear()
-        self._worker = threading.Thread(target=self._run_loop, name='PhysicalBondMonitor')
+
+        task_uuid = log.get_task_uuid()
+        def _run_with_context():
+            if task_uuid:
+                log.set_task_uuid(task_uuid)
+            self._run_loop()
+
+        self._worker = threading.Thread(target=_run_with_context, name='PhysicalBondMonitor')
         self._worker.daemon = True
         self._worker.start()
 

--- a/kvmagent/kvmagent/plugins/physical_memory_monitor.py
+++ b/kvmagent/kvmagent/plugins/physical_memory_monitor.py
@@ -4,6 +4,7 @@ from zstacklib.utils import jsonobject
 from zstacklib.utils import lock
 from zstacklib.utils import log
 from zstacklib.utils import bash
+from zstacklib.utils import thread
 import time
 import threading
 
@@ -77,8 +78,7 @@ class PhysicalMemoryMonitor(kvmagent.KvmAgent):
 			self.monitor_thread.join()
 
 		self.state = True
-		self.monitor_thread = threading.Thread(target=_monitor_error)
-		self.monitor_thread.start()
+		self.monitor_thread = thread.ThreadFacade.run_in_thread(target=_monitor_error)
 	
 	def send_physical_memory_ecc_error_alarm_to_mn(self, detail):
 		physical_memory_ecc_error_alarm = PhysicalMemoryECCErrorAlarm()

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -750,8 +750,11 @@ class QueryVmLatenciesThread(threading.Thread):
         self.uuids = uuids
         self.times = times
         self.res = []
+        self.task_uuid = log.get_task_uuid()
 
     def run(self):
+        if self.task_uuid:
+            log.set_task_uuid(self.task_uuid)
         self.res = self.func(self.uuids, self.times)
 
     def getResult(self):

--- a/zstacklib/zstacklib/utils/http.py
+++ b/zstacklib/zstacklib/utils/http.py
@@ -82,12 +82,18 @@ class SyncUriHandler(object):
 
     @cherrypy.expose
     def index(self):
-        req = Request.from_cherrypy_request(cherrypy.request)
-        logger.debug('sync http call: %s' % req.body)
-        rsp = self._do_index(req)
-        self._check_response(rsp)
-        logger.debug("sync http reply to %s: \"%s\"" % (cherrypy.url(), rsp))
-        return rsp
+        # sync request does not have taskuuid in design, use function name for tracking
+        task_uuid = self.uri_obj.func.__name__
+        log.set_task_uuid(task_uuid)
+        try:
+            req = Request.from_cherrypy_request(cherrypy.request)
+            logger.debug('sync http call: %s' % req.body)
+            rsp = self._do_index(req)
+            self._check_response(rsp)
+            logger.debug("sync http reply to %s: \"%s\"" % (cherrypy.url(), rsp))
+            return rsp
+        finally:
+            log.set_task_uuid(None)
 
 class RawUriHandler(object):
     def __init__(self, uri_obj):
@@ -96,18 +102,24 @@ class RawUriHandler(object):
     @cherrypy.config(**{'response.timeout': 7200}) # default is 300s
     @cherrypy.expose
     def index(self):
-        logger.debug('raw http handler: %s' % self.uri_obj.uri)
+        # sync request does not have taskuuid in design, use function name for tracking
+        task_uuid = self.uri_obj.func.__name__
+        log.set_task_uuid(task_uuid)
         try:
+            logger.debug('raw http handler: %s' % self.uri_obj.uri)
             return self.uri_obj.func(cherrypy.request)
+        except cherrypy.HTTPError as e:
+            content = traceback.format_exc()
+            logger.warn('[WARN]: %s]' % content)
+            cherrypy.response.status = e.status
+            return e._message
         except Exception as e:
             content = traceback.format_exc()
             logger.warn('[WARN]: %s]' % content)
-            if isinstance(e, cherrypy.HTTPError):
-                cherrypy.response.status = e.status
-                return e._message
-            else:
-                cherrypy.response.status = 500
-                return str(e)
+            cherrypy.response.status = 500
+            return str(e)
+        finally:
+            log.set_task_uuid(None)
 
 class RawUriStreamHandler(object):
     def __init__(self, uri_obj):
@@ -116,14 +128,19 @@ class RawUriStreamHandler(object):
     @cherrypy.config(**{'response.timeout': 7200}) # default is 300s
     @cherrypy.expose
     def index(self, **kwargs):
-        logger.debug('raw http handler: %s' % self.uri_obj.uri)
+        # sync request does not have taskuuid in design, use function name for tracking
+        task_uuid = self.uri_obj.func.__name__
+        log.set_task_uuid(task_uuid)
         try:
+            logger.debug('raw http handler: %s' % self.uri_obj.uri)
             return self.uri_obj.func(cherrypy.request, cherrypy.response, **kwargs)
         except Exception as e:
             content = traceback.format_exc()
             logger.warn('[WARN]: %s]' % content)
             cherrypy.response.status = 500
             return str(e)
+        finally:
+            log.set_task_uuid(None)
 
     index._cp_config = {'response.stream': True}
 
@@ -139,6 +156,7 @@ class AsyncUirHandler(SyncUriHandler):
 
     @thread.AsyncThread
     def _run_index(self, task_uuid, request):
+        log.set_task_uuid(task_uuid)
         callback_uri = self._get_callback_uri(request)
         with self.HANDLER_DICT_LOCK:
             if task_uuid in self.HANDLER_DICT:
@@ -188,6 +206,7 @@ class AsyncUirHandler(SyncUriHandler):
             raise cherrypy.HTTPError(400, err)
 
         task_uuid = cherrypy.request.headers[TASK_UUID]
+        log.set_task_uuid(task_uuid)
         req = Request.from_cherrypy_request(cherrypy.request)
 
         filter_body = log.mask_sensitive_field(self.uri_obj.cmd, req.body)

--- a/zstacklib/zstacklib/utils/log.py
+++ b/zstacklib/zstacklib/utils/log.py
@@ -7,10 +7,41 @@ import sys
 import os.path
 import gzip
 import shutil
+import threading
 
 import simplejson
 from concurrentlog_handler import ConcurrentRotatingFileHandler
 from random import randint
+
+class ZstackLoggingContext(object):
+    def __init__(self):
+        self.tl = threading.local()
+
+    def set_task_uuid(self, uuid):
+        self.tl.task_uuid = uuid
+
+    def get_task_uuid(self):
+        try:
+            return self.tl.task_uuid
+        except AttributeError:
+            return None
+
+_zstack_logging_context = ZstackLoggingContext()
+
+def set_task_uuid(task_uuid):
+    _zstack_logging_context.set_task_uuid(task_uuid)
+
+def get_task_uuid():
+    return _zstack_logging_context.get_task_uuid()
+
+class TaskUuidFilter(logging.Filter):
+    def filter(self, record):
+        uuid = get_task_uuid()
+        if uuid:
+            record.task_uuid = uuid
+        else:
+            record.task_uuid = 'None'
+        return True
 
 class ZstackRotatingFileHandler(ConcurrentRotatingFileHandler):
     def __init__(self, filename, **kws):
@@ -90,7 +121,7 @@ class LogConfig(object):
     instance = None
 
     LOG_FOLER = '/var/log/zstack'
-    LOG_FORMAT = '%(asctime)s %(thread)d %(levelname)s [%(name)s] %(message)s'
+    LOG_FORMAT = '%(asctime)s %(thread)d [task=%(task_uuid)s] %(levelname)s [%(name)s] %(message)s'
 
     def __init__(self):
         if not os.path.exists(self.LOG_FOLER):
@@ -123,6 +154,7 @@ class LogConfig(object):
             return logger
 
         logger.setLevel(logging.DEBUG)
+        logger.addFilter(TaskUuidFilter())
         max_rotate_handler = ZstackRotatingFileHandler(self.log_path, maxBytes=30*1024*1024, backupCount=30)
         formatter = logging.Formatter(self.LOG_FORMAT)
         max_rotate_handler.setFormatter(formatter)

--- a/zstacklib/zstacklib/utils/progress_report.py
+++ b/zstacklib/zstacklib/utils/progress_report.py
@@ -11,8 +11,11 @@ class WatchThread_1(threading.Thread):
         threading.Thread.__init__(self)
         self.func = func
         self.keepRunning = True
+        self.task_uuid = log.get_task_uuid()
 
     def run(self):
+        if self.task_uuid:
+            log.set_task_uuid(self.task_uuid)
         logger.debug("watch_thread_1: %s start" % self.__class__)
         try:
             synced = 0

--- a/zstacklib/zstacklib/utils/thread.py
+++ b/zstacklib/zstacklib/utils/thread.py
@@ -25,7 +25,13 @@ class AsyncThread(object):
 class ThreadFacade(object):
     @staticmethod
     def run_in_thread(target, args=(), kwargs={}):
+        task_uuid = log.get_task_uuid()
+        if not task_uuid:
+            task_uuid = target.__name__
+
         def safe_run(*sargs, **skwargs):
+            if task_uuid:
+                log.set_task_uuid(task_uuid)
             try:
                 target(*sargs, **skwargs)
             except Exception as e:


### PR DESCRIPTION
    1. Why is this change necessary?
       Currently, logs in zstacklib agents (like kvmagent) lack task context information.
       When debugging asynchronous tasks that span across multiple threads or HTTP requests,
       it is difficult to correlate logs belonging to the same task ID.

    2. How does it address the problem?
       - Introduce ZstackLoggingContext using threading.local to store taskUuid.
       - Add TaskUuidFilter to inject taskUuid into log records.
       - Update LOG_FORMAT to include '[task=%(task_uuid)s]'.
       - Modify http.py to extract 'taskuuid' header and initialize context for AsyncUriHandler,
         and clear context for Sync/Raw handlers to prevent pollution.
       - Update ThreadFacade to automatically propagate taskUuid to child threads.
       - Update plugins (ha_plugin, vm_plugin, etc.) that used raw threading.Thread to ensure context
      propagation.

    3. Are there any side effects?
       - Log format is changed to include '[task=UUID]' or '[task=None]'.
       - Minor performance overhead due to thread-local access and filter execution on each log emit.

      Resolves: ZSTAC-81483

    Change-Id: I6874616f7275696c616d766970796f6c6d757572

sync from gitlab !6564