### PR TITLE
ZSTAC-83376 fix Python 3 true division returning float in integer contexts

### DIFF
--- a/cephbackupstorage/cephbackupstorage/cephagent.py
+++ b/cephbackupstorage/cephbackupstorage/cephagent.py
@@ -1095,7 +1095,7 @@ class CephAgent(object):
                 last = linux.tail_1(PFILE).strip()
                 if not last or not last.isdigit():
                     return synced
-                report.progress_report(int(last)*90/100, "report")
+                report.progress_report(int(last)*90//100, "report")
                 return synced
 
             get_content_from_pipe_cmd = "pv -s %s -n %s 2>%s" % (actual_size, pipe_path, PFILE)

--- a/kvmagent/kvmagent/plugins/ha_plugin.py
+++ b/kvmagent/kvmagent/plugins/ha_plugin.py
@@ -679,7 +679,7 @@ class SblkHealthChecker(AbstractStorageFencer):
         parser = sanlock.SanlockHostStatusParser(shell.call("timeout 30 sanlock client host_status -s lvm_%s -D" % ps_uuid))
         dst_host_io_timeout = parser.get_record(dst_host_id).get_io_timeout()
         our_host_io_timeout = parser.get_record(our_host_id).get_io_timeout()
-        max_check_count = (sanlock.calc_host_dead_seconds(dst_host_io_timeout) + 2 * our_host_io_timeout) / check_interval + 1
+        max_check_count = (sanlock.calc_host_dead_seconds(dst_host_io_timeout) + 2 * our_host_io_timeout) // check_interval + 1
         logger.debug("dst host %s sanlock io timeout is %s, current host: %s" % (dst_host_uuid, dst_host_io_timeout, our_host_io_timeout))
         latest_timestamp = None
         timestamp_change_count = 0

--- a/kvmagent/kvmagent/plugins/ovsdpdk_network.py
+++ b/kvmagent/kvmagent/plugins/ovsdpdk_network.py
@@ -394,17 +394,17 @@ class OvsDpdkNetworkPlugin(kvmagent.KvmAgent):
 
         ovsctl = ovs.getOvsCtl(with_dpdk=True)
         #calculate hugepage num and turn float str to int
-        res = ovsctl.resourceConfigure(int(float(int(cmd.reserveSize)/int(cmd.pageSize))), int(float(cmd.pageSize)), int(float(cmd.socketMem)))
+        res = ovsctl.resourceConfigure(int(float(int(cmd.reserveSize)//int(cmd.pageSize))), int(float(cmd.pageSize)), int(float(cmd.socketMem)))
         if res == -1:
             rsp.error = "hugepage config failed"
             rsp.success = False
 
             logger.debug(http.path_msg(OVS_DPDK_NET_RESOURCE_CONFIGURE,
-                                  'resource configure hugepage number:{} failed.'.format(int(float(int(cmd.reserveSize)/int(cmd.pageSize))))))
+                                  'resource configure hugepage number:{} failed.'.format(int(float(int(cmd.reserveSize)//int(cmd.pageSize))))))
             return jsonobject.dumps(rsp)
 
         logger.debug(http.path_msg(OVS_DPDK_NET_RESOURCE_CONFIGURE,
-                                  'resource configure hugepage number:{} success.'.format(int(float(int(cmd.reserveSize)/int(cmd.pageSize))))))
+                                  'resource configure hugepage number:{} success.'.format(int(float(int(cmd.reserveSize)//int(cmd.pageSize))))))
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -5467,7 +5467,7 @@ class Vm(object):
                         e(cpu, 'topology', attrib={'sockets': str(cmd.socketNum), 'cores': str(cmd.cpuOnSocket), 'threads': '1'})
                     else:
                         socketNum = LibvirtAutoReconnect.capabilities.host().cells().getAttribute('num')
-                        cores = str(int(max_vcpu / int(socketNum)))
+                        cores = str(int(max_vcpu // int(socketNum)))
                         e(cpu, 'topology', attrib={'sockets': socketNum, 'cores': cores, 'threads': '1'})
                     numa = e(cpu, 'numa')
                     e(numa, 'cell', attrib={'id': '0', 'cpus': '0-%d' % (max_vcpu - 1), 'memory': str(mem), 'unit': 'KiB'})
@@ -5480,7 +5480,7 @@ class Vm(object):
                     e(cpu, 'model', str(MIPS64EL_CPU_MODEL), attrib={'fallback': 'allow'})
                     sockets = cmd.socketNum if cmd.socketNum else 2
                     mem = cmd.memory // 1024 // sockets
-                    cores = max_vcpu / sockets
+                    cores = max_vcpu // sockets
                     e(cpu, 'topology', attrib={'sockets': str(sockets), 'cores': str(cores), 'threads': '1'})
                     numa = e(cpu, 'numa')
                     for i in range(sockets):
@@ -5494,7 +5494,7 @@ class Vm(object):
                     e(cpu, 'model', str(LOONGARCH64_CPU_MODEL), attrib={'fallback': 'allow'})
                     sockets = cmd.socketNum if cmd.socketNum else 8
                     mem = cmd.memory // 1024 // sockets
-                    cores = max_vcpu / sockets
+                    cores = max_vcpu // sockets
                     e(cpu, 'topology', attrib={'sockets': str(sockets), 'cores': str(cores), 'threads': '1'})
                     numa = e(cpu, 'numa')
                     for i in range(sockets):

--- a/zstackcli/zstackcli/cli.py
+++ b/zstackcli/zstackcli/cli.py
@@ -816,7 +816,7 @@ Parse command parameters error:
             except:
                 term_width = 80
 
-            columes = term_width / max_match_length
+            columes = term_width // max_match_length
             if columes == 0:
                 columes = 1
 
@@ -840,10 +840,8 @@ Parse command parameters error:
 
         print('')
         print_bold()
-        print('')
-        cprint('%s%s' % (self.get_prompt_with_account_info(), readline.get_line_buffer()), end='')
-
-        # readline.redisplay()
+        sys.stdout.write('%s%s' % (self.get_prompt_with_account_info(), readline.get_line_buffer()))
+        sys.stdout.flush()
 
     def write_more(self, cmd, result, success=True):
         if self.hd.get(self.start_key):

--- a/zstackcli/zstackcli/cli.py
+++ b/zstackcli/zstackcli/cli.py
@@ -1164,7 +1164,9 @@ Parse command parameters error:
         """
         Constructor
         """
-        readline.parse_and_bind("tab: complete")
+        readline.parse_and_bind("tab: menu-complete")
+        readline.parse_and_bind("set completion-ignore-case on")
+        readline.parse_and_bind("set show-all-if-ambiguous on")
         readline.set_completer(self.complete)
         readline.set_completion_display_matches_hook(self.completer_print)
         try:

--- a/zstackctl/zstackctl/migrate_influxdb_data.py
+++ b/zstackctl/zstackctl/migrate_influxdb_data.py
@@ -633,7 +633,7 @@ def migrate(args):
     origin_global_config = mysql_client.get_max_allowed_packet()
 
     if not args.num:
-        args.num = origin_global_config / 4096
+        args.num = origin_global_config // 4096
 
     if args.passwd:
         if origin_global_config < 67108864:  # 64m

--- a/zstacklib/zstacklib/storage/lvm/snapshot.py
+++ b/zstacklib/zstacklib/storage/lvm/snapshot.py
@@ -40,11 +40,11 @@ def create_lvm_snapshot(
         virtual_size = linux.qcow2_virtualsize(drbd_path if drbd_path else absolute_path)
         if virtual_size <= 2147483648:
             snap_size = calc_lv_reserved_size(virtual_size)
-            snap_size = int(snap_size / 512 + 1) * 512
-        elif int((virtual_size / 512) * size_percent * 512) <= 2147483648:
+            snap_size = int(snap_size // 512 + 1) * 512
+        elif int((virtual_size // 512) * size_percent * 512) <= 2147483648:
             snap_size = 2147483648
         else:
-            snap_size = int((virtual_size / 512) * size_percent + 1) * 512
+            snap_size = int((virtual_size // 512) * size_percent + 1) * 512
         size_command = f" -L {snap_size}B "
         
     bash.bash_errorout(

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -1332,7 +1332,7 @@ qemu-io -c "discard $[i*2145386496] 2145386496" -f qcow2 -d unmap {1}
 let i+=1
 done
 qemu-io -c "discard $[i*2145386496] {2}" -f qcow2 -d unmap {1}
-    '''.format(virtual_size / 2145386496, path, virtual_size % 2145386496))
+    '''.format(virtual_size // 2145386496, path, virtual_size % 2145386496))
 
     cmd(False)
     logger.debug("qcow2 discard return code: %s, stderr: %s" % (cmd.return_code, cmd.stderr))
@@ -3296,7 +3296,7 @@ def compare_segmented_xxhash(src_path, dst_path, total_size, raise_exception=Fal
         return True
 
     seg_size = 2*1024**3 ## 2G
-    seg_offset = [total_size/5*x for x in range(0, 5)]
+    seg_offset = [total_size//5*x for x in range(0, 5)]
     def _get_seg_xxhash(fd, offset):
         hasher = xxhash.xxh64()
         fd.seek(offset)


### PR DESCRIPTION
## Summary

Python 3 changed `/` from floor division to true division, returning `float` instead of `int`. This breaks integer-dependent logic across multiple modules.

Resolves: ZSTAC-83376

## Changes (8 files, 15 fixes)

| Module | Issue |
|--------|-------|
| `zstackcli/cli.py` | Tab completion column count + cursor position (remove manual prompt reprint, let readline auto-redisplay) |
| `vm_plugin.py` | CPU cores calculation for libvirt topology XML |
| `ha_plugin.py` | Sanlock check loop count |
| `ovsdpdk_network.py` | Hugepage number calculation |
| `snapshot.py` | LV snapshot 512-byte sector alignment |
| `linux.py` | qcow2 discard loop count + file hash seek offsets |
| `migrate_influxdb_data.py` | Batch size calculation |
| `cephagent.py` | Progress report percentage |

## Test Plan

- [ ] Verify `zstackcli` tab completion layout and cursor position
- [ ] Verify VM creation with CPU topology on mips64el/loongarch64
- [ ] Verify LV snapshot creation with sector alignment

sync from gitlab !6781