### PR TITLE
<fix>[zstacklib]: fix tail_1 returning bytes instead of str

### DIFF
--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -3079,7 +3079,7 @@ def tail_1(path, split=b"\n"):
         f.seek(-2, os.SEEK_END)
         while f.tell() > 0 and f.read(1) != split:
             f.seek(-2, os.SEEK_CUR)
-        return f.readline()
+        return f.readline().decode('utf-8', errors='replace')
 
 
 # check if file 'fpath' contains .conf style configurations


### PR DESCRIPTION
## 变更说明

`linux.tail_1()` 以二进制模式 (`'rb'`) 打开文件，`f.readline()` 返回 `bytes`，但所有调用方都期望 `str`（调用 `.strip()`, `.split()`, `in` 字符串检查, `.isdigit()` 等）。

当文件大小 <= 2 时走 `read_file()` 返回 `str`，大文件路径返回 `bytes`，类型不一致。

**修复**：对 `f.readline()` 结果调用 `.decode('utf-8', errors='replace')` 统一返回 `str`。

## 影响范围

所有使用 `linux.tail_1()` 的调用点：
- `cephbackupstorage/cephbackupstorage/cephagent.py`
- `kvmagent/kvmagent/plugins/localstorage.py`
- `kvmagent/kvmagent/plugins/imagestore.py`
- `kvmagent/kvmagent/plugins/zses.py`

Resolves: ZSTAC-75445

sync from gitlab !6686