### PR TITLE
fix(kvm): restore zwatch-vm-agent to copy_tools tool_list [ZSTAC-83094]

### DIFF
--- a/kvmagent/ansible/kvm.py
+++ b/kvmagent/ansible/kvm.py
@@ -505,7 +505,7 @@ def install_kvm_pkg():
 
 def copy_tools():
     """copy binary tools"""
-    tool_list = ['collectd_exporter', 'node_exporter', 'ipmi_exporter', 'dnsmasq', 'pushgateway', 'sas3ircu', 'zs-raid-heartbeat']
+    tool_list = ['collectd_exporter', 'node_exporter', 'ipmi_exporter', 'dnsmasq', 'zwatch-vm-agent', 'zwatch-vm-agent_freebsd_amd64', 'pushgateway', 'sas3ircu', 'zs-raid-heartbeat']
 
     for tool in tool_list:
         arch_lable = '' if host_info.host_arch == 'x86_64' else '_' + host_info.host_arch


### PR DESCRIPTION
## 问题

升级 python3.11 时误合入 euler2403 feature branch 的 commit，其中 `copy_tools()` 的 `tool_list` 删除了 `zwatch-vm-agent` 和 `zwatch-vm-agent_freebsd_amd64`，导致所有系统不再部署 zwatch-vm-agent，VM 访问 `http://169.254.169.254/agent_version` 返回 404。

## 修复

1. 恢复 `zwatch-vm-agent` 和 `zwatch-vm-agent_freebsd_amd64` 到 `tool_list`
2. 用 `abi2_tools` 集合限制 `_abi2` 后缀只作用于有 abi2 变体的工具（避免 oe2403sp1 上查找不存在的 `zwatch-vm-agent_abi2` 二进制）

## 关联

- Jira: [ZSTAC-83094](http://jira.zstack.io/browse/ZSTAC-83094)
- 引入问题的 commit: `68f4382da9bef83e503dbea0fd2ee187516b3215` (MR !6666)

sync from gitlab !6719