### PR TITLE
<fix>[zstacklib]: add python3-libselinux for all RPM-based distros

### DIFF
--- a/zstacklib/ansible/zstacklib.py
+++ b/zstacklib/ansible/zstacklib.py
@@ -2352,9 +2352,9 @@ class ZstackLib(object):
                 if self.distro_version >= 7 and self.zstack_releasever in centos:
                     self.copy_redhat_yum_repo()
                 # zstack_repo is empty, will use system repo
-                # libselinux-python depend by ansible copy/file/template module
-                # when selinux enabled on host
-                yum_install_package("libselinux-python", self.host_post_info)
+                # python3-libselinux is needed by ansible copy/file/template/
+                # selinux modules when selinux is enabled on host
+                yum_install_package("python3-libselinux", self.host_post_info)
                 # install epel-release
                 if self.distro in RPM_BASED_OS and self.zstack_releasever in centos:
                     self.copy_epel_yum_repo()
@@ -2374,8 +2374,7 @@ class ZstackLib(object):
                 # generate zstack experimental repo anyway
                 self.generate_zstack_experimental_yum_repo()
 
-            # install libselinux-python and other command system libs from user
-            # defined repos
+            # install python3-libselinux and other system libs
             self.install_rpm_based_os_requirements(
                 self.zstack_repo, user_defined)
         elif self.distro in DEB_BASED_OS:
@@ -2412,17 +2411,13 @@ class ZstackLib(object):
             "vim-minimal",
         }
 
+        # python3-libselinux is required by ansible selinux/copy/file modules
+        basic.add("python3-libselinux")
+
         if self.distro in KYLIN_DISTRO:
             basic.add("chrony")
             basic.add("iptables")
-            basic.add("python3-libselinux")
             return basic
-
-        # python3-libselinux is required by ansible selinux module's respawn
-        # mechanism: when the current interpreter lacks selinux bindings,
-        # ansible probes system python (/usr/bin/python3) and respawns with
-        # the one that has python3-libselinux installed.
-        basic.add("python3-libselinux")
 
         if self.distro_version >= 7:
             # to avoid install some pkgs on virtual router which release is
@@ -2447,8 +2442,7 @@ class ZstackLib(object):
             before_install_command += \
                 "yum clean --enablerepo=%s metadata && " % zstack_repo
 
-        # install libselinux-python and other command system libs from user
-        # defined repos
+        # install python3-libselinux first, it's needed by ansible modules
         selinux_pkgs = [p for p in required_rpm_set if "selinux" in p]
         if zstack_repo == "false":
             batch_yum_install_package(selinux_pkgs, self.host_post_info)
@@ -2555,7 +2549,7 @@ enabled=0" >  /etc/yum.repos.d/zstack-mn.repo; sync /etc/yum.repos.d/zstack-mn.r
             raise Exception(
                 "failed to read yum repo content from %s" % yum_repo_file_path)
 
-        # copy module may not supported due to libselinux-python requirement
+        # copy module may not work without python3-libselinux
         # manually create yum repo to /etc/yum.repos.d/
         command = """
 cat << 'EOF' > /etc/yum.repos.d/%s

--- a/zstacklib/ansible/zstacklib.py
+++ b/zstacklib/ansible/zstacklib.py
@@ -2415,10 +2415,14 @@ class ZstackLib(object):
         if self.distro in KYLIN_DISTRO:
             basic.add("chrony")
             basic.add("iptables")
-            # TODO: python3.11-libselinux is not available on most distros,
-            #  need to build or find a package for python3.11 when SELinux is enabled
             basic.add("python3-libselinux")
             return basic
+
+        # python3-libselinux is required by ansible selinux module's respawn
+        # mechanism: when ansible runs with python3.11 (which lacks selinux
+        # bindings), it probes system interpreters and respawns with python3.9
+        # which has python3-libselinux installed.
+        basic.add("python3-libselinux")
 
         if self.distro_version >= 7:
             # to avoid install some pkgs on virtual router which release is

--- a/zstacklib/ansible/zstacklib.py
+++ b/zstacklib/ansible/zstacklib.py
@@ -2419,9 +2419,9 @@ class ZstackLib(object):
             return basic
 
         # python3-libselinux is required by ansible selinux module's respawn
-        # mechanism: when ansible runs with python3.11 (which lacks selinux
-        # bindings), it probes system interpreters and respawns with python3.9
-        # which has python3-libselinux installed.
+        # mechanism: when the current interpreter lacks selinux bindings,
+        # ansible probes system python (/usr/bin/python3) and respawns with
+        # the one that has python3-libselinux installed.
         basic.add("python3-libselinux")
 
         if self.distro_version >= 7:

--- a/zstacklib/ansible/zstacklib.py
+++ b/zstacklib/ansible/zstacklib.py
@@ -2405,18 +2405,17 @@ class ZstackLib(object):
         return python_requirement_set
 
     def _basic_rpm_set(self):
-        basic = {
-            "gcc",
-            "autoconf",
-            "vim-minimal",
-        }
-
         # python3-libselinux is required by ansible selinux/copy/file modules.
         # When the current interpreter (e.g. python3.11) lacks selinux bindings,
         # ansible's respawn mechanism probes system python (/usr/bin/python3)
         # and re-executes the module with the interpreter that has
         # python3-libselinux installed.
-        basic.add("python3-libselinux")
+        basic = {
+            "gcc",
+            "autoconf",
+            "vim-minimal",
+            "python3-libselinux",
+        }
 
         if self.distro in KYLIN_DISTRO:
             basic.add("chrony")

--- a/zstacklib/ansible/zstacklib.py
+++ b/zstacklib/ansible/zstacklib.py
@@ -2411,7 +2411,11 @@ class ZstackLib(object):
             "vim-minimal",
         }
 
-        # python3-libselinux is required by ansible selinux/copy/file modules
+        # python3-libselinux is required by ansible selinux/copy/file modules.
+        # When the current interpreter (e.g. python3.11) lacks selinux bindings,
+        # ansible's respawn mechanism probes system python (/usr/bin/python3)
+        # and re-executes the module with the interpreter that has
+        # python3-libselinux installed.
         basic.add("python3-libselinux")
 
         if self.distro in KYLIN_DISTRO:


### PR DESCRIPTION
## 问题

ZSTAC-83144: 欧拉(Helix)系统添加物理机失败，deploy.log 中 ansible selinux 模块报错：
```
ModuleNotFoundError: No module named 'selinux'
Failed to import the required Python library (libselinux-python) on Python /usr/bin/python3.11
```

## 根因

1. Helix/openEuler 主机升级到 Python 3.11 后，ansible 自动发现并使用 python3.11
2. ansible selinux 模块需要 `python3-libselinux` 包提供的 Python bindings
3. `_basic_rpm_set()` 只为 `KYLIN_DISTRO` 安装 `python3-libselinux`，Helix/openEuler 不在其中
4. 目标机上 `python3-libselinux` 未安装，ansible 的 respawn 机制也无法找到可用的解释器

## 修复

在 `_basic_rpm_set()` 中为所有 RPM-based 发行版添加 `python3-libselinux`。

安装后 ansible selinux 模块的 respawn 机制可正常工作：python3.11 import 失败 → 探测到 `/usr/bin/python3` (python3.9) 有 selinux bindings → 用 python3.9 重新执行模块 → 成功。

## 验证

在 172.26.106.107 (Helix 22.03 aarch64) 上验证：
- 未装 `python3-libselinux` 时，ansible selinux 模块失败
- 安装 `python3-libselinux` 后，ansible selinux 模块成功（auto python 和 force python3.9 均通过）

Resolves: ZSTAC-83144

sync from gitlab !6733