### PR TITLE
<fix>[ha]: skip virsh check when no VM processes on faulted NIC

### DIFF
--- a/kvmagent/kvmagent/plugins/ha_plugin.py
+++ b/kvmagent/kvmagent/plugins/ha_plugin.py
@@ -248,6 +248,11 @@ class PhysicalNicFencer(AbstractHaFencer):
             return vm_use_falut_nic_pids_dict, falut_nic
         logger.debug("nics[%s] is down" % ",".join(falut_nic))
 
+        vm_in_process_uuid_list = find_vm_uuid_list_by_process()
+        if len(vm_in_process_uuid_list) == 0:
+            logger.debug("no vm processes running, skip virsh check for faulted nics")
+            return vm_use_falut_nic_pids_dict, falut_nic
+
         r = bash.bash_r("timeout 5 virsh list")
         if r == 0:
             vm_use_falut_nic_pids_dict = self.find_vm_use_falut_nic_with_virsh(falut_nic)


### PR DESCRIPTION
Resolves: ZSTAC-79557

When PhysicalNicFencer detects a NIC in DOWN state, it unconditionally calls `virsh list` (expensive) even when no VM processes are running on the host. This causes unnecessary performance overhead on hosts with faulted NICs but no VMs.

Fix: Add early-exit using `find_vm_uuid_list_by_process()` (lightweight /proc scan) before calling virsh. If no VM processes exist, skip virsh entirely.

Target: 5.5.6

sync from gitlab !6631