### PR TITLE
<fix>[zstacklib]: fix get_virtualenv_python_version

### DIFF
--- a/zstacklib/ansible/zstacklib.py
+++ b/zstacklib/ansible/zstacklib.py
@@ -1702,7 +1702,14 @@ def get_virtualenv_python_version(venv, host_post_info):
                         "reply is below:\n %s") % result)
         raise Exception(result)
 
-    return ret['stdout'].strip().split()[1] if ret['rc'] == 0 else None
+    if ret['rc'] != 0:
+        return None
+    # Python 2 outputs version to stderr, Python 3 outputs to stdout
+    version_output = ret.get('stdout', '').strip() or ret.get('stderr', '').strip()
+    parts = version_output.split() if version_output else []
+    if len(parts) < 2:
+        raise Exception("failed to get python version from %s, output: %s" % (venv, version_output))
+    return parts[1]
 
 
 


### PR DESCRIPTION
## 问题

`get_virtualenv_python_version` 在 venv 为 Python 2 时抛出 `IndexError: list index out of range`。

## 原因

Python 2 的 `python --version` 输出到 stderr，Python 3 输出到 stdout。当 venv 是 Python 2 时，`ret['stdout']` 为空字符串，`''.strip().split()[1]` 导致 IndexError。

## 修复

- 优先读 stdout，为空时 fallback 到 stderr
- 解析失败时明确抛出异常，而非静默返回 None

Resolves: ZSTAC-82619

sync from gitlab !6682