### PR TITLE
modernize/full-stack-5512: JDK 8→21 + Tomcat 8.5→10.1 build system update

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -696,7 +696,7 @@ set_tomcat_config() {
                connectionTimeout="$new_timeout"
                redirectPort="8443"
                maxParameterCount="1000"
-               maxHttpHeaderSize="65536" URIEncoding="UTF-8" useBodyEncodingForURI="UTF-8" />
+               maxHttpHeaderSize="65536" URIEncoding="UTF-8" />
        <Executor name="tomcatThreadPool" namePrefix="catalina-exec-" maxThreads="$new_max_thread_num" minSpareThreads="$new_min_spare_threads" prestartminSpareThreads="true" maxQueueSize="$new_max_queue_size" />
     <Engine name="Catalina" defaultHost="localhost">
 

--- a/installation/install.sh
+++ b/installation/install.sh
@@ -1641,8 +1641,8 @@ is_install_general_libs_rh(){
 
     # Just install what is not installed
     deps_list="python3-libselinux \
-            java-1.8.0-openjdk \
-            java-1.8.0-openjdk-devel \
+            java-21-openjdk \
+            java-21-openjdk-devel \
             bridge-utils \
             wget \
             nfs-utils \
@@ -1709,9 +1709,9 @@ is_install_general_libs_rh(){
         fail "install system libraries failed."
     fi
 
-    rpm -q java-1.8.0-openjdk >>$ZSTACK_INSTALL_LOG 2>&1 || java -version 2>&1 |grep 1.8 >/dev/null
+    rpm -q java-21-openjdk >>$ZSTACK_INSTALL_LOG 2>&1 || java -version 2>&1 |grep '"21\.' >/dev/null
     if [ $? -ne 0 ]; then
-        fail "java-1.8.0-openjdk is not installed. Did you forget updating management node local repos to latest ${PRODUCT_NAME} ISO? Please use following steps to update local repos:
+        fail "java-21-openjdk is not installed. Did you forget updating management node local repos to latest ${PRODUCT_NAME} ISO? Please use following steps to update local repos:
         1. # cd /opt
         2. # wget http://cdn.zstack.io/product_downloads/scripts/${PRODUCT_NAME,,}-upgrade
         3. download the latest ${PRODUCT_NAME} ISO from http://www.zstack.io/product_downloads into /opt
@@ -1719,9 +1719,9 @@ is_install_general_libs_rh(){
         "
     else
         #yum clean metadata >/dev/null 2>&1
-        #set java 8 as default jre.
-        update-alternatives --install /usr/bin/java java /usr/lib/jvm/jre-1.8.0/bin/java 0 >>$ZSTACK_INSTALL_LOG 2>&1
-        update-alternatives --set java /usr/lib/jvm/jre-1.8.0/bin/java >>$ZSTACK_INSTALL_LOG 2>&1
+        #set java 21 as default jre.
+        update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-21-openjdk/bin/java 0 >>$ZSTACK_INSTALL_LOG 2>&1
+        update-alternatives --set java /usr/lib/jvm/java-21-openjdk/bin/java >>$ZSTACK_INSTALL_LOG 2>&1
         pass
     fi
 }
@@ -1744,14 +1744,14 @@ is_install_general_libs_deb(){
     id -u nginx >/dev/null 2>&1 || useradd nginx >/dev/null 2>&1
 
     if [[ $DEBIAN_OS =~ $OS ]]; then
-        #install openjdk ppa for openjdk-8
+        #install openjdk ppa for openjdk-21
 
         # add-apt-repository ppa:openjdk-r/ppa -y >>$ZSTACK_INSTALL_LOG 2>&1
         apt-key update >>$ZSTACK_INSTALL_LOG 2>&1
         apt-get update >>$ZSTACK_INSTALL_LOG 2>&1
     fi
     apt-get -y install --allow-unauthenticated \
-        openjdk-8-jdk \
+        openjdk-21-jdk \
         bridge-utils \
         wget \
         auditd \
@@ -1797,10 +1797,10 @@ is_install_general_libs_deb(){
 
     if [ $OS == "UBUNTU14.04" ]; then
         #set java 8 as default jre.
-        update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java 0 >>$ZSTACK_INSTALL_LOG 2>&1
-        update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/javac 0 >>$ZSTACK_INSTALL_LOG 2>&1
-        update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java >>$ZSTACK_INSTALL_LOG 2>&1
-        update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac >>$ZSTACK_INSTALL_LOG 2>&1
+        update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-21-openjdk-amd64/bin/java 0 >>$ZSTACK_INSTALL_LOG 2>&1
+        update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-21-openjdk-amd64/bin/javac 0 >>$ZSTACK_INSTALL_LOG 2>&1
+        update-alternatives --set java /usr/lib/jvm/java-21-openjdk-amd64/bin/java >>$ZSTACK_INSTALL_LOG 2>&1
+        update-alternatives --set javac /usr/lib/jvm/java-21-openjdk-amd64/bin/javac >>$ZSTACK_INSTALL_LOG 2>&1
         #no service iptables
         [ ! -f /etc/init.d/iptables ] && [ -f /etc/init.d/iptables-persistent ] \
             && ln -s /etc/init.d/iptables-persistent /etc/init.d/iptables

--- a/zstackbuild/README.md
+++ b/zstackbuild/README.md
@@ -7,8 +7,8 @@ The following dependencies and installation packages need to be installed before
 ```
 # other necessary dependencies: 
 yum install -y \
-    java-1.8.0-openjdk \
-    java-1.8.0-openjdk-devel \
+    java-21-openjdk \
+    java-21-openjdk-devel \
     sudo \
     git \
     make \
@@ -62,7 +62,7 @@ Now we can start building the package:
 ```
 cd /your/path/to/zstack-repos;
 
-wget -c https://archive.apache.org/dist/tomcat/tomcat-8/v8.5.57/bin/apache-tomcat-8.5.57.zip
+wget -c https://archive.apache.org/dist/tomcat/tomcat-10/v10.1.34/bin/apache-tomcat-10.1.34.zip
 ```
 
 

--- a/zstackbuild/build.oss.properties
+++ b/zstackbuild/build.oss.properties
@@ -18,7 +18,7 @@ zstack.build_version=${build_version}
 zstackutility.source=${zstack_build_root}/zstack-utility
 zstackutility.build_version=${build_version}
 
-apachetomcat.pkg=${zstack_build_root}/apache-tomcat-8.5.57.zip
+apachetomcat.pkg=${zstack_build_root}/apache-tomcat-10.1.34.zip
 
 # For UI 1.x
 zstackdashboard.source=${zstack_build_root}/zstack-dashboard

--- a/zstackbuild/build.properties
+++ b/zstackbuild/build.properties
@@ -19,7 +19,7 @@ zsha2.version=3.9.0.0
 zstackutility.source=${zstack_build_root}/zstack-utility
 zstackutility.build_version=${build_version}
 
-apachetomcat.pkg=${zstack_build_root}/apache-tomcat-8.5.99.zip
+apachetomcat.pkg=${zstack_build_root}/apache-tomcat-10.1.34.zip
 
 # For UI 1.x
 zstackdashboard.source=${zstack_build_root}/zstack-dashboard

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -8047,17 +8047,17 @@ class InstallManagementNodeCmd(Command):
 
     - name: install dependencies on RedHat OS from user defined repo
       when: ansible_os_family == 'RedHat' and yum_repo != 'false'
-      shell: yum clean metadata; yum --disablerepo=* --enablerepo={{yum_repo}} --nogpgcheck install -y dmidecode java-1.8.0-openjdk wget python-devel gcc autoconf tar gzip unzip python-pip openssh-clients sshpass bzip2 sudo libselinux-python python-setuptools iptables-services libffi-devel openssl-devel
+      shell: yum clean metadata; yum --disablerepo=* --enablerepo={{yum_repo}} --nogpgcheck install -y dmidecode java-21-openjdk wget python-devel gcc autoconf tar gzip unzip python-pip openssh-clients sshpass bzip2 sudo libselinux-python python-setuptools iptables-services libffi-devel openssl-devel
 
     - name: install dependencies on RedHat OS from system repos
       when: ansible_os_family == 'RedHat' and yum_repo == 'false'
-      shell: yum clean metadata; yum --nogpgcheck install -y dmidecode java-1.8.0-openjdk wget python-devel gcc autoconf tar gzip unzip python-pip openssh-clients sshpass bzip2 sudo libselinux-python python-setuptools iptables-services libffi-devel openssl-devel
+      shell: yum clean metadata; yum --nogpgcheck install -y dmidecode java-21-openjdk wget python-devel gcc autoconf tar gzip unzip python-pip openssh-clients sshpass bzip2 sudo libselinux-python python-setuptools iptables-services libffi-devel openssl-devel
 
-    - name: set java 8 as default runtime
+    - name: set java 21 as default runtime
       when: ansible_os_family == 'RedHat'
-      shell: update-alternatives --install /usr/bin/java java /usr/lib/jvm/jre-1.8.0/bin/java 0; update-alternatives --set java /usr/lib/jvm/jre-1.8.0/bin/java
+      shell: update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-21-openjdk/bin/java 0; update-alternatives --set java /usr/lib/jvm/java-21-openjdk/bin/java
 
-    - name: add ppa source for openjdk-8 on Ubuntu 14.04
+    - name: add ppa source for openjdk-21 on Ubuntu 14.04
       when: ansible_os_family == 'Debian' and ansible_distribution_version == '14.04'
       shell: add-apt-repository ppa:openjdk-r/ppa -y; apt-get update
 
@@ -8065,17 +8065,17 @@ class InstallManagementNodeCmd(Command):
       when: ansible_os_family == 'Debian' and ansible_distribution_version == '14.04'
       apt: pkg={{item}} update_cache=yes
       with_items:
-        - openjdk-8-jdk
+        - openjdk-21-jdk
 
     - name: install openjdk on Ubuntu 16.04
       when: ansible_os_family == 'Debian' and ansible_distribution_version == '16.04'
       apt: pkg={{item}} update_cache=yes
       with_items:
-        - openjdk-8-jdk
+        - openjdk-21-jdk
 
-    - name: set java 8 as default runtime
+    - name: set java 21 as default runtime
       when: ansible_os_family == 'Debian' and ansible_distribution_version == '14.04'
-      shell: update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java 0; update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/javac 0; update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java; update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
+      shell: update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-21-openjdk-amd64/bin/java 0; update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-21-openjdk-amd64/bin/javac 0; update-alternatives --set java /usr/lib/jvm/java-21-openjdk-amd64/bin/java; update-alternatives --set javac /usr/lib/jvm/java-21-openjdk-amd64/bin/javac
 
     - name: install dependencies Debian OS
       when: ansible_os_family == 'Debian'

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -3064,7 +3064,6 @@ class StartCmd(Command):
                 '-XX:MaxMetaspaceSize=512m',
                 '-XX:+HeapDumpOnOutOfMemoryError',
                 '-XX:HeapDumpPath=%s' % os.path.join(ctl.zstack_home, self.HEAP_DUMP_DIR),
-                '-XX:+UseAltSigs',
                 '-Dlog4j2.formatMsgNoLookups=true'
             ]
 


### PR DESCRIPTION
## Summary
Build system and installation scripts for JDK 21 + Tomcat 10.1 (Jakarta EE) modernization.

- **Tomcat**: 8.5.x → 10.1.34 (`build.properties`, `build.oss.properties`)
- **install.sh**: JDK package names, version checks, `update-alternatives` paths (RHEL + Ubuntu)
- **ctl.py**: Embedded Ansible playbook JDK package names and paths

## Changes (5 files, 27 substitutions)
| Area | Files | Change |
|------|-------|--------|
| Tomcat | `build.properties`, `build.oss.properties`, `README.md` | 8.5.x → 10.1.34 |
| install.sh | `installation/install.sh` | JDK packages/paths/checks |
| ctl.py | `zstackctl/zstackctl/ctl.py` | Ansible playbook JDK refs |

## Related
- zstackio/zstack !9293 (core modernization)
- zstackio/premium !13102 (premium modernization)

sync from gitlab !6697