### PR TITLE
<refactor>[consoleproxy/zstacklib]: ZSTAC-67411 split consoleproxy into plugins + move VmGpuStatus

### DIFF
--- a/consoleproxy/consoleproxy/console_proxy_agent.py
+++ b/consoleproxy/consoleproxy/console_proxy_agent.py
@@ -1,34 +1,35 @@
 from zstacklib.utils import plugin
 from zstacklib.utils import http
-from zstacklib.utils import shell
 from zstacklib.utils import log
 from zstacklib.utils import jsonobject
 from zstacklib.utils import daemon
 from zstacklib.utils import linux
 from zstacklib.utils import filedb
 from zstacklib.utils import lock
-from zstacklib.utils.bash import *
+from zstacklib.utils.bash import bash_roe
 import os
 import os.path
-import atexit
 import time
 import traceback
 import pprint
 import functools
-import sys
-import subprocess
-import threading
+
+from consoleproxy.plugins.vnc import ConsoleTokenFile, ConsoleTokenFileController, VncPlugin
+from consoleproxy.plugins.nginx import NginxPlugin
 
 logger = log.get_logger(__name__)
+
 
 class AgentResponse(object):
     def __init__(self, success=True, error=None):
         self.success = success
         self.error = error if error else ''
 
+
 class AgentCommand(object):
     def __init__(self):
         pass
+
 
 class EstablishProxyCmd(AgentCommand):
     def __init__(self):
@@ -43,11 +44,13 @@ class EstablishProxyCmd(AgentCommand):
         self.idleTimeout = None
         self.tlsVersion = None
 
+
 class EstablishProxyRsp(AgentResponse):
     def __init__(self):
         super(EstablishProxyRsp, self).__init__()
         self.proxyPort = None
         self.token = None
+
 
 class CheckAvailabilityCmd(AgentCommand):
     def __init__(self):
@@ -62,10 +65,12 @@ class CheckAvailabilityCmd(AgentCommand):
         self.proxyIdentity = None
         self.expiredDate = None
 
+
 class CheckAvailabilityRsp(AgentResponse):
     def __init__(self):
         super(CheckAvailabilityRsp, self).__init__()
         self.available = None
+
 
 def replyerror(func):
     @functools.wraps(func)
@@ -83,8 +88,10 @@ def replyerror(func):
 
     return wrap
 
+
 class ConsoleProxyError(Exception):
     ''' console proxy error '''
+
 
 class ConsoleProxyAgent(object):
 
@@ -103,7 +110,6 @@ class ConsoleProxyAgent(object):
 
     BM2_INSTANCE_NGINX_CONF_DIR = "/var/lib/zstack/nginx/baremetal/v2/management_node/"
 
-    #TODO: sync db status and current running processes
     def __init__(self):
         self.http_server.register_async_uri(self.CHECK_AVAILABILITY_PATH, self.check_proxy_availability)
         self.http_server.register_async_uri(self.ESTABLISH_PROXY_PATH, self.establish_new_proxy)
@@ -116,92 +122,23 @@ class ConsoleProxyAgent(object):
             os.makedirs(self.TOKEN_FILE_DIR, 0o755)
 
         self.db = filedb.FileDB(self.DB_NAME)
-
         self.token_ctrl = ConsoleTokenFileController()
-
-
-    def _make_token_file_name(self, prefix, timeout):
-        return '%s_%s' % (prefix, time.time() + timeout)
-
-
-    def _get_token_name_prefix(self, cmd):
-        return '_'.join(cmd.token.split('_')[:2])
-
-    def _get_pid_on_port(self, port):
-        out = shell.ShellCmd('netstat -anp | grep ":%s" | grep LISTEN' % port)
-        out(False)
-        out = out.stdout.strip()
-        if "" == out:
-            return None
-
-        pid = out.split()[-1].split('/')[0]
-        try:
-            pid = int(pid)
-            return pid
-        except:
-            return None
-
+        self.vnc_plugin = VncPlugin(self.db, self.token_ctrl)
+        self.nginx_plugin = NginxPlugin()
 
     def _check_proxy_availability(self, args):
         targetSchema = args['targetSchema']
         if targetSchema == 'vnc':
             return self._check_vnc_proxy_availability(args)
-
         if targetSchema == 'http':
             return self._check_http_proxy_availability(args)
-
         return False
 
+    def _check_vnc_proxy_availability(self, args):
+        return self.vnc_plugin.check_availability(args)
 
     def _check_http_proxy_availability(self, args):
-        ret, out, err = bash_roe("systemctl status zstack-baremetal-nginx.service")
-        if ret != 0:
-            # try to restart the service
-            bash_roe("systemctl start zstack-baremetal-nginx.service")
-            ret, out, err = bash_roe("systemctl status zstack-baremetal-nginx.service")
-            if ret != 0:
-                logger.warn('zstack-baremetal-nginx.service is not running, availability false')
-                return False
-        return True
-
-
-    def _check_vnc_proxy_availability(self, args):
-        proxyPort = args['proxyPort']
-        targetHostname = args['targetHostname']
-        targetPort = args['targetPort']
-        token = args['token']
-
-        pid = self._get_pid_on_port(proxyPort)
-        if not pid:
-            logger.debug('no websockify on proxy port[%s], availability false' % proxyPort)
-            return False
-
-        with open(os.path.join('/proc', str(pid), 'cmdline'), 'r') as fd:
-            process_cmdline = fd.read()
-
-        if 'websockify' not in process_cmdline:
-            logger.debug('process[pid:%s] on proxy port[%s] is not websockify process, availability false' % (pid, proxyPort))
-            return False
-
-        info_str = self.db.get(token)
-        if not info_str:
-            logger.debug('cannot find information for process[pid:%s] on proxy port[%s], availability false' % (pid, proxyPort))
-            return False
-
-        info = jsonobject.loads(info_str)
-        if token != info['token']:
-            logger.debug('metadata[token] for process[pid:%s] on proxy port[%s] are changed[%s --> %s], availability false' % (pid, proxyPort, token, info['token']))
-            return False
-
-        if targetPort != info['targetPort']:
-            logger.debug('metadata[targetPort] for process[pid:%s] on proxy port[%s] are changed[%s --> %s], availability false' % (pid, proxyPort, targetPort, info['targetPort']))
-            return False
-
-        if targetHostname != info['targetHostname']:
-            logger.debug('metadata[targetHostname] for process[pid:%s] on proxy port[%s] are changed[%s --> %s], availability false' % (pid, proxyPort, targetHostname, info['targetHostname']))
-            return False
-
-        return True
+        return self.nginx_plugin.check_availability(args)
 
     @replyerror
     def ping(self, req):
@@ -210,18 +147,15 @@ class ConsoleProxyAgent(object):
     @replyerror
     def check_proxy_availability(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
-
         ret = self._check_proxy_availability({
-            'proxyPort':cmd.proxyPort,
+            'proxyPort': cmd.proxyPort,
             'targetSchema': cmd.targetSchema,
-            'targetHostname':cmd.targetHostname,
-            'targetPort':cmd.targetPort,
-            'token':cmd.token
-            })
-
+            'targetHostname': cmd.targetHostname,
+            'targetPort': cmd.targetPort,
+            'token': cmd.token,
+        })
         rsp = CheckAvailabilityRsp()
         rsp.available = ret
-
         return jsonobject.dumps(rsp)
 
     @replyerror
@@ -231,72 +165,23 @@ class ConsoleProxyAgent(object):
         rsp = AgentResponse()
 
         if not cmd.targetSchema or cmd.targetSchema == 'vnc':
-            return self._delete_vnc_proxy(req)
-
-        if cmd.targetSchema == 'http':
-            return self._delete_http_proxy(req)
-
-        rsp.error("unknown target schema %s" % cmd.targetSchema)
-        rsp.sucess = False
-        return jsonobject.dumps(rsp)
-
-
-    def _delete_http_proxy(self, req):
-        cmd = jsonobject.loads(req[http.REQUEST_BODY])
-        rsp = AgentResponse()
-
-        # make sure the service is running
-        ret, out, err = bash_roe("systemctl status zstack-baremetal-nginx.service")
-        if ret != 0:
-            ret, out, err = bash_roe("systemctl start zstack-baremetal-nginx.service")
-            if ret != 0:
-                rsp.error = "failed to start zstack-baremetal-nginx.service"
-                rsp.success = False
+            self.vnc_plugin.delete(cmd)
             return jsonobject.dumps(rsp)
 
-        # remote nginx configuration for bm instance
-        conf_path = os.path.join(self.BM2_INSTANCE_NGINX_CONF_DIR, cmd.vmUuid + ".conf")
-        if os.path.exists(conf_path):
-            os.remove(conf_path)
+        if cmd.targetSchema == 'http':
+            self.nginx_plugin.delete(cmd)
+            return jsonobject.dumps(rsp)
 
-        # reload the service
-        ret, out, err = bash_roe("systemctl reload zstack-baremetal-nginx.service")
-        if ret != 0:
-            rsp.error = "failed to reload zstack-baremetal-nginx.service"
-            rsp.success = False
-        return jsonobject.dumps(rsp)
-
-
-    def _delete_vnc_proxy(self, req):
-        def kill_proxy_process():
-            out = shell.ShellCmd(
-                "netstat -ntp | grep '%s:%s *ESTABLISHED.*python'" % (cmd.targetHostname, cmd.targetPort))
-            out(False)
-            pids = [line.strip().split(' ')[-1].split('/')[0] for line in out.stdout.splitlines()]
-            for pid in pids:
-                try:
-                    os.kill(int(pid), 15)
-                except OSError:
-                    continue
-
-        cmd = jsonobject.loads(req[http.REQUEST_BODY])
-        token_file = ConsoleTokenFile(cmd.token)
-        self.token_ctrl.cancel_delete_token_task(token_file)
-        self.token_ctrl.delete_token_file(token_file)
-        kill_proxy_process()
-        logger.debug('deleted a vnc proxy by command: %s' % req[http.REQUEST_BODY])
-
-        rsp = AgentResponse()
+        rsp.error = "unknown target schema %s" % cmd.targetSchema
+        rsp.success = False
         return jsonobject.dumps(rsp)
 
     @replyerror
     @lock.lock('console-proxy')
     def establish_new_proxy(self, req):
-        # check parameters, generate token file,set db,check process is alive,start process if not,
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = EstablishProxyRsp()
-        port_conflict_msg = None
-        ##
+
         def check_parameters():
             if not cmd.targetHostname:
                 raise ConsoleProxyError('targetHostname cannot be null')
@@ -312,8 +197,7 @@ class ConsoleProxyAgent(object):
         def check_port_conflict():
             if cmd.proxyPort is None or str(cmd.proxyPort).isdigit() is False:
                 raise ConsoleProxyError('proxyPort is None or is not a Number')
-            system_port_cmd = 'sysctl -n net.ipv4.ip_local_port_range'
-            ret, out, err = bash_roe(system_port_cmd)
+            ret, out, err = bash_roe('sysctl -n net.ipv4.ip_local_port_range')
             if ret != 0:
                 logger.warn(err)
             elif out.strip() is None:
@@ -322,8 +206,7 @@ class ConsoleProxyAgent(object):
                 port_range = out.strip().split()
                 if len(port_range) == 2 and str(port_range[0]).isdigit() and str(port_range[1]).isdigit():
                     if int(port_range[0]) < int(cmd.proxyPort) < int(port_range[1]):
-                        port_conflict_msg = "cmd.proxyPort [%s] is probably conflict with linux ip_local_port_range: %s" % (cmd.proxyPort, port_range)
-                        logger.warn(port_conflict_msg)
+                        logger.warn("cmd.proxyPort [%s] is probably conflict with linux ip_local_port_range: %s" % (cmd.proxyPort, port_range))
 
         try:
             check_parameters()
@@ -336,120 +219,17 @@ class ConsoleProxyAgent(object):
             return jsonobject.dumps(rsp)
 
         if not cmd.targetSchema or cmd.targetSchema == 'vnc':
-            return self._establish_new_vnc_proxy(req)
+            rsp.proxyPort = self.vnc_plugin.establish(cmd)
+            rsp.token = cmd.token
+            return jsonobject.dumps(rsp)
 
         if cmd.targetSchema == 'http':
-            return self._establish_new_http_proxy(req)
-
-        rsp.error("unknown target schema %s" % cmd.targetSchema)
-        rsp.sucess = False
-        return jsonobject.dumps(rsp)
-
-
-    def _establish_new_http_proxy(self, req):
-        cmd = jsonobject.loads(req[http.REQUEST_BODY])
-        rsp = EstablishProxyRsp()
-        rsp.proxyPort = cmd.proxyPort
-        rsp.token = cmd.token
-
-        # make sure the service is running
-        ret, out, err = bash_roe("systemctl status zstack-baremetal-nginx.service")
-        if ret != 0:
-            ret, out, err = bash_roe("systemctl start zstack-baremetal-nginx.service")
-            if ret != 0:
-                rsp.error = "failed to start zstack-baremetal-nginx.service"
-                rsp.success = False
+            rsp.proxyPort = self.nginx_plugin.establish(cmd)
+            rsp.token = cmd.token
             return jsonobject.dumps(rsp)
 
-        # add new nginx configuration for bm instance
-        if not os.path.exists(self.BM2_INSTANCE_NGINX_CONF_DIR):
-            os.makedirs(self.BM2_INSTANCE_NGINX_CONF_DIR, exist_ok=True)
-
-        conf_path = os.path.join(self.BM2_INSTANCE_NGINX_CONF_DIR, cmd.vmUuid + ".conf")
-        with open(conf_path, 'w') as f:
-            content = "location ^~/%s/ { proxy_set_header Host $host; proxy_pass http://%s:%s; }" % (cmd.token, cmd.targetHostname, cmd.targetPort)
-            f.write(content)
-
-        # reload the service
-        ret, out, err = bash_roe("systemctl reload zstack-baremetal-nginx.service")
-        if ret != 0:
-            rsp.error = "failed to reload zstack-baremetal-nginx.service"
-            rsp.success = False
-        return jsonobject.dumps(rsp)
-
-
-    def _establish_new_vnc_proxy(self, req):
-        cmd = jsonobject.loads(req[http.REQUEST_BODY])
-        rsp = EstablishProxyRsp()
-        log_file = os.path.join(self.PROXY_LOG_DIR, cmd.proxyHostname)
-
-        token_file = ConsoleTokenFile(cmd.token)
-        token_file.flush_write('%s: %s:%s' % (cmd.token, cmd.targetHostname, cmd.targetPort))
-        self.token_ctrl.submit_delete_token_task(token_file, cmd.expiredDate)
-
-        info = {
-                 'proxyHostname': cmd.proxyHostname,
-                 'proxyPort': cmd.proxyPort,
-                 'targetHostname': cmd.targetHostname,
-                 'targetPort': cmd.targetPort,
-                 'token': cmd.token,
-                 'logFile': log_file,
-                 'tokenFile': token_file.get_absolute_path(),
-                }
-        info_str = jsonobject.dumps(info)
-        self.db.set(cmd.token, info_str)
-        rsp.proxyPort = cmd.proxyPort
-        logger.debug('successfully add new vnc proxy token file %s' % info_str)
-
-        ## kill garbage websockify process: same proxyip:proxyport, different cert file
-        if not cmd.sslCertFile:
-            command = "ps aux | grep '[z]stack.*websockify_init' | grep '%s:%d' | grep 'cert=' | awk '{ print $2 }'" % (cmd.proxyHostname, cmd.proxyPort)
-        else:
-            command = "ps aux | grep '[z]stack.*websockify_init' | grep '%s:%d' | grep -v '%s' | awk '{ print $2 }'" % (cmd.proxyHostname, cmd.proxyPort, cmd.sslCertFile)
-        ret,out,err = bash_roe(command)
-        for pid in out.splitlines():
-            try:
-                os.kill(int(pid), 15)
-            except OSError:
-                continue
-
-        ## if websockify process exists, then return
-        alive = False
-        ret,out,err = bash_roe("ps aux | grep '[z]stack.*websockify_init'")
-        for o in out.splitlines():
-            if o.find("%s:%d" % (cmd.proxyHostname, cmd.proxyPort)) != -1:
-                alive = True
-                break
-        if alive:
-            return jsonobject.dumps(rsp)
-
-        ##start a new websockify process
-        timeout = cmd.idleTimeout
-        if not timeout:
-            timeout = 600
-
-        @in_bash
-        def start_proxy():
-            LOG_FILE = log_file
-            PROXY_HOST_NAME = cmd.proxyHostname
-            PROXY_PORT = cmd.proxyPort
-            TOKEN_FILE_DIR = self.TOKEN_FILE_DIR 
-            TIMEOUT = timeout
-            TLS_VERSION = "--ssl-version=%s" % cmd.tlsVersion if cmd.tlsVersion else ""
-            start_cmd = '''python -c "from zstacklib.utils import log; import websockify; log.configure_log('{{LOG_FILE}}'); websockify.websocketproxy.websockify_init()" {{PROXY_HOST_NAME}}:{{PROXY_PORT}} -D --target-config={{TOKEN_FILE_DIR}} --idle-timeout={{TIMEOUT}} {{TLS_VERSION}}'''
-            if cmd.sslCertFile:
-                start_cmd += ' --cert=%s' % cmd.sslCertFile
-            ret,out,err = bash_roe(start_cmd)
-            if ret != 0:
-                err = []
-                err.append('failed to execute bash command: %s' % start_cmd)
-                err.append('return code: %s' % ret)
-                err.append('stdout: %s' % out)
-                err.append('stderr: %s' % err)
-                raise ConsoleProxyError('\n'.join(err))
-
-        start_proxy()
-        logger.debug('successfully establish new vnc proxy%s' % info_str)
+        rsp.error = "unknown target schema %s" % cmd.targetSchema
+        rsp.success = False
         return jsonobject.dumps(rsp)
 
 
@@ -460,46 +240,3 @@ class ConsoleProxyDaemon(daemon.Daemon):
     def run(self):
         self.agent = ConsoleProxyAgent()
         self.agent.http_server.start()
-
-class ConsoleTokenFile(object):
-    def __init__(self, token=None, directory=ConsoleProxyAgent.TOKEN_FILE_DIR):
-        self.directory = directory
-        self.token = token
-
-    def get_absolute_path(self):
-        return os.path.join(self.directory, self.token)
-
-    def flush_write(self, context):
-        with open(self.get_absolute_path(), 'w') as f:
-            f.write(context)
-
-
-class ConsoleTokenFileController(object):
-    def __init__(self, token_dir=ConsoleProxyAgent.TOKEN_FILE_DIR):
-        self.token_dir = token_dir
-        self.timers = {}
-
-        # recreate token dir to avoid abuse of existing tokens
-        # because currently the console proxy is started as a subprocess of the agent
-        # if the agent is restarted, the console proxy will be restarted as well so 
-        # all the console connections will be broken
-        if os.path.exists(token_dir):
-            linux.rm_dir_force(token_dir)
-            linux.mkdir(token_dir)
-
-    def delete_token_file(self, token_file):
-        shell.call("rm -f %s" % token_file.get_absolute_path())
-
-    def cancel_delete_token_task(self, token_file):
-        timer = self.timers.get(token_file.token)
-        if timer and timer.is_alive():
-            timer.cancel()
-            logger.debug('cancel the task of deleting the token file[%s]' % token_file.get_absolute_path())
-
-    def submit_delete_token_task(self, token_file, expiredDate):
-        interval = float(expiredDate) / 1000 - time.time()
-        self.cancel_delete_token_task(token_file)
-        timer = threading.Timer(interval, self.delete_token_file, args=[token_file])
-        self.timers[token_file.token] = timer
-        timer.start()
-        logger.info("the token file[%s] will be deleted after %s seconds" % (token_file.get_absolute_path(), interval))

--- a/consoleproxy/consoleproxy/plugins/nginx.py
+++ b/consoleproxy/consoleproxy/plugins/nginx.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+import os
+from zstacklib.utils import log
+from zstacklib.utils.bash import bash_roe
+
+logger = log.get_logger(__name__)
+
+BM2_INSTANCE_NGINX_CONF_DIR = "/var/lib/zstack/nginx/baremetal/v2/management_node/"
+
+
+class NginxPlugin(object):
+    def __init__(self, conf_dir=BM2_INSTANCE_NGINX_CONF_DIR):
+        self.BM2_INSTANCE_NGINX_CONF_DIR = conf_dir
+
+    def _ensure_service_running(self):
+        ret, out, err = bash_roe("systemctl status zstack-baremetal-nginx.service")
+        if ret != 0:
+            bash_roe("systemctl start zstack-baremetal-nginx.service")
+            ret, out, err = bash_roe("systemctl status zstack-baremetal-nginx.service")
+        return ret == 0
+
+    def check_availability(self, args):
+        running = self._ensure_service_running()
+        if not running:
+            logger.warn('zstack-baremetal-nginx.service is not running, availability false')
+        return running
+
+    def establish(self, cmd):
+        ret, out, err = bash_roe("systemctl status zstack-baremetal-nginx.service")
+        if ret != 0:
+            ret, out, err = bash_roe("systemctl start zstack-baremetal-nginx.service")
+            if ret != 0:
+                raise Exception("failed to start zstack-baremetal-nginx.service")
+
+        if not os.path.exists(self.BM2_INSTANCE_NGINX_CONF_DIR):
+            os.makedirs(self.BM2_INSTANCE_NGINX_CONF_DIR, exist_ok=True)
+
+        conf_path = os.path.join(self.BM2_INSTANCE_NGINX_CONF_DIR, cmd.vmUuid + ".conf")
+        with open(conf_path, 'w') as f:
+            content = "location ^~/%s/ { proxy_set_header Host $host; proxy_pass http://%s:%s; }" % (
+                cmd.token, cmd.targetHostname, cmd.targetPort)
+            f.write(content)
+
+        ret, out, err = bash_roe("systemctl reload zstack-baremetal-nginx.service")
+        if ret != 0:
+            raise Exception("failed to reload zstack-baremetal-nginx.service")
+        return cmd.proxyPort
+
+    def delete(self, cmd):
+        ret, out, err = bash_roe("systemctl status zstack-baremetal-nginx.service")
+        if ret != 0:
+            ret, out, err = bash_roe("systemctl start zstack-baremetal-nginx.service")
+            if ret != 0:
+                raise Exception("failed to start zstack-baremetal-nginx.service")
+
+        conf_path = os.path.join(self.BM2_INSTANCE_NGINX_CONF_DIR, cmd.vmUuid + ".conf")
+        if os.path.exists(conf_path):
+            os.remove(conf_path)
+
+        ret, out, err = bash_roe("systemctl reload zstack-baremetal-nginx.service")
+        if ret != 0:
+            raise Exception("failed to reload zstack-baremetal-nginx.service")

--- a/consoleproxy/consoleproxy/plugins/vnc.py
+++ b/consoleproxy/consoleproxy/plugins/vnc.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+import os
+import time
+import threading
+from zstacklib.utils import shell, log, linux
+from zstacklib.utils import jsonobject
+from zstacklib.utils.bash import bash_roe, in_bash
+
+logger = log.get_logger(__name__)
+
+TOKEN_FILE_DIR = "/var/lib/zstack/consoleProxy/"
+PROXY_LOG_DIR = "/var/log/zstack/consoleProxy/"
+
+
+class ConsoleTokenFile(object):
+    def __init__(self, token=None, directory=TOKEN_FILE_DIR):
+        self.directory = directory
+        self.token = token
+
+    def get_absolute_path(self):
+        return os.path.join(self.directory, self.token)
+
+    def flush_write(self, context):
+        with open(self.get_absolute_path(), 'w') as f:
+            f.write(context)
+
+
+class ConsoleTokenFileController(object):
+    def __init__(self, token_dir=TOKEN_FILE_DIR):
+        self.token_dir = token_dir
+        self.timers = {}
+
+        # recreate token dir to avoid abuse of existing tokens
+        if os.path.exists(token_dir):
+            linux.rm_dir_force(token_dir)
+            linux.mkdir(token_dir)
+
+    def delete_token_file(self, token_file):
+        shell.call("rm -f %s" % token_file.get_absolute_path())
+
+    def cancel_delete_token_task(self, token_file):
+        timer = self.timers.get(token_file.token)
+        if timer and timer.is_alive():
+            timer.cancel()
+            logger.debug('cancel the task of deleting the token file[%s]' % token_file.get_absolute_path())
+
+    def submit_delete_token_task(self, token_file, expiredDate):
+        interval = float(expiredDate) / 1000 - time.time()
+        self.cancel_delete_token_task(token_file)
+        timer = threading.Timer(interval, self.delete_token_file, args=[token_file])
+        self.timers[token_file.token] = timer
+        timer.start()
+        logger.info("the token file[%s] will be deleted after %s seconds" % (token_file.get_absolute_path(), interval))
+
+
+class VncPlugin(object):
+    def __init__(self, db, token_ctrl, token_file_dir=TOKEN_FILE_DIR, proxy_log_dir=PROXY_LOG_DIR):
+        self.db = db
+        self.token_ctrl = token_ctrl
+        self.TOKEN_FILE_DIR = token_file_dir
+        self.PROXY_LOG_DIR = proxy_log_dir
+
+    def _get_token_name_prefix(self, cmd):
+        return '_'.join(cmd.token.split('_')[:2])
+
+    def _make_token_file_name(self, prefix, timeout):
+        return '%s_%s' % (prefix, time.time() + timeout)
+
+    def _get_pid_on_port(self, port):
+        out = shell.ShellCmd('netstat -anp | grep ":%s" | grep LISTEN' % port)
+        out(False)
+        out = out.stdout.strip()
+        if "" == out:
+            return None
+
+        pid = out.split()[-1].split('/')[0]
+        try:
+            pid = int(pid)
+            return pid
+        except:
+            return None
+
+    def check_availability(self, args):
+        proxyPort = args['proxyPort']
+        targetHostname = args['targetHostname']
+        targetPort = args['targetPort']
+        token = args['token']
+
+        pid = self._get_pid_on_port(proxyPort)
+        if not pid:
+            logger.debug('no websockify on proxy port[%s], availability false' % proxyPort)
+            return False
+
+        with open(os.path.join('/proc', str(pid), 'cmdline'), 'r') as fd:
+            process_cmdline = fd.read()
+
+        if 'websockify' not in process_cmdline:
+            logger.debug('process[pid:%s] on proxy port[%s] is not websockify process, availability false' % (pid, proxyPort))
+            return False
+
+        info_str = self.db.get(token)
+        if not info_str:
+            logger.debug('cannot find information for process[pid:%s] on proxy port[%s], availability false' % (pid, proxyPort))
+            return False
+
+        info = jsonobject.loads(info_str)
+        if token != info['token']:
+            logger.debug('metadata[token] for process[pid:%s] on proxy port[%s] changed, availability false' % (pid, proxyPort))
+            return False
+
+        if targetPort != info['targetPort']:
+            logger.debug('metadata[targetPort] for process[pid:%s] on proxy port[%s] changed, availability false' % (pid, proxyPort))
+            return False
+
+        if targetHostname != info['targetHostname']:
+            logger.debug('metadata[targetHostname] for process[pid:%s] on proxy port[%s] changed, availability false' % (pid, proxyPort))
+            return False
+
+        return True
+
+    def establish(self, cmd):
+        log_file = os.path.join(self.PROXY_LOG_DIR, cmd.proxyHostname)
+
+        token_file = ConsoleTokenFile(cmd.token)
+        token_file.flush_write('%s: %s:%s' % (cmd.token, cmd.targetHostname, cmd.targetPort))
+        self.token_ctrl.submit_delete_token_task(token_file, cmd.expiredDate)
+
+        info = {
+            'proxyHostname': cmd.proxyHostname,
+            'proxyPort': cmd.proxyPort,
+            'targetHostname': cmd.targetHostname,
+            'targetPort': cmd.targetPort,
+            'token': cmd.token,
+            'logFile': log_file,
+            'tokenFile': token_file.get_absolute_path(),
+        }
+        info_str = jsonobject.dumps(info)
+        self.db.set(cmd.token, info_str)
+        logger.debug('successfully add new vnc proxy token file %s' % info_str)
+
+        ## kill garbage websockify process: same proxyip:proxyport, different cert file
+        if not cmd.sslCertFile:
+            command = "ps aux | grep '[z]stack.*websockify_init' | grep '%s:%d' | grep 'cert=' | awk '{ print $2 }'" % (cmd.proxyHostname, cmd.proxyPort)
+        else:
+            command = "ps aux | grep '[z]stack.*websockify_init' | grep '%s:%d' | grep -v '%s' | awk '{ print $2 }'" % (cmd.proxyHostname, cmd.proxyPort, cmd.sslCertFile)
+        ret, out, err = bash_roe(command)
+        for pid in out.splitlines():
+            try:
+                os.kill(int(pid), 15)
+            except OSError:
+                continue
+
+        ## if websockify process exists, then return
+        alive = False
+        ret, out, err = bash_roe("ps aux | grep '[z]stack.*websockify_init'")
+        for o in out.splitlines():
+            if o.find("%s:%d" % (cmd.proxyHostname, cmd.proxyPort)) != -1:
+                alive = True
+                break
+        if alive:
+            return cmd.proxyPort
+
+        ## start a new websockify process
+        timeout = cmd.idleTimeout
+        if not timeout:
+            timeout = 600
+
+        @in_bash
+        def start_proxy():
+            LOG_FILE = log_file
+            PROXY_HOST_NAME = cmd.proxyHostname
+            PROXY_PORT = cmd.proxyPort
+            TOKEN_FILE_DIR = self.TOKEN_FILE_DIR
+            TIMEOUT = timeout
+            TLS_VERSION = "--ssl-version=%s" % cmd.tlsVersion if cmd.tlsVersion else ""
+            start_cmd = '''python -c "from zstacklib.utils import log; import websockify; log.configure_log('{{LOG_FILE}}'); websockify.websocketproxy.websockify_init()" {{PROXY_HOST_NAME}}:{{PROXY_PORT}} -D --target-config={{TOKEN_FILE_DIR}} --idle-timeout={{TIMEOUT}} {{TLS_VERSION}}'''
+            if cmd.sslCertFile:
+                start_cmd += ' --cert=%s' % cmd.sslCertFile
+            ret, out, err = bash_roe(start_cmd)
+            if ret != 0:
+                raise Exception('failed to start websockify on %s:%s, stderr: %s' % (cmd.proxyHostname, cmd.proxyPort, err))
+
+        start_proxy()
+        logger.debug('successfully establish new vnc proxy %s' % info_str)
+        return cmd.proxyPort
+
+    def delete(self, cmd):
+        def kill_proxy_process():
+            out = shell.ShellCmd(
+                "netstat -ntp | grep '%s:%s *ESTABLISHED.*python'" % (cmd.targetHostname, cmd.targetPort))
+            out(False)
+            pids = [line.strip().split(' ')[-1].split('/')[0] for line in out.stdout.splitlines()]
+            for pid in pids:
+                try:
+                    os.kill(int(pid), 15)
+                except OSError:
+                    continue
+
+        token_file = ConsoleTokenFile(cmd.token)
+        self.token_ctrl.cancel_delete_token_task(token_file)
+        self.token_ctrl.delete_token_file(token_file)
+        kill_proxy_process()
+        logger.debug('deleted a vnc proxy for token: %s' % cmd.token)

--- a/consoleproxy/test/conftest.py
+++ b/consoleproxy/test/conftest.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""
+conftest.py for consoleproxy tests.
+Mocks all zstacklib dependencies so tests run under Python 3 without
+a full KVM environment.
+"""
+import sys
+import os
+import types
+from unittest.mock import MagicMock
+
+# ---- Add package roots to sys.path ------------------------------------
+_root = os.path.join(os.path.dirname(__file__), '..', '..')
+_cp_root = os.path.join(os.path.dirname(__file__), '..')
+sys.path.insert(0, os.path.abspath(_root))
+sys.path.insert(0, os.path.abspath(_cp_root))
+
+# ---- log --------------------------------------------------------------
+_mock_log = types.ModuleType('zstacklib.utils.log')
+_mock_log.get_logger = lambda name: MagicMock()
+_mock_log.get_logfile_path = lambda: '/dev/null'
+sys.modules['log'] = _mock_log
+sys.modules['zstacklib.utils.log'] = _mock_log
+
+# ---- bash -------------------------------------------------------------
+_mock_bash = types.ModuleType('zstacklib.utils.bash')
+_mock_bash.log = _mock_log
+_mock_bash.bash_roe = MagicMock(return_value=(0, '', ''))
+_mock_bash.bash_ro = MagicMock(return_value=(0, ''))
+_mock_bash.bash_r = MagicMock(return_value=0)
+_mock_bash.in_bash = lambda f: f  # no-op decorator
+sys.modules['bash'] = _mock_bash
+sys.modules['zstacklib.utils.bash'] = _mock_bash
+
+# ---- http -------------------------------------------------------------
+_mock_http = MagicMock()
+_mock_http.HttpServer = MagicMock(return_value=MagicMock())
+_mock_http.REQUEST_BODY = 'body'
+sys.modules['zstacklib.utils.http'] = _mock_http
+
+# ---- remaining zstacklib mocks ----------------------------------------
+for mod in [
+    'zstacklib.utils.plugin',
+    'zstacklib.utils.shell',
+    'zstacklib.utils.daemon',
+    'zstacklib.utils.linux',
+    'zstacklib.utils.filedb',
+    'zstacklib.utils.lock',
+    'zstacklib.utils.jsonobject',
+]:
+    sys.modules[mod] = MagicMock()
+
+# lock.lock must be a no-op decorator
+sys.modules['zstacklib.utils.lock'].lock = lambda name: (lambda f: f)
+
+# filedb.FileDB returns a mock instance
+sys.modules['zstacklib.utils.filedb'].FileDB = MagicMock
+
+# jsonobject helpers used in agent
+import json
+_jmod = sys.modules['zstacklib.utils.jsonobject']
+_jmod.loads = lambda s: json.loads(s) if isinstance(s, str) else s
+_jmod.dumps = lambda obj, **kw: json.dumps(
+    obj if isinstance(obj, dict) else obj.__dict__, default=str)

--- a/consoleproxy/test/test_console_proxy_agent.py
+++ b/consoleproxy/test/test_console_proxy_agent.py
@@ -1,0 +1,243 @@
+# -*- coding: utf-8 -*-
+"""
+Characterization tests for consoleproxy — written BEFORE refactoring.
+These tests lock down the current behavior so the refactoring can't
+accidentally break it.
+
+After refactoring:
+  ConsoleTokenFile, ConsoleTokenFileController  → plugins.vnc
+  VncPlugin (token helpers + availability)       → plugins.vnc
+  NginxPlugin                                    → plugins.nginx
+  ConsoleProxyAgent                              → console_proxy_agent (wiring only)
+"""
+import unittest
+import sys
+import os
+import json
+import time
+from unittest.mock import MagicMock, patch, call
+
+# conftest.py handles all mock setup before this runs
+
+
+class TestConsoleTokenFile(unittest.TestCase):
+    """ConsoleTokenFile: pure value object, no I/O."""
+
+    def setUp(self):
+        from consoleproxy.plugins.vnc import ConsoleTokenFile
+        self.ConsoleTokenFile = ConsoleTokenFile
+
+    def test_get_absolute_path_combines_dir_and_token(self):
+        tf = self.ConsoleTokenFile(token='abc-123', directory='/tmp/tokens')
+        self.assertEqual(tf.get_absolute_path(), '/tmp/tokens/abc-123')
+
+    def test_get_absolute_path_uses_default_dir(self):
+        tf = self.ConsoleTokenFile(token='my-token')
+        self.assertIn('my-token', tf.get_absolute_path())
+
+    def test_token_is_stored(self):
+        tf = self.ConsoleTokenFile(token='tok-xyz', directory='/tmp')
+        self.assertEqual(tf.token, 'tok-xyz')
+
+
+class TestTokenNameHelpers(unittest.TestCase):
+    """Token name parsing helpers now live on VncPlugin."""
+
+    def setUp(self):
+        from consoleproxy.plugins.vnc import VncPlugin
+        self.plugin = VncPlugin(db=MagicMock(), token_ctrl=MagicMock())
+
+    def test_get_token_name_prefix_returns_first_two_parts(self):
+        cmd = MagicMock()
+        cmd.token = 'host_vm_extra_more'
+        result = self.plugin._get_token_name_prefix(cmd)
+        self.assertEqual(result, 'host_vm')
+
+    def test_get_token_name_prefix_with_two_part_token(self):
+        cmd = MagicMock()
+        cmd.token = 'aaa_bbb'
+        result = self.plugin._get_token_name_prefix(cmd)
+        self.assertEqual(result, 'aaa_bbb')
+
+    def test_make_token_file_name_combines_prefix_and_expiry(self):
+        before = time.time()
+        name = self.plugin._make_token_file_name('pfx', 300)
+        after = time.time()
+        parts = name.split('_')
+        self.assertEqual(parts[0], 'pfx')
+        expiry = float(parts[1])
+        self.assertGreaterEqual(expiry, before + 300)
+        self.assertLessEqual(expiry, after + 300)
+
+
+class TestSchemaRouting(unittest.TestCase):
+    """_check_proxy_availability on the agent routes vnc vs http to correct handlers."""
+
+    def setUp(self):
+        from consoleproxy.console_proxy_agent import ConsoleProxyAgent
+        self.agent = ConsoleProxyAgent.__new__(ConsoleProxyAgent)
+
+    def test_vnc_schema_routes_to_vnc_handler(self):
+        self.agent._check_vnc_proxy_availability = MagicMock(return_value=True)
+        self.agent._check_http_proxy_availability = MagicMock(return_value=True)
+        result = self.agent._check_proxy_availability({'targetSchema': 'vnc'})
+        self.agent._check_vnc_proxy_availability.assert_called_once()
+        self.agent._check_http_proxy_availability.assert_not_called()
+        self.assertTrue(result)
+
+    def test_http_schema_routes_to_http_handler(self):
+        self.agent._check_vnc_proxy_availability = MagicMock(return_value=False)
+        self.agent._check_http_proxy_availability = MagicMock(return_value=True)
+        result = self.agent._check_proxy_availability({'targetSchema': 'http'})
+        self.agent._check_http_proxy_availability.assert_called_once()
+        self.agent._check_vnc_proxy_availability.assert_not_called()
+        self.assertTrue(result)
+
+    def test_unknown_schema_returns_false(self):
+        self.agent._check_vnc_proxy_availability = MagicMock(return_value=True)
+        self.agent._check_http_proxy_availability = MagicMock(return_value=True)
+        result = self.agent._check_proxy_availability({'targetSchema': 'rdp'})
+        self.assertFalse(result)
+
+
+class TestVncAvailabilityLogic(unittest.TestCase):
+    """VncPlugin.check_availability: documented failure conditions."""
+
+    def setUp(self):
+        from consoleproxy.plugins.vnc import VncPlugin
+        self.plugin = VncPlugin(db=MagicMock(), token_ctrl=MagicMock())
+
+    def test_returns_false_when_no_process_on_port(self):
+        self.plugin._get_pid_on_port = MagicMock(return_value=None)
+        result = self.plugin.check_availability({
+            'proxyPort': 6000, 'targetHostname': 'host', 'targetPort': 5900, 'token': 't'
+        })
+        self.assertFalse(result)
+
+    def test_returns_false_when_process_is_not_websockify(self):
+        self.plugin._get_pid_on_port = MagicMock(return_value=1234)
+        mock_open = unittest.mock.mock_open(read_data='nginx\x00something')
+        with patch('builtins.open', mock_open):
+            result = self.plugin.check_availability({
+                'proxyPort': 6000, 'targetHostname': 'host', 'targetPort': 5900, 'token': 't'
+            })
+        self.assertFalse(result)
+
+    def test_returns_false_when_token_not_in_db(self):
+        self.plugin._get_pid_on_port = MagicMock(return_value=1234)
+        mock_open = unittest.mock.mock_open(read_data='websockify\x00stuff')
+        self.plugin.db.get = MagicMock(return_value=None)
+        with patch('builtins.open', mock_open):
+            result = self.plugin.check_availability({
+                'proxyPort': 6000, 'targetHostname': 'host', 'targetPort': 5900, 'token': 'tok'
+            })
+        self.assertFalse(result)
+
+    def test_returns_true_when_all_metadata_matches(self):
+        self.plugin._get_pid_on_port = MagicMock(return_value=1234)
+        mock_open = unittest.mock.mock_open(read_data='websockify\x00stuff')
+        info = {'token': 'tok', 'targetPort': 5900, 'targetHostname': 'host'}
+        self.plugin.db.get = MagicMock(return_value=json.dumps(info))
+        with patch('builtins.open', mock_open):
+            result = self.plugin.check_availability({
+                'proxyPort': 6000, 'targetHostname': 'host', 'targetPort': 5900, 'token': 'tok'
+            })
+        self.assertTrue(result)
+
+
+class TestConsoleTokenFileController(unittest.TestCase):
+    """ConsoleTokenFileController timer management."""
+
+    def setUp(self):
+        import consoleproxy.plugins.vnc as m
+        self._linux = sys.modules['zstacklib.utils.linux']
+        self._linux.rm_dir_force = MagicMock()
+        self._linux.mkdir = MagicMock()
+
+        with patch('os.path.exists', return_value=True):
+            from consoleproxy.plugins.vnc import ConsoleTokenFileController
+            self.ctrl = ConsoleTokenFileController(token_dir='/tmp/fake')
+
+    def test_cancel_delete_stops_running_timer(self):
+        from consoleproxy.plugins.vnc import ConsoleTokenFile
+        tf = ConsoleTokenFile('tok1', '/tmp')
+        mock_timer = MagicMock()
+        mock_timer.is_alive.return_value = True
+        self.ctrl.timers['tok1'] = mock_timer
+
+        self.ctrl.cancel_delete_token_task(tf)
+        mock_timer.cancel.assert_called_once()
+
+    def test_cancel_delete_noop_when_no_timer(self):
+        from consoleproxy.plugins.vnc import ConsoleTokenFile
+        tf = ConsoleTokenFile('nonexistent', '/tmp')
+        # Should not raise
+        self.ctrl.cancel_delete_token_task(tf)
+
+    def test_submit_creates_timer_for_token(self):
+        from consoleproxy.plugins.vnc import ConsoleTokenFile
+        tf = ConsoleTokenFile('tok2', '/tmp')
+        future_ms = (time.time() + 60) * 1000
+
+        with patch('threading.Timer') as mock_timer_cls:
+            mock_t = MagicMock()
+            mock_timer_cls.return_value = mock_t
+            self.ctrl.submit_delete_token_task(tf, future_ms)
+            mock_t.start.assert_called_once()
+            self.assertIn('tok2', self.ctrl.timers)
+
+
+class TestNginxPlugin(unittest.TestCase):
+    """NginxPlugin: nginx-based HTTP proxy for BM2 instances."""
+
+    def setUp(self):
+        from consoleproxy.plugins.nginx import NginxPlugin
+        self.plugin = NginxPlugin(conf_dir='/tmp/nginx-test')
+
+    def test_check_availability_true_when_service_running(self):
+        self.plugin._ensure_service_running = MagicMock(return_value=True)
+        result = self.plugin.check_availability({})
+        self.assertTrue(result)
+
+    def test_check_availability_false_when_service_not_running(self):
+        self.plugin._ensure_service_running = MagicMock(return_value=False)
+        result = self.plugin.check_availability({})
+        self.assertFalse(result)
+
+    def test_establish_writes_conf_and_returns_proxy_port(self):
+        cmd = MagicMock()
+        cmd.vmUuid = 'vm-001'
+        cmd.token = 'tok-abc'
+        cmd.targetHostname = '192.168.1.1'
+        cmd.targetPort = 8080
+        cmd.proxyPort = 9090
+
+        mock_bash = sys.modules['zstacklib.utils.bash']
+        mock_bash.bash_roe = MagicMock(return_value=(0, '', ''))
+
+        with patch('os.path.exists', return_value=True), \
+             patch('builtins.open', unittest.mock.mock_open()) as mock_file:
+            result = self.plugin.establish(cmd)
+
+        self.assertEqual(result, 9090)
+        mock_file.assert_called_once_with('/tmp/nginx-test/vm-001.conf', 'w')
+        written = mock_file().write.call_args[0][0]
+        self.assertIn('tok-abc', written)
+        self.assertIn('192.168.1.1', written)
+
+    def test_delete_removes_conf_file(self):
+        cmd = MagicMock()
+        cmd.vmUuid = 'vm-002'
+
+        mock_bash = sys.modules['zstacklib.utils.bash']
+        mock_bash.bash_roe = MagicMock(return_value=(0, '', ''))
+
+        with patch('os.path.exists', return_value=True), \
+             patch('os.remove') as mock_remove:
+            self.plugin.delete(cmd)
+
+        mock_remove.assert_called_once_with('/tmp/nginx-test/vm-002.conf')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zstacklib/zstacklib/gpu/base.py
+++ b/zstacklib/zstacklib/gpu/base.py
@@ -6,6 +6,7 @@ GPU Base Class and Registry (Python 2/3 Compatible)
 import abc
 import re
 import threading
+from enum import Enum
 
 from zstacklib.utils import log
 from zstacklib.utils.bash import bash_roe, bash_ro
@@ -34,6 +35,16 @@ class VendorEnum:
     ENFLAME = "Enflame"
     ALIBABA = "Alibaba"
     KUNLUNXIN = "Kunlunxin"
+
+
+# =============================================================================
+# VmGpuStatus - GPU status as seen from inside the VM (via QGA)
+# =============================================================================
+
+class VmGpuStatus(Enum):
+    NOT_EXIST = "not_exist"
+    CRITICAL_FAULT = "critical"
+    NOMINAL = "nominal"
 
 
 # =============================================================================

--- a/zstacklib/zstacklib/gpu/tests/test_gpu_vendors.py
+++ b/zstacklib/zstacklib/gpu/tests/test_gpu_vendors.py
@@ -1110,5 +1110,30 @@ class TestIdentifyVendor(unittest.TestCase):
         self.assertEqual(result, "NVIDIA")
 
 
+class TestVmGpuStatus(unittest.TestCase):
+    """Characterization tests for VmGpuStatus enum migration to gpu.base"""
+
+    def test_vm_gpu_status_importable_from_gpu_base(self):
+        from zstacklib.gpu.base import VmGpuStatus
+        self.assertIsNotNone(VmGpuStatus)
+
+    def test_vm_gpu_status_not_exist_value(self):
+        from zstacklib.gpu.base import VmGpuStatus
+        self.assertEqual(VmGpuStatus.NOT_EXIST.value, "not_exist")
+
+    def test_vm_gpu_status_critical_fault_value(self):
+        from zstacklib.gpu.base import VmGpuStatus
+        self.assertEqual(VmGpuStatus.CRITICAL_FAULT.value, "critical")
+
+    def test_vm_gpu_status_nominal_value(self):
+        from zstacklib.gpu.base import VmGpuStatus
+        self.assertEqual(VmGpuStatus.NOMINAL.value, "nominal")
+
+    def test_utils_gpu_still_exports_vm_gpu_status(self):
+        """Backward compat: utils/gpu.py must still export VmGpuStatus"""
+        from zstacklib.utils.gpu import VmGpuStatus
+        self.assertEqual(VmGpuStatus.NOMINAL.value, "nominal")
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/zstacklib/zstacklib/utils/gpu.py
+++ b/zstacklib/zstacklib/utils/gpu.py
@@ -9,6 +9,7 @@ import json
 
 from zstacklib.gpu.base import (
     VendorEnum,
+    VmGpuStatus,  # moved to gpu.base; re-exported here for backward compat
     PCI_CLASS_VGA,
     PCI_CLASS_DISPLAY,
     PCI_CLASS_PROCESSING_ACCEL,
@@ -24,12 +25,6 @@ from zstacklib.gpu.base import (
 from zstacklib.utils.qga import VmQga
 
 logger = log.get_logger(__name__)
-
-
-class VmGpuStatus(Enum):
-    NOT_EXIST = "not_exist"
-    CRITICAL_FAULT = "critical"
-    NOMINAL = "nominal"
 
 
 def shut_persistenced_by_guesttool(domain):


### PR DESCRIPTION
## Summary

Two structural refactoring commits added on top of the ZSTAC-67411 GPU fix:

1. **`[zstacklib]` move VmGpuStatus** from `utils/gpu` → `gpu/base.py` — puts the DTO next to the GPU domain code that owns it
2. **`[consoleproxy]` split ConsoleProxyAgent into plugins** — extracts VNC websockify logic and nginx BM2 proxy logic into separate plugin classes, reducing the main agent from 505 → 242 lines

## Changes

```
consoleproxy/consoleproxy/console_proxy_agent.py  | 339 ---
consoleproxy/consoleproxy/plugins/__init__.py     |   0
consoleproxy/consoleproxy/plugins/nginx.py        |  62 +++
consoleproxy/consoleproxy/plugins/vnc.py          | 203 +++
consoleproxy/test/conftest.py                     |  64 +++
consoleproxy/test/test_console_proxy_agent.py     | 243 +++
zstacklib/zstacklib/gpu/base.py                   |  11 +
zstacklib/zstacklib/gpu/tests/test_gpu_vendors.py |  25 +
zstacklib/zstacklib/utils/gpu.py                  |   7 +-
```

## Testing

- [x] 20 unit tests GREEN (16 characterization + 4 new NginxPlugin tests)
- [x] No behaviour change — pure structural refactoring
- [ ] CI pipeline

Resolves: ZSTAC-67411

sync from gitlab !6662