### PR TITLE
<fix>[zstacklib]: Add 'Processing accelerators' to tianshu DEVICE_TYPES

### DIFF
--- a/zstacklib/zstacklib/gpu/vendors/tianshu.py
+++ b/zstacklib/zstacklib/gpu/vendors/tianshu.py
@@ -10,13 +10,13 @@ class Tianshu(GPUBase):
     VENDOR_IDS = {"1e3e"}
     PCI_NAME_KEYWORDS = {"1e3e"}
     CLI_TOOL = "ixsmi"
-    DEVICE_TYPES = {"3D controller", "VGA compatible controller"}
+    DEVICE_TYPES = {"3D controller", "VGA compatible controller", "Processing accelerators"}
 
     @classmethod
     def get_pci_only_candidates(cls, device_ids, device_names):
         """
         When ixsmi is not available, identify Tianshu GPU by PCI: vendor 1e3e,
-        class 3D controller or VGA compatible controller.
+        class 3D controller, VGA compatible controller, or Processing accelerators.
         """
         from zstacklib.utils.pci import normalize_pci_address
 

--- a/zstacklib/zstacklib/utils/gpu.py
+++ b/zstacklib/zstacklib/utils/gpu.py
@@ -852,7 +852,8 @@ def _gpu_device_processor(pci_device_to, context):
                 and is_valid_video_controller(pci_device_to.device)):
             pci_device_to.type = GPU_TYPE_VIDEO_CONTROLLER
         elif ((PCI_CLASS_PROCESSING_ACCEL in pci_device_to.type or (
-                pci_device_mapper.get(PCI_CLASS_PROCESSING_ACCEL) is not None))
+                pci_device_mapper.get(PCI_CLASS_PROCESSING_ACCEL) is not None
+                and pci_device_mapper.get(PCI_CLASS_PROCESSING_ACCEL) in pci_device_to.type))
               and is_valid_processing_accelerator(pci_device_to.device)):
             pci_device_to.type = GPU_TYPE_PROCESSING_ACCELERATORS
         elif ((PCI_CLASS_COPROCESSOR in pci_device_to.type or (


### PR DESCRIPTION
Add 'Processing accelerators' to DEVICE_TYPES so that
Tianshu devices with this PCI class are recognized via PCI fallback
path and enter gpu_info_map correctly

Resolves: ZSTAC-79982

Change-Id: I636c696d746d79726f6c666b76746273757a7165

sync from gitlab !6722