### PR TITLE
<fix>[kvmagent]: fix swtpm path error

### DIFF
--- a/kvmagent/kvmagent/plugins/vms/tpm.py
+++ b/kvmagent/kvmagent/plugins/vms/tpm.py
@@ -26,7 +26,12 @@ class TpmStateHostFile(object):
 
 def build_tpm_state_vm_host_folder_path(vm_uuid):
     # type: (str) -> str
-    return "/var/lib/libvirt/swtpm/%s" % (vm_uuid)
+    vm_uuid_with_hyphen = re.sub(
+        r'^([a-fA-F0-9]{8})([a-fA-F0-9]{4})([a-fA-F0-9]{4})([a-fA-F0-9]{4})([a-fA-F0-9]{12})$',
+        r'\1-\2-\3-\4-\5',
+        vm_uuid
+    )
+    return "/var/lib/libvirt/swtpm/%s/" % (vm_uuid_with_hyphen)
 
 def check_tpm_state_vm_host_file_path_format(path):
     # type: (str) -> bool
@@ -34,6 +39,6 @@ def check_tpm_state_vm_host_file_path_format(path):
         return False
     
     path = path.rstrip('/')
-    uuid_pattern = r'[a-fA-F0-9]{8}[a-fA-F0-9]{4}[a-fA-F0-9]{4}[a-fA-F0-9]{4}[a-fA-F0-9]{12}'
+    uuid_pattern = r'[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}'
     pattern = r'^/var/lib/libvirt/swtpm/({0})$'.format(uuid_pattern)
     return bool(re.match(pattern, path))

--- a/kvmagent/kvmagent/plugins/vms/vm_host_file.py
+++ b/kvmagent/kvmagent/plugins/vms/vm_host_file.py
@@ -70,8 +70,9 @@ def read_vm_host_file_targz(to):
     tmp_tar_path = os.path.join(tmp_dir, "archive.tar.gz")
 
     try:
-        base_dir = os.path.dirname(to.path)
-        target_name = os.path.basename(to.path)
+        base_path = to.path.rstrip("/")
+        base_dir = os.path.dirname(base_path)
+        target_name = os.path.basename(base_path)
         cmd = "tar -czf %s -C %s %s" % (pipes.quote(tmp_tar_path), pipes.quote(base_dir), pipes.quote(target_name))
         r, _, e = bash.bash_roe(cmd)
         if r != 0:

--- a/kvmagent/kvmagent/plugins/vms/vm_host_file.py
+++ b/kvmagent/kvmagent/plugins/vms/vm_host_file.py
@@ -21,7 +21,7 @@ class VmHostFileTO(object):
         self.type = ''
         self.fileFormat = ''
         self.contentBase64 = ''
-        self.error = ''
+        self.error = None  # type: str
 
 def is_allowed_paths(path):
     # type: (str) -> bool


### PR DESCRIPTION
Modified the ``build_tpm_state_vm_host_folder_path`` method
to add normalization processing for the VM UUID.

This converts it to a hyphenated format before
using it in path construction.

Resolves: ZSV-11463
Related: ZSV-11310

Change-Id: I786176646a6a756e727571696374716e6f6f6268

sync from gitlab !6708