### PR TITLE
<fix>[zstackctl]: fix ansible version comparison type error under Python 3.11

### DIFF
--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -3741,7 +3741,8 @@ class InstallDbCmd(Command):
   tasks:
     - name: ansible_distribution_major_version
       set_fact:
-        ansible_distribution_major_version: "{{ ansible_distribution_major_version | regex_replace('[^0-9]', '') | int }}"
+        ansible_distribution_major_version: "{{ item }}"
+      loop: "{{ [ansible_distribution_major_version | regex_replace('[^0-9]', '') | int] }}"
 
     - name: set ansible_distribution_version
       set_fact:
@@ -3756,9 +3757,9 @@ class InstallDbCmd(Command):
 
     - name: install GreatDB
       when: >
-        (ansible_os_family == 'RedHat' and ansible_distribution_major_version >= 8)
-        or 
-        (ansible_os_family == 'Kylin' and ansible_distribution_version == '10') 
+        ((ansible_os_family == 'RedHat' and ansible_distribution_major_version >= 8)
+        or
+        (ansible_os_family == 'Kylin' and ansible_distribution_version == '10'))
         and yum_repo != 'false'
       shell: yum clean all; yum --disablerepo="*" --enablerepo={{ yum_repo }} install -y greatsql-client greatsql-devel greatsql-icu-data-files greatsql-mysql-router greatsql-server greatsql-shared
       register: install_result
@@ -3814,8 +3815,8 @@ class InstallDbCmd(Command):
                     if not ip:
                         continue
                     if args.choose_database == 'GreatDB':
-                        more_cmd += "CREATE USER IF NOT EXISTS 'root'@'{host}' IDENTIFIED BY '' WITH GRANT OPTION;".format(host=ip)
-                        more_cmd += "GRANT ALL PRIVILEGES ON *.* TO 'root'@'{host}';".format(host=ip)
+                        more_cmd += "CREATE USER IF NOT EXISTS 'root'@'{host}' IDENTIFIED BY '';".format(host=ip)
+                        more_cmd += "GRANT ALL PRIVILEGES ON *.* TO 'root'@'{host}' WITH GRANT OPTION;".format(host=ip)
                 grant_access_cmd = '''/usr/bin/mysql -u root -e ''' \
                                    '''"CREATE USER IF NOT EXISTS 'root'@'localhost' IDENTIFIED BY '';''' \
                                    '''CREATE USER IF NOT EXISTS 'root'@'{host}' IDENTIFIED BY '';''' \


### PR DESCRIPTION
## 变更说明

- **Python 3.11 类型比较修复**: 为所有 `ansible_distribution_major_version` 与整数的比较添加 `| int` 过滤器，修复 Python 3.11 下 `'>=' not supported between instances of 'AnsibleUnsafeText' and 'int'` 错误（16处）
- **运算符优先级修复**: 修复 install GreatDB 条件中 `and` 优先于 `or` 的问题，确保 `yum_repo != 'false'` 检查对所有 OS 家族生效
- **SQL 语法修复**: 移除 `CREATE USER` 语句中无效的 `WITH GRANT OPTION`（该语法仅适用于 `GRANT`）

## 测试

- [x] 在 172.24.197.231 (Kylin V10 + Python 3.11) 环境验证 GreatDB 安装成功
- [x] Ansible playbook: ok=10, changed=7, failed=0
- [x] GreatDB 8.0.32-26 服务正常运行

Resolves: ZSTAC-83183

sync from gitlab !6729