### PR TITLE
<fix>[vm]: ZSTAC-37134 add size-limited vmcore dump for all crash types

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -101,6 +101,8 @@ GUEST_TOOLS_ISO_PATH = "/var/lib/zstack/guesttools/GuestTools.iso"
 GUEST_TOOLS_ISO_LINUX_PATH = "/var/lib/zstack/guesttools/GuestTools_linux.iso"
 
 VM_CORE_DUMP_DIR = "/var/lib/zstack/kvmcoredump"
+VM_CORE_DUMP_DIR_MAX_SIZE = 8 * 1024 * 1024 * 1024   # 8 GB total dir limit
+VM_CORE_DUMP_MIN_FREE_DISK = 10 * 1024 * 1024 * 1024  # require 10 GB free before dumping
 
 SYSTEM_VIRTIO_DRIVER_PATHS = {
     'VFD_X86' : '/var/lib/zstack/virtio-drivers/virtio-win_x86.vfd',
@@ -8390,6 +8392,18 @@ class VmPlugin(kvmagent.KvmAgent):
 
     def _dump(self, vm_instance_uuid):
         try:
+            if not os.path.exists(VM_CORE_DUMP_DIR):
+                os.makedirs(VM_CORE_DUMP_DIR)
+            free_disk = linux.get_free_disk_size(VM_CORE_DUMP_DIR)
+            if free_disk < VM_CORE_DUMP_MIN_FREE_DISK:
+                logger.warn("skip vmcore dump for vm[uuid:%s]: insufficient free disk space "
+                            "(%d bytes free, need %d bytes)" % (vm_instance_uuid, free_disk, VM_CORE_DUMP_MIN_FREE_DISK))
+                return
+            dir_size = linux.get_filesystem_folder_size(VM_CORE_DUMP_DIR)
+            if dir_size >= VM_CORE_DUMP_DIR_MAX_SIZE:
+                logger.warn("skip vmcore dump for vm[uuid:%s]: dump dir already at limit "
+                            "(%d bytes)" % (vm_instance_uuid, dir_size))
+                return
             vm = get_vm_by_uuid(vm_instance_uuid)
             vm.dump_guest_memory("%s/%s" % (VM_CORE_DUMP_DIR, vm_instance_uuid))
             logger.debug("successfully dump vm[uuid:%s] guest memory" % vm_instance_uuid)
@@ -12197,6 +12211,7 @@ host side snapshot files chian:
 
         clean_stale_vm_vnc_port_chain()
 
+        @thread.AsyncThread
         def monitor_vmcore_dump_path():
             while True:
                 try:
@@ -12205,7 +12220,7 @@ host side snapshot files chian:
                         os.makedirs(vmcore_dump_path)
 
                     dir_size = linux.get_filesystem_folder_size(vmcore_dump_path)
-                    if dir_size > 2 * 4 * 1024 * 1024 * 1024:
+                    if dir_size > VM_CORE_DUMP_DIR_MAX_SIZE:
                         logger.debug("vmcore dump path size is %s, clean up it" % dir_size)
                         linux.rm_dir_force(vmcore_dump_path)
                 except:
@@ -12213,6 +12228,8 @@ host side snapshot files chian:
                     logger.warn(content)
                 finally:
                     time.sleep(600)
+
+        monitor_vmcore_dump_path()
 
 
 
@@ -12757,14 +12774,20 @@ host side snapshot files chian:
 
             vm_uuid = dom.name()
 
+            logger.info('crashed event received from vm[uuid:%s]' % vm_uuid)
+            logger.info('detail is %s, opaque is %s' % (detail, opaque))
+
+            @thread.AsyncThread
+            def dump_on_crash():
+                self._dump(vm_uuid)
+
+            dump_on_crash()
+
             # this is an operation outside zstack, report it
             url = self.config.get(kvmagent.SEND_COMMAND_URL)
             if not url:
                 logger.warn('cannot find SEND_COMMAND_URL, unable to report crash event of vm[uuid:%s]' % vm_uuid)
                 return
-
-            logger.info('crashed event recieved from vm[uuid:%s]' % vm_uuid)
-            logger.info('detail is %s, opaque is %s' % (detail, opaque))
 
             @thread.AsyncThread
             def report_to_management_node():

--- a/kvmagent/kvmagent/test/vm_plugin_testsuite/test_vm_dump.py
+++ b/kvmagent/kvmagent/test/vm_plugin_testsuite/test_vm_dump.py
@@ -4,6 +4,7 @@ from kvmagent.test.utils.stub import *
 from zstacklib.test.utils import misc
 from zstacklib.utils import linux
 from unittest import TestCase
+from unittest.mock import patch, MagicMock
 
 init_kvmagent()
 vm_utils.init_vm_plugin()
@@ -36,3 +37,42 @@ class TestVmPlugin(TestCase, vm_utils.VmPluginTestStub):
         self.assertTrue(dir_size > 0, "core dump file %s size is 0" % vmcore_dump_path)
         self.assertTrue(dir_size < 2 * 1024 * 1024 * 1024, "core dump file %s size is too large" % vmcore_dump_path)
         self._destroy_vm(vm_uuid)
+
+    def test_dump_skipped_when_insufficient_disk_space(self):
+        """_dump() must be skipped when free disk space is below VM_CORE_DUMP_MIN_FREE_DISK."""
+        plugin = vm_plugin.VmPlugin()
+        mock_vm = MagicMock()
+
+        with patch('kvmagent.plugins.vm_plugin.os.path.exists', return_value=True), \
+             patch('kvmagent.plugins.vm_plugin.linux.get_free_disk_size', return_value=1 * 1024 * 1024 * 1024), \
+             patch('kvmagent.plugins.vm_plugin.linux.get_filesystem_folder_size', return_value=0), \
+             patch('kvmagent.plugins.vm_plugin.get_vm_by_uuid', return_value=mock_vm):
+            plugin._dump('test-vm-uuid')
+            mock_vm.dump_guest_memory.assert_not_called()
+
+    def test_dump_skipped_when_dump_dir_at_limit(self):
+        """_dump() must be skipped when dump dir total size reaches VM_CORE_DUMP_DIR_MAX_SIZE."""
+        plugin = vm_plugin.VmPlugin()
+        mock_vm = MagicMock()
+
+        with patch('kvmagent.plugins.vm_plugin.os.path.exists', return_value=True), \
+             patch('kvmagent.plugins.vm_plugin.linux.get_free_disk_size',
+                   return_value=vm_plugin.VM_CORE_DUMP_MIN_FREE_DISK + 1), \
+             patch('kvmagent.plugins.vm_plugin.linux.get_filesystem_folder_size',
+                   return_value=vm_plugin.VM_CORE_DUMP_DIR_MAX_SIZE), \
+             patch('kvmagent.plugins.vm_plugin.get_vm_by_uuid', return_value=mock_vm):
+            plugin._dump('test-vm-uuid')
+            mock_vm.dump_guest_memory.assert_not_called()
+
+    def test_dump_proceeds_when_disk_ok(self):
+        """_dump() must call dump_guest_memory when disk space is sufficient."""
+        plugin = vm_plugin.VmPlugin()
+        mock_vm = MagicMock()
+
+        with patch('kvmagent.plugins.vm_plugin.os.path.exists', return_value=True), \
+             patch('kvmagent.plugins.vm_plugin.linux.get_free_disk_size',
+                   return_value=vm_plugin.VM_CORE_DUMP_MIN_FREE_DISK + 1), \
+             patch('kvmagent.plugins.vm_plugin.linux.get_filesystem_folder_size', return_value=0), \
+             patch('kvmagent.plugins.vm_plugin.get_vm_by_uuid', return_value=mock_vm):
+            plugin._dump('test-vm-uuid')
+            mock_vm.dump_guest_memory.assert_called_once()


### PR DESCRIPTION
## Summary
- `_dump()`: Added disk space guards (10GB free minimum, 8GB dir size limit)
- `_vm_crashed_event()`: Added async `_dump()` call — vmcore now generated for ALL crash types, not just blue screen
- `monitor_vmcore_dump_path()`: Fixed — added `@AsyncThread` decorator and actual invocation
- Replaced magic numbers with named constants `VM_CORE_DUMP_DIR_MAX_SIZE` / `VM_CORE_DUMP_MIN_FREE_DISK`
- Added 3 unit tests for disk space check scenarios

## Root Cause
1. `_vm_crashed_event` never called `_dump()` — dumps only happened via `stop_vm(debug=True)`
2. `monitor_vmcore_dump_path` cleanup thread was defined but never started (no decorator, no call)

## Test
- Python syntax check pass
- 3 new unit tests (mock-based) for skip/proceed scenarios

Resolves: ZSTAC-37134

sync from gitlab !6636