### PR TITLE
<fix>[kvm]: strip spice graphics from migration destination XML

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -4158,6 +4158,20 @@ class Vm(object):
                 devices.insert(parent_index, new_disk)
                 xml_changed = True
 
+        # Remove spice graphics and related channels to prevent migration
+        # failure when target host uses a newer qemu that does not support spice
+        for graphics in list(tree.iterfind('devices/graphics')):
+            if graphics.attrib.get('type') == 'spice':
+                devices.remove(graphics)
+                xml_changed = True
+                logger.debug('removed spice graphics from migration destination XML for vm[uuid:%s]' % self.uuid)
+
+        for channel in list(tree.iterfind('devices/channel')):
+            if channel.attrib.get('type') == 'spicevmc':
+                devices.remove(channel)
+                xml_changed = True
+                logger.debug('removed spicevmc channel from migration destination XML for vm[uuid:%s]' % self.uuid)
+
         if xml_changed:
             return migrate_disks.keys(), etree.tostring(tree.getroot())
         else:


### PR DESCRIPTION
## Summary
- ZSTAC-75321: qemu 2.12 创建的 VM 含 spice graphics，迁移到 qemu 6.2 时报 spice not enabled
- 修复：_build_domain_new_xml() 中自动移除 spice graphics 和 spicevmc channel，确保跨版本迁移兼容

## Files Changed
- `vm_plugin.py` — 迁移目标 XML 去除 spice graphics/channel

Resolves: ZSTAC-75321

sync from gitlab !6614