### PR TITLE
<fix>[zstackctl]: clean up __pycache__ under ansible/files before starting MN

### DIFF
--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -3180,6 +3180,18 @@ class StartCmd(Command):
             else:
                 ctl.delete_properties(['simulatorsOn'])
 
+        def clean_pycache():
+            ansible_files_dir = os.path.join(os.path.expanduser('~zstack'), "ansible/files")
+            if os.path.isdir(ansible_files_dir):
+                for root, dirs, _ in os.walk(ansible_files_dir):
+                    for d in dirs:
+                        if d == '__pycache__':
+                            pycache_dir = os.path.join(root, d)
+                            try:
+                                rmtree(pycache_dir)
+                            except Exception as e:
+                                warn("failed to remove %s: %s" % (pycache_dir, str(e)))
+
         if os.getuid() != 0:
             raise CtlError('please use sudo or root user')
 
@@ -3201,6 +3213,7 @@ class StartCmd(Command):
         prepare_bean_ref_context_xml()
 
         linux.sync_file(ctl.properties_file_path)
+        clean_pycache()
         start_mgmt_node()
         #sleep a while, since zstack won't start up so quickly
         time.sleep(5)


### PR DESCRIPTION
## 问题

MN 启动失败，报错 `AccessDeniedException: .../zstacklib/__pycache__`。

## 根因

老版本代码没有 `-B` 参数，但 `zstack.properties` 中 `Ansible.executable` 已被设为 `python3.11`（从上一次 py3 升级遗留）。老版本以 `sudo` 执行 `python3.11 consoleproxy.py` 时，Python 3 自动在 `ansible/files/zstacklib/` 下生成了 `root:root` 的 `__pycache__` 目录。

升级到新版本后，MN 以 zstack 用户启动，`AnsibleFacadeImpl.deployModule()` 中 `FileUtils.forceDelete()` 无权删除 root 所属的 `__pycache__`，导致启动失败。

## 修复

在 `zstack-ctl start_node` 启动 MN 之前（此时以 root 运行），清理 `ansible/files/` 下所有 `__pycache__` 目录。

## Jira
http://jira.zstack.io/browse/ZSTAC-82619

sync from gitlab !6750