### PR TITLE
[BugFix: ZSTAC-83056] fix Windows VM file upload UnicodeDecodeError in qga

### DIFF
--- a/zstacklib/zstacklib/utils/qga.py
+++ b/zstacklib/zstacklib/utils/qga.py
@@ -184,11 +184,11 @@ class VmQga(object):
         parsedRet = parsed['return']
         if isinstance(parsedRet, dict):
             if 'out-data' in parsedRet:
-                parsedRet['out-data'] = base64.b64decode(parsedRet['out-data']).decode()
+                parsedRet['out-data'] = decode_with_fallback(base64.b64decode(parsedRet['out-data']))
             if 'err-data' in parsedRet:
-                parsedRet['err-data'] = base64.b64decode(parsedRet['err-data']).decode()
+                parsedRet['err-data'] = decode_with_fallback(base64.b64decode(parsedRet['err-data']))
             if 'buf-b64' in parsedRet:
-                parsedRet['buf-b64'] = base64.b64decode(parsedRet['buf-b64']).decode()
+                parsedRet['buf-b64'] = decode_with_fallback(base64.b64decode(parsedRet['buf-b64']))
 
         return parsedRet
 


### PR DESCRIPTION
## Summary
- Windows 云主机上传文件失败，`call_qga_command` 中 `base64.b64decode(...).decode()` 默认用 UTF-8 解码，但 Windows 返回 GBK 编码数据导致 `UnicodeDecodeError`
- 将 `.decode()` 替换为已有的 `decode_with_fallback()` 函数（UTF-8 → GB2312 → ISO-8859-1 逐一尝试）

## Changes
- `zstacklib/zstacklib/utils/qga.py`: `call_qga_command()` 中 `out-data`、`err-data`、`buf-b64` 三处解码改用 `decode_with_fallback()`

Resolves: ZSTAC-83056

sync from gitlab !6716