### PR TITLE
<refactor>[shared_block]: extract connect helpers to instance methods and lvm module

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -219,6 +219,18 @@ class CreateVolumeFromCacheRsp(AgentRsp):
         self.size = None
 
 
+class TakeoverRsp(AgentRsp):
+    def __init__(self):
+        super(TakeoverRsp, self).__init__()
+
+
+class GetVgsInfoRsp(AgentRsp):
+    def __init__(self):
+        super(GetVgsInfoRsp, self).__init__()
+        self.vgsSharedBlockStructs = {}
+        self.vgsSharedBlockCount = {}
+
+
 def translate_absolute_path_from_install_path(path):
     if path is None:
         raise Exception("install path can not be null")
@@ -367,6 +379,8 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
     SHRINK_SNAPSHOT_PATH = "/sharedblock/snapshot/shrink"
     GET_QCOW2_HASH_VALUE_PATH = "/sharedblock/getqcow2hash"
     CHECK_STATE_PATH = "/sharedblock/vgstate/check"
+    TAKEOVER_PATH = "/sharedblock/takeover"
+    VGS_INFO_PATH = "/sharedblock/vgs/info"
 
     vgs_in_progress = set()
     vg_size = {}
@@ -419,6 +433,8 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         http_server.register_async_uri(self.SHRINK_SNAPSHOT_PATH, self.shrink_snapshot)
         http_server.register_async_uri(self.GET_QCOW2_HASH_VALUE_PATH, self.get_qcow2_hashvalue)
         http_server.register_async_uri(self.CHECK_STATE_PATH, self.check_vg_state)
+        http_server.register_async_uri(self.TAKEOVER_PATH, self.takeover)
+        http_server.register_async_uri(self.VGS_INFO_PATH, self.vgs_info)
 
         self.imagestore_client = ImageStoreClient()
 
@@ -550,21 +566,21 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         ## lvm.refresh_lv_uuid_cache_if_need()
         return jsonobject.dumps(rsp)
 
-    @kvmagent.replyerror
-    def connect(self, req):
-        cmd = jsonobject.loads(req[http.REQUEST_BODY])
-        global MAX_ACTUAL_SIZE_FACTOR
-        MAX_ACTUAL_SIZE_FACTOR = cmd.maxActualSizeFactor
+    def _run_with_sblk_lock(self, cmd, handler, operation, lock_retry_times=10, lock_retry_interval=(0.1, 1)):
+        """Common wrapper for connect/takeover: acquires NamedLock, calls handler, handles errors.
+
+        lock_retry_interval can be a number or a (min, max) tuple for random sleep.
+        """
         sblk_lock = lock.NamedLock("sharedblock-%s" % cmd.vgUuid)
         rsp = None
         try:
-            self.get_lock(sblk_lock)
-            rsp = self.do_connect(cmd)
+            self.get_lock(sblk_lock, retry_times=lock_retry_times, retry_interval=lock_retry_interval)
+            rsp = handler(cmd)
         except SharedBlockConnectException as e:
             r = AgentRsp()
             r.success = False
-            r.error = "can not connect sharedblock primary storage[uuid: %s] on host[uuid: %s], " \
-                        "because other thread is connecting now" % (cmd.vgUuid, cmd.hostUuid)
+            r.error = "can not %s sharedblock primary storage[uuid: %s] on host[uuid: %s], " \
+                      "because other thread is %s now" % (operation, cmd.vgUuid, cmd.hostUuid, operation)
             rsp = jsonobject.dumps(r)
         except Exception as e:
             if rsp is None:
@@ -575,7 +591,14 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
                 rsp = jsonobject.dumps(r)
         finally:
             self.release_lock(sblk_lock)
-            return rsp
+        return rsp
+
+    @kvmagent.replyerror
+    def connect(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        global MAX_ACTUAL_SIZE_FACTOR
+        MAX_ACTUAL_SIZE_FACTOR = cmd.maxActualSizeFactor
+        return self._run_with_sblk_lock(cmd, self.do_connect, "connecting")
 
     @kvmagent.replyerror
     @lock.file_lock(LOCK_FILE)
@@ -591,22 +614,22 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         logger.debug("find/create vg %s lock..." % cmd.vgUuid)
         rsp.isFirst = self.create_vg_if_not_found(cmd.vgUuid, disks, cmd.hostUuid, allDisks, cmd.forceWipe, cmd.isFirst)
 
-#       sanlock table:
-#
-#       | sanlock patch version | delta lease sleep time | retry times |
-#       | --------------------- | ---------------------- | ----------- |
-#       | 1                     | 40 seconds             | 15          |
-#       | 2 or higher           | 0 second               | 3           |
-#
-#
-#       explain:
-#
-#       In sanlock patch version 1, when you start a vg lock, it takes around 40 seconds
-#       in delta lease. So 15 retry times are required to check if vg lockspace exists.
-#
-#       In sanlock patch version 2, the sleep time in delta lease can be defined by zstack
-#       utility in sanlock.conf. It's 0 second by default, so retry times can be reduced to
-#       3 in order to save time.
+        #       sanlock table:
+        #
+        #       | sanlock patch version | delta lease sleep time | retry times |
+        #       | --------------------- | ---------------------- | ----------- |
+        #       | 1                     | 40 seconds             | 15          |
+        #       | 2 or higher           | 0 second               | 3           |
+        #
+        #
+        #       explain:
+        #
+        #       In sanlock patch version 1, when you start a vg lock, it takes around 40 seconds
+        #       in delta lease. So 15 retry times are required to check if vg lockspace exists.
+        #
+        #       In sanlock patch version 2, the sleep time in delta lease can be defined by zstack
+        #       utility in sanlock.conf. It's 0 second by default, so retry times can be reduced to
+        #       3 in order to save time.
 
         retry_times_for_checking_vg_lockspace = lvm.get_retry_times_for_checking_vg_lockspace()
 
@@ -631,16 +654,23 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         rsp.lunCapacities = lvm.get_lun_capacities_from_vg(cmd.vgUuid, self.vgs_path_and_wwid)
         return jsonobject.dumps(rsp)
 
-    @linux.retry(times=10, sleep_time=random.uniform(0.1, 1))
-    def get_lock(self, sblk_lock):
-        sblk_lock.lock = lock._get_lock(sblk_lock.name)
-        if sblk_lock.lock.acquire(False) is False:
-            raise SharedBlockConnectException("can not get %s lock, there is other thread running" % sblk_lock.name)
+    def get_lock(self, sblk_lock, retry_times=10, retry_interval=(0.1, 1)):
+        for i in range(retry_times):
+            sblk_lock.lock = lock._get_lock(sblk_lock.name)
+            if sblk_lock.lock.acquire(False):
+                return
+            if i < retry_times - 1:
+                sleep = random.uniform(*retry_interval) if isinstance(retry_interval, tuple) else retry_interval
+                logger.debug("cannot get %s lock, retry %d/%d after %.1fs"
+                             % (sblk_lock.name, i + 1, retry_times, sleep))
+                time.sleep(sleep)
+        raise SharedBlockConnectException("can not get %s lock after %d retries, there is other thread running" % (sblk_lock.name, retry_times))
 
     def release_lock(self, sblk_lock):
         try:
             sblk_lock.lock.release()
-        except Exception:
+        except Exception as e:
+            logger.debug("release lock %s failed (ignored): %s" % (sblk_lock.name, str(e)))
             return
 
     def prepare_disk(self, cmd):
@@ -1731,4 +1761,113 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             if error:
                 rsp.failedVgs.update({vg_uuid: error})
 
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def takeover(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        global MAX_ACTUAL_SIZE_FACTOR
+        MAX_ACTUAL_SIZE_FACTOR = cmd.maxActualSizeFactor
+        return self._run_with_sblk_lock(cmd, self.do_takeover, "taking over",
+                                           lock_retry_times=10, lock_retry_interval=(1, 2))
+
+    @kvmagent.replyerror
+    @lock.file_lock(LOCK_FILE)
+    def do_takeover(self, cmd):
+        rsp = TakeoverRsp()
+        logger.info("takeover starts: vgUuid=%s, hostId=%s, hostUuid=%s, disks=%s"
+                    % (cmd.vgUuid, cmd.hostId, cmd.hostUuid, cmd.sharedBlockUuids))
+
+        # Step 1: prepare disk paths
+        _, _, allDiskPaths, allDisks = self.prepare_disk(cmd)
+        logger.info("takeover[1/8] prepared %d disk paths" % len(allDiskPaths))
+
+        # Step 2: configure LVM
+        lvm.config_lvm(cmd.hostId, allDiskPaths, cmd.vgUuid, cmd.hostUuid, DEFAULT_SANLOCK_LV_SIZE,
+                       kvmagent.get_host_os_type(), cmd.enableLvmetad)
+        logger.info("takeover[2/8] LVM config applied")
+
+        # Step 3: start lock service
+        lvm.start_lock_service(cmd.ioTimeout)
+        logger.info("takeover[3/8] lock service started")
+
+        # Step 4: find VG on storage by exact WWID match
+        def get_vg_name_by_shared_block_uuid():
+            vgsSharedBlockStructs, vgsSharedBlockCount = lvm.get_vgs_info(tag=INIT_TAG)
+            target_wwids = set(w.strip().lower() for w in cmd.sharedBlockUuids if w and w.strip())
+            matched_vgs = []
+
+            for _vg_uuid, block_devices in vgsSharedBlockStructs.items():
+                expected_pv_count = vgsSharedBlockCount.get(_vg_uuid, len(block_devices))
+                if any(not bd.wwid for bd in block_devices) or len(block_devices) != expected_pv_count:
+                    logger.warn("skip VG %s: incomplete WWID set" % _vg_uuid)
+                    continue
+                vg_wwids = set(bd.wwid.strip().lower() for bd in block_devices)
+                if target_wwids == vg_wwids:
+                    matched_vgs.append(_vg_uuid)
+
+            if len(matched_vgs) == 0:
+                available = {k: [bd.wwid for bd in v]
+                             for k, v in vgsSharedBlockStructs.items()}
+                raise Exception("cannot find VG with tag prefix [%s] and exact WWID match. "
+                                "target=%s, available=%s" % (INIT_TAG, cmd.sharedBlockUuids, available))
+            if len(matched_vgs) > 1:
+                raise Exception("found multiple VGs matching the same WWID set: %s" % matched_vgs)
+            return matched_vgs[0]
+
+        vg_uuid_on_storage = get_vg_name_by_shared_block_uuid()
+        logger.info("takeover[4/8] matched VG: %s (target: %s)" % (vg_uuid_on_storage, cmd.vgUuid))
+
+        # Step 5: reset sanlock lockspace and re-establish lock.
+        # Sequence: start_vg_lock (join) -> reset_sanlock_lockspace (reinit leases)
+        #   -> drop_vg_lock (flush stale state) -> start_vg_lock (rejoin clean)
+        #   -> check_gl_lock (force-enable GL after reset)
+        lvm.check_stuck_vglk_and_gllk()
+        retry_times = lvm.get_retry_times_for_checking_vg_lockspace()
+
+        # All steps after start_vg_lock are wrapped in try/except: on failure,
+        # drop_vg_lock cleans up so the next host can retry.
+        active_vg_uuid = vg_uuid_on_storage
+        try:
+            lvm.start_vg_lock(vg_uuid_on_storage, cmd.hostId, retry_times)
+            lvm.reset_sanlock_lockspace(vg_uuid_on_storage)
+            lvm.drop_vg_lock(vg_uuid_on_storage)
+            lvm.start_vg_lock(vg_uuid_on_storage, cmd.hostId, retry_times)
+            logger.info("takeover[5/8] sanlock lockspace reset for %s" % vg_uuid_on_storage)
+
+            lvm.check_gl_lock()
+
+            # Step 6: rename VG to match the target platform's database UUID
+            if vg_uuid_on_storage != cmd.vgUuid:
+                lvm.rename_vg(vg_uuid_on_storage, cmd.vgUuid)
+                active_vg_uuid = cmd.vgUuid
+                logger.info("takeover[6/8] VG renamed %s -> %s" % (vg_uuid_on_storage, cmd.vgUuid))
+                # Wait for lockspace restart under the new name
+                lvm.start_vg_lock(cmd.vgUuid, cmd.hostId, retry_times)
+            else:
+                logger.info("takeover[6/8] VG name already matches, skip rename")
+
+            self.clear_stalled_qmp_socket()
+
+            # Step 7: fix PV state (restore missing PVs, reset PV UUIDs)
+            lvm.check_missing_pv(cmd.vgUuid)
+            lvm.reset_pv_uuids(cmd.vgUuid)
+            logger.info("takeover[7/8] PV state fixed for %s" % cmd.vgUuid)
+
+            # Step 8: stamp VG tag with current host info
+            new_tag = "%s::%s::%s::%s" % (INIT_TAG, cmd.hostUuid, time.time(), linux.get_hostname())
+            lvm.update_vg_tag(cmd.vgUuid, INIT_TAG, new_tag)
+            logger.info("takeover[8/8] VG tag updated for %s" % cmd.vgUuid)
+        except Exception:
+            logger.warn("takeover failed after lockspace established, "
+                        "dropping vg lock for %s to allow next host to retry" % active_vg_uuid)
+            lvm.drop_vg_lock(active_vg_uuid)
+            raise
+
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def vgs_info(self, req):
+        rsp = GetVgsInfoRsp()
+        rsp.vgsSharedBlockStructs, rsp.vgsSharedBlockCount = lvm.get_vgs_info(tag=INIT_TAG)
         return jsonobject.dumps(rsp)

--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -3,7 +3,6 @@ import os.path
 import re
 import random
 import traceback
-import difflib
 
 from kvmagent import kvmagent
 from kvmagent.plugins.imagestore import ImageStoreClient
@@ -218,6 +217,7 @@ class CreateVolumeFromCacheRsp(AgentRsp):
         super(CreateVolumeFromCacheRsp, self).__init__()
         self.actualSize = None
         self.size = None
+
 
 def translate_absolute_path_from_install_path(path):
     if path is None:
@@ -552,25 +552,13 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
 
     @kvmagent.replyerror
     def connect(self, req):
-        @linux.retry(times=10, sleep_time=random.uniform(0.1, 1))
-        def get_lock(sblk_lock):
-            sblk_lock.lock = lock._get_lock(sblk_lock.name)
-            if sblk_lock.lock.acquire(False) is False:
-                raise SharedBlockConnectException("can not get %s lock, there is other thread running" % sblk_lock.name)
-
-        def release_lock(sblk_lock):
-            try:
-                sblk_lock.lock.release()
-            except Exception:
-                return
-
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         global MAX_ACTUAL_SIZE_FACTOR
         MAX_ACTUAL_SIZE_FACTOR = cmd.maxActualSizeFactor
         sblk_lock = lock.NamedLock("sharedblock-%s" % cmd.vgUuid)
         rsp = None
         try:
-            get_lock(sblk_lock)
+            self.get_lock(sblk_lock)
             rsp = self.do_connect(cmd)
         except SharedBlockConnectException as e:
             r = AgentRsp()
@@ -586,13 +574,76 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
                 r.error = "%s\n%s" % (str(e), content)
                 rsp = jsonobject.dumps(r)
         finally:
-            release_lock(sblk_lock)
+            self.release_lock(sblk_lock)
             return rsp
 
     @kvmagent.replyerror
     @lock.file_lock(LOCK_FILE)
     def do_connect(self, cmd):
         rsp = ConnectRsp()
+
+        diskPaths, disks, allDiskPaths, allDisks = self.prepare_disk(cmd)
+
+        lvm.config_lvm(cmd.hostId, allDiskPaths, cmd.vgUuid, cmd.hostUuid, DEFAULT_SANLOCK_LV_SIZE,
+                       kvmagent.get_host_os_type(), cmd.enableLvmetad)
+
+        lvm.start_lock_service(cmd.ioTimeout)
+        logger.debug("find/create vg %s lock..." % cmd.vgUuid)
+        rsp.isFirst = self.create_vg_if_not_found(cmd.vgUuid, disks, cmd.hostUuid, allDisks, cmd.forceWipe, cmd.isFirst)
+
+#       sanlock table:
+#
+#       | sanlock patch version | delta lease sleep time | retry times |
+#       | --------------------- | ---------------------- | ----------- |
+#       | 1                     | 40 seconds             | 15          |
+#       | 2 or higher           | 0 second               | 3           |
+#
+#
+#       explain:
+#
+#       In sanlock patch version 1, when you start a vg lock, it takes around 40 seconds
+#       in delta lease. So 15 retry times are required to check if vg lockspace exists.
+#
+#       In sanlock patch version 2, the sleep time in delta lease can be defined by zstack
+#       utility in sanlock.conf. It's 0 second by default, so retry times can be reduced to
+#       3 in order to save time.
+
+        retry_times_for_checking_vg_lockspace = lvm.get_retry_times_for_checking_vg_lockspace()
+
+        lvm.check_stuck_vglk_and_gllk()
+        logger.debug("starting vg %s lock..." % cmd.vgUuid)
+        lvm.start_vg_lock(cmd.vgUuid, cmd.hostId, retry_times_for_checking_vg_lockspace)
+
+        if lvm.lvm_vgck(cmd.vgUuid, 60)[0] is False and lvm.lvm_check_operation(cmd.vgUuid) is False:
+            lvm.drop_vg_lock(cmd.vgUuid)
+            logger.debug("restarting vg %s lock..." % cmd.vgUuid)
+            lvm.start_vg_lock(cmd.vgUuid, cmd.hostId, retry_times_for_checking_vg_lockspace)
+
+        # lvm.clean_vg_exists_host_tags(cmd.vgUuid, cmd.hostUuid, HEARTBEAT_TAG)
+        # lvm.add_vg_tag(cmd.vgUuid, "%s::%s::%s::%s" % (HEARTBEAT_TAG, cmd.hostUuid, time.time(), linux.get_hostname()))
+        self.clear_stalled_qmp_socket()
+        lvm.check_missing_pv(cmd.vgUuid)
+
+        rsp.totalCapacity, rsp.availableCapacity = lvm.get_vg_size(cmd.vgUuid)
+        rsp.hostId = lvm.get_running_host_id(cmd.vgUuid)
+        rsp.vgLvmUuid = lvm.get_vg_lvm_uuid(cmd.vgUuid)
+        rsp.hostUuid = cmd.hostUuid
+        rsp.lunCapacities = lvm.get_lun_capacities_from_vg(cmd.vgUuid, self.vgs_path_and_wwid)
+        return jsonobject.dumps(rsp)
+
+    @linux.retry(times=10, sleep_time=random.uniform(0.1, 1))
+    def get_lock(self, sblk_lock):
+        sblk_lock.lock = lock._get_lock(sblk_lock.name)
+        if sblk_lock.lock.acquire(False) is False:
+            raise SharedBlockConnectException("can not get %s lock, there is other thread running" % sblk_lock.name)
+
+    def release_lock(self, sblk_lock):
+        try:
+            sblk_lock.lock.release()
+        except Exception:
+            return
+
+    def prepare_disk(self, cmd):
         diskPaths = set()
         disks = set()
         allDiskPaths = set()
@@ -624,112 +675,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             allDiskPaths.add("/dev/sd*")
             allDiskPaths.add("/dev/vd*")
 
-        def config_lvm(host_id, enableLvmetad=False):
-            lvm.backup_lvm_config()
-            config = lvm.get_lvm_default_config()
-            lvmlockd_lock_retries = 6
-            config.modify({
-                "use_lvmlockd": 1,
-                "host_id": host_id,
-                "sanlock_lv_extend": DEFAULT_SANLOCK_LV_SIZE,
-                "lvmlockd_lock_retries": lvmlockd_lock_retries,
-                "issue_discards": 0,
-                "reserved_stack": 256,
-                "reserved_memory": 131072,
-                "use_lvmetad": 1 if enableLvmetad else 0
-            })
-            if kvmagent.get_host_os_type() == "debian":
-                config.modify({"udev_rules": 0, "udev_sync": 0})
-            config.write_to_file(lvm.LVM_CONFIG_TMP_FILE)
-            lvm.config_lvm_filter([os.path.basename(lvm.LVM_CONFIG_TMP_FILE)], preserve_disks=allDiskPaths)
-
-            new_config = linux.read_file(lvm.LVM_CONFIG_TMP_FILE)
-            old_config = linux.read_file(lvm.LVM_LOCAL_CONFIG_FILE)
-            diff = list(difflib.unified_diff(old_config.splitlines() if old_config is not None else [], new_config.splitlines()))
-            if len(diff) == 0:
-                logger.debug("lvm config has not changed")
-            else:
-                linux.write_file(lvm.LVM_CONFIG_FILE, new_config, create_if_not_exist=True)
-                linux.write_file(lvm.LVM_LOCAL_CONFIG_FILE, new_config, create_if_not_exist=True)
-                logger.debug("lvm config has changed:\n %s" % '\n'.join(diff))
-                lvm.report_config_changed()
-
-            # max lock retries times = (external lvmlockd_lock_retries + 1) * (internal lock_retries + 1 after a lock conflict)
-            lvm.lvm_cmd_timeout_with_locking = ((lvmlockd_lock_retries + 1) * 6) * 5
-            lvm.modify_sanlock_config("sh_retries", 20)
-            lvm.modify_sanlock_config("logfile_priority", 7)
-            lvm.modify_sanlock_config("renewal_read_extend_sec", 24)
-            lvm.modify_sanlock_config("debug_renew", 1)
-            lvm.modify_sanlock_config("use_watchdog", 0)
-            lvm.modify_sanlock_config("max_sectors_kb", "ignore")
-            lvm.modify_sanlock_config("watchdog_fire_timeout", 1)
-            lvm.modify_sanlock_config("kill_grace_seconds", 40)
-            lvm.modify_sanlock_config("zstack_vglock_timeout", 0)
-            lvm.modify_sanlock_config("use_zstack_vglock_timeout", 0)
-            lvm.modify_sanlock_config("zstack_vglock_large_delay", 8)
-            lvm.modify_sanlock_config("use_zstack_vglock_large_delay", 0)
-
-            sanlock_hostname = "%s-%s-%s" % (cmd.vgUuid[:8], cmd.hostUuid[:8], linux.get_hostname()[:20])
-            lvm.modify_sanlock_config("our_host_name", sanlock_hostname)
-            shell.call("sed -i 's/.*rotate .*/rotate 10/g' /etc/logrotate.d/sanlock", exception=False)
-            shell.call("sed -i 's/.*size .*/size 20M/g' /etc/logrotate.d/sanlock", exception=False)
-
-        config_lvm(cmd.hostId, cmd.enableLvmetad)
-
-        lvm.start_lock_service(cmd.ioTimeout)
-        logger.debug("find/create vg %s lock..." % cmd.vgUuid)
-        rsp.isFirst = self.create_vg_if_not_found(cmd.vgUuid, disks, cmd.hostUuid, allDisks, cmd.forceWipe, cmd.isFirst)
-
-#       sanlock table:
-#       
-#       | sanlock patch version | delta lease sleep time | retry times |
-#       | --------------------- | ---------------------- | ----------- |
-#       | 1                     | 40 seconds             | 15          |
-#       | 2 or higher           | 0 second               | 3           |
-#       
-#       
-#       explain:
-#       
-#       In sanlock patch version 1, when you start a vg lock, it takes around 40 seconds
-#       in delta lease. So 15 retry times are required to check if vg lockspace exists.
-#       
-#       In sanlock patch version 2, the sleep time in delta lease can be defined by zstack
-#       utility in sanlock.conf. It's 0 second by default, so retry times can be reduced to
-#       3 in order to save time.
-
-        @bash.in_bash
-        def get_retry_times_for_checking_vg_lockspace():
-            r, sanlock_patch_version = bash.bash_ro("sanlock get_patch_version")
-            # if version is not a digit, e.g. "client action get_patch_version is unknown", it also means that sanlock patch version < 2
-            if sanlock_patch_version.strip().isdigit() is False:
-                return 15
-            elif int(sanlock_patch_version.strip()) >= 2:
-                return 3
-            else:
-                return 15
-
-        retry_times_for_checking_vg_lockspace = get_retry_times_for_checking_vg_lockspace()
-
-        lvm.check_stuck_vglk_and_gllk()
-        logger.debug("starting vg %s lock..." % cmd.vgUuid)
-        lvm.start_vg_lock(cmd.vgUuid, cmd.hostId, retry_times_for_checking_vg_lockspace)
-
-        if lvm.lvm_vgck(cmd.vgUuid, 60)[0] is False and lvm.lvm_check_operation(cmd.vgUuid) is False:
-            lvm.drop_vg_lock(cmd.vgUuid)
-            logger.debug("restarting vg %s lock..." % cmd.vgUuid)
-            lvm.start_vg_lock(cmd.vgUuid, cmd.hostId, retry_times_for_checking_vg_lockspace)
-
-        # lvm.clean_vg_exists_host_tags(cmd.vgUuid, cmd.hostUuid, HEARTBEAT_TAG)
-        # lvm.add_vg_tag(cmd.vgUuid, "%s::%s::%s::%s" % (HEARTBEAT_TAG, cmd.hostUuid, time.time(), linux.get_hostname()))
-        self.clear_stalled_qmp_socket()
-        lvm.check_missing_pv(cmd.vgUuid)
-
-        rsp.totalCapacity, rsp.availableCapacity = lvm.get_vg_size(cmd.vgUuid)
-        rsp.hostId = lvm.get_running_host_id(cmd.vgUuid)
-        rsp.vgLvmUuid = lvm.get_vg_lvm_uuid(cmd.vgUuid)
-        rsp.hostUuid = cmd.hostUuid
-        rsp.lunCapacities = lvm.get_lun_capacities_from_vg(cmd.vgUuid, self.vgs_path_and_wwid)
-        return jsonobject.dumps(rsp)
+        return diskPaths, disks, allDiskPaths, allDisks
 
     @staticmethod
     @bash.in_bash

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -168,6 +168,8 @@ class SharedBlockCandidateStruct:
         self.source = None  # type: str
         self.transport = None  # type: str
         self.targetIdentifier = None  # type: str
+        self.mpathDevice = None  # type: str
+        self.dev_name = None  # type: str
 
 def get_vg_uuid(path):
     # type: (str) -> str
@@ -291,13 +293,14 @@ def get_mpath_block_devices(scsi_info):
 
     block_devices_list = [None] * len(mpath_devices)
 
-    def get_slave_block_devices(slave, dm, i):
+    def get_slave_block_devices(slave, dm, i, mpath_dev):
         try:
             struct = get_device_info(slave, scsi_info)
             if struct is None:
                 return
             struct.type = "mpath"
             struct.dev_name = slave
+            struct.mpathDevice = mpath_dev
             block_devices_list[i] = struct
         except Exception as e:
             logger.warn(linux.get_exception_stacktrace())
@@ -315,11 +318,12 @@ def get_mpath_block_devices(scsi_info):
                 struct = SharedBlockCandidateStruct()
                 struct.wwid = get_dm_wwid(dm)
                 struct.type = "mpath"
+                struct.mpathDevice = mpath_device
                 block_devices_list[idx] = struct
                 continue
 
             slave_devices.extend(slaves)
-            threads.append(thread.ThreadFacade.run_in_thread(get_slave_block_devices, [slaves[0], dm, idx]))
+            threads.append(thread.ThreadFacade.run_in_thread(get_slave_block_devices, [slaves[0], dm, idx, mpath_device]))
         except Exception as e:
             logger.warn(linux.get_exception_stacktrace())
             continue
@@ -654,7 +658,7 @@ def config_lvm_filter(files, no_drbd=False, preserve_disks=None):
 
     if preserve_disks is not None and len(preserve_disks) != 0:
         filter_str = 'filter=['
-        for disk in preserve_disks:
+        for disk in sorted(preserve_disks):
             filter_str += '"a|^%s$|", ' % disk.replace("/", "\\/")
         filter_str += '"r\/.*\/"]'
 
@@ -2780,14 +2784,20 @@ def config_lvm(host_id, all_disk_paths, vg_uuid, host_uuid, default_sanlock_lv_s
     config_lvm_filter([os.path.basename(LVM_CONFIG_TMP_FILE)], preserve_disks=all_disk_paths)
 
     new_config = linux.read_file(LVM_CONFIG_TMP_FILE)
-    old_config = linux.read_file(LVM_LOCAL_CONFIG_FILE)
-    diff = list(difflib.unified_diff(old_config.splitlines() if old_config is not None else [], new_config.splitlines()))
-    if len(diff) == 0:
+    old_local_config = linux.read_file(LVM_LOCAL_CONFIG_FILE)
+    old_global_config = linux.read_file(LVM_CONFIG_FILE)
+    local_diff = list(difflib.unified_diff(
+        old_local_config.splitlines() if old_local_config is not None else [],
+        new_config.splitlines()))
+    global_diff = list(difflib.unified_diff(
+        old_global_config.splitlines() if old_global_config is not None else [],
+        new_config.splitlines()))
+    if len(local_diff) == 0 and len(global_diff) == 0:
         logger.debug("lvm config has not changed")
     else:
         linux.write_file(LVM_CONFIG_FILE, new_config, create_if_not_exist=True)
         linux.write_file(LVM_LOCAL_CONFIG_FILE, new_config, create_if_not_exist=True)
-        logger.debug("lvm config has changed:\n %s" % '\n'.join(diff))
+        logger.debug("lvm config has changed:\n %s" % '\n'.join(global_diff or local_diff))
         report_config_changed()
 
     # max lock retries times = (external lvmlockd_lock_retries + 1) * (internal lock_retries + 1 after a lock conflict)
@@ -2810,3 +2820,205 @@ def config_lvm(host_id, all_disk_paths, vg_uuid, host_uuid, default_sanlock_lv_s
     modify_sanlock_config("our_host_name", sanlock_hostname)
     shell.call("sed -i 's/.*rotate .*/rotate 10/g' /etc/logrotate.d/sanlock", exception=False)
     shell.call("sed -i 's/.*size .*/size 20M/g' /etc/logrotate.d/sanlock", exception=False)
+
+
+@bash.in_bash
+def get_vgs_info(tag):
+    vgsSharedBlockStructs = {}
+    vgsSharedBlockCount = {}
+
+    block_devices = get_block_devices()
+
+    block_devices_by_dev_name = {}
+    for bd in block_devices:
+        if bd.dev_name:
+            block_devices_by_dev_name[bd.dev_name] = bd
+        if bd.mpathDevice:
+            block_devices_by_dev_name[bd.mpathDevice] = bd
+            try:
+                dm_name = os.path.basename(os.path.realpath("/dev/mapper/%s" % bd.mpathDevice))
+                if dm_name:
+                    block_devices_by_dev_name[dm_name] = bd
+                    for slave in os.listdir("/sys/class/block/%s/slaves/" % dm_name):
+                        if slave and slave.strip():
+                            block_devices_by_dev_name[slave.strip()] = bd
+            except Exception:
+                logger.warn("resolve dm name failed for mpath device %s: %s" %
+                            (bd.mpathDevice, linux.get_exception_stacktrace()))
+
+    r, o, e = bash.bash_roe("vgs --nolocking -t -o vg_name,pv_count,pv_name,tags --noheadings")
+    if r != 0:
+        raise Exception("get vgs info failed, error: %s" % e)
+
+    for info in form.load('vg_name pv_count pv_name tags\n' + o):
+        vg_name = info['vg_name']
+        pv_count = info['pv_count']
+        pv_name = info['pv_name']
+        tags = info['tags']
+
+        tag_list = [t.strip() for t in (tags or "").split(",") if t.strip()]
+        if not any(t.startswith(tag) for t in tag_list):
+            continue
+
+        pv_basename = os.path.basename(pv_name)
+        if vg_name not in vgsSharedBlockStructs:
+            vgsSharedBlockStructs[vg_name] = []
+        if vg_name not in vgsSharedBlockCount:
+            vgsSharedBlockCount[vg_name] = int(pv_count)
+
+        block_device = block_devices_by_dev_name.get(pv_basename)
+        if block_device is None:
+            # fallback: try resolving via realpath (e.g. /dev/mapper/mpathX -> dm-N)
+            try:
+                real_name = os.path.basename(os.path.realpath(pv_name))
+                block_device = block_devices_by_dev_name.get(real_name)
+            except Exception as e:
+                logger.warn("resolve realpath failed for pv %s: %s" % (pv_name, str(e)))
+        if block_device:
+            vgsSharedBlockStructs[vg_name].append(block_device)
+        else:
+            logger.warn("PV %s belongs to VG %s but not found in block devices scan" % (pv_basename, vg_name))
+
+    for vg_name, expected_count in vgsSharedBlockCount.items():
+        actual_count = len(vgsSharedBlockStructs.get(vg_name, []))
+        if actual_count < expected_count:
+            logger.warn("VG %s has incomplete WWID set: expected %d PVs but resolved %d block devices. "
+                        "WWID matching may fail for this VG." % (vg_name, expected_count, actual_count))
+
+    return vgsSharedBlockStructs, vgsSharedBlockCount
+
+
+@bash.in_bash
+def reset_pv_uuids(vg_uuid):
+    """Reset all PV UUIDs in the VG to avoid collision with the source platform."""
+    pvs_output = bash.bash_o(
+        "timeout -s SIGKILL 10 pvs --noheading --nolocking -t "
+        "-Svg_name=%s -oname" % vg_uuid).strip().splitlines()
+
+    succeeded = []
+    for pv_line in pvs_output:
+        pv_name = pv_line.strip()
+        if not pv_name:
+            continue
+        r, _, e = bash.bash_roe("timeout -s SIGKILL 30 pvchange --yes --uuid %s" % pv_name)
+        if r != 0:
+            raise Exception("failed to reset PV UUID for %s: %s\n"
+                            "succeeded PVs: %s" % (pv_name, e, succeeded))
+        succeeded.append(pv_name)
+
+    if succeeded:
+        logger.debug("reset PV UUIDs for VG %s: %s" % (vg_uuid, succeeded))
+
+
+@bash.in_bash
+def rename_vg(old_vg_uuid, new_vg_uuid):
+    if old_vg_uuid == new_vg_uuid:
+        logger.debug("rename vg skipped: old_vgUuid == new_vgUuid (%s)" % old_vg_uuid)
+        return
+
+    if vg_exists(new_vg_uuid) and not vg_exists(old_vg_uuid):
+        logger.debug("rename vg skipped: %s already exists and %s not found" % (new_vg_uuid, old_vg_uuid))
+        return
+
+    if vg_exists(new_vg_uuid) and vg_exists(old_vg_uuid):
+        raise Exception("both old VG %s and new VG %s exist on this host. "
+                        "Refusing to rename - manual investigation required." % (old_vg_uuid, new_vg_uuid))
+
+    @linux.retry(times=5, sleep_time=2)
+    def do_vg_rename():
+        r, o, e = bash.bash_roe(
+            "timeout -s SIGKILL %s vgrename %s %s" %
+            (lvm_cmd_timeout_with_locking, old_vg_uuid, new_vg_uuid))
+        if r != 0:
+            raise Exception("unable to rename vg %s to %s, "
+                            "stdout:%s, stderr:%s" % (old_vg_uuid, new_vg_uuid, str(o), str(e)))
+
+        old_exists = vg_exists(old_vg_uuid)
+        new_exists = vg_exists(new_vg_uuid)
+        if old_exists or not new_exists:
+            raise RetryException(
+                "unexpected VG state after rename %s -> %s: old_exists=%s, new_exists=%s" % (
+                    old_vg_uuid, new_vg_uuid, old_exists, new_exists))
+
+        logger.debug("rename vg %s to %s successfully" % (old_vg_uuid, new_vg_uuid))
+
+    do_vg_rename()
+
+    old_exists = vg_exists(old_vg_uuid)
+    new_exists = vg_exists(new_vg_uuid)
+    if old_exists or not new_exists:
+        raise Exception("vg rename post-check failed: old_exists=%s, new_exists=%s for %s -> %s" %
+                        (old_exists, new_exists, old_vg_uuid, new_vg_uuid))
+
+
+@bash.in_bash
+def reset_sanlock_lockspace(vg_uuid):
+    lockspace_path = "/dev/mapper/%s-lvmlock" % vg_uuid
+
+    fix_vglk(vg_uuid)
+
+    # Reinit delta lease area (clears ALL host slots).
+    r, o, e = bash.bash_roe(
+        "timeout -s SIGKILL 60 sanlock direct init -s lvm_%s:0:%s:0" % (vg_uuid, lockspace_path))
+    if r != 0:
+        raise Exception("failed to init sanlock lockspace for %s: stdout=%s, stderr=%s"
+                        % (vg_uuid, o, e))
+
+    # Reinit GLLK and VGLK resource leases (clear source platform owner residue).
+    sector_size = sanlock.get_sector_size(vg_uuid)
+    align_size = sanlock.sector_size_to_align_size(sector_size)
+    gllk_offset = sanlock.GLLK_BEGIN * align_size
+    vglk_offset = sanlock.VGLK_BEGIN * align_size
+
+    r, o, e = bash.bash_roe(
+        "timeout -s SIGKILL 30 sanlock direct init -r lvm_%s:GLLK:%s:%s" % (vg_uuid, lockspace_path, gllk_offset))
+    if r != 0:
+        logger.warn("failed to reinit GLLK for %s (non-fatal): %s" % (vg_uuid, e))
+    else:
+        logger.debug("reset_sanlock_lockspace: reinit GLLK at offset %s" % gllk_offset)
+
+    r, o, e = bash.bash_roe(
+        "timeout -s SIGKILL 30 sanlock direct init -r lvm_%s:VGLK:%s:%s" % (vg_uuid, lockspace_path, vglk_offset))
+    if r != 0:
+        logger.warn("failed to reinit VGLK for %s (non-fatal): %s" % (vg_uuid, e))
+    else:
+        logger.debug("reset_sanlock_lockspace: reinit VGLK at offset %s" % vglk_offset)
+
+    # Reinit per-LV resource leases.
+    o = bash.bash_errorout("lvs -ouuid,lock_args -Svg_name=%s --noheading --nolocking -t" % vg_uuid)
+
+    def repair(uuid, offset):
+        r, _o, e = bash.bash_roe("timeout -s SIGKILL 30 sanlock direct init -r lvm_%s:%s:%s:%s" % (vg_uuid, uuid, lockspace_path, offset))
+        if r != 0:
+            logger.warn("failed to reinit LV lease %s for %s (non-fatal): %s" % (uuid, vg_uuid, e))
+
+    for line in o.strip().splitlines():
+        xs = line.strip().split()
+        if len(xs) < 2 or ":" not in xs[1]:
+            logger.warn("reset_sanlock_lockspace: skip unparseable LV lease line: %r" % line)
+            continue
+        uuid = xs[0]
+        offset = xs[1].split(":")[-1]
+        logger.debug("reset_sanlock_lockspace: reinit LV lease %s offset %s" % (uuid, offset))
+        repair(uuid, offset)
+
+@bash.in_bash
+def update_vg_tag(vg_uuid, old_tag_prefix, new_tag):
+    """Update VG tag: find existing tag by old_tag_prefix and replace with new_tag."""
+    r, o, e = bash.bash_roe("timeout -s SIGKILL 10 vgs --nolocking -t -o tags --noheadings %s" % vg_uuid)
+    if r != 0:
+        logger.warn("failed to get VG tags for %s, skipping tag update" % vg_uuid)
+        return
+
+    old_tag = next((t.strip() for t in o.strip().split(",")
+                    if t.strip().startswith(old_tag_prefix)), None)
+    if not old_tag:
+        logger.warn("no tag with prefix [%s] found on VG %s, skipping tag update" % (old_tag_prefix, vg_uuid))
+        return
+
+    r, o, e = bash.bash_roe(
+        "vgchange --deltag %s --addtag %s %s" % (linux.shellquote(old_tag), linux.shellquote(new_tag), vg_uuid))
+    if r != 0:
+        logger.warn("failed to update VG tag for %s: %s (non-fatal)" % (vg_uuid, e))
+    else:
+        logger.debug("updated VG tag for %s: %s -> %s" % (vg_uuid, old_tag, new_tag))

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -1,3 +1,4 @@
+import difflib
 import functools
 import random
 import os
@@ -2743,3 +2744,69 @@ class LvmlockdStatus(object):
         except Exception as e:
             logger.warn(str(e))
             self.failed = True
+
+
+@bash.in_bash
+def get_retry_times_for_checking_vg_lockspace():
+    _, sanlock_patch_version = bash.bash_ro("sanlock get_patch_version")
+    # if version is not a digit, e.g. "client action get_patch_version is unknown", it also means that sanlock patch version < 2
+    if sanlock_patch_version.strip().isdigit() is False:
+        return 15
+    elif int(sanlock_patch_version.strip()) >= 2:
+        return 3
+    else:
+        return 15
+
+
+def config_lvm(host_id, all_disk_paths, vg_uuid, host_uuid, default_sanlock_lv_size, host_os_type,
+               enable_lvmetad=False):
+    backup_lvm_config()
+    config = get_lvm_default_config()
+    lvmlockd_lock_retries = 6
+    config.modify({
+        "use_lvmlockd": 1,
+        "host_id": host_id,
+        "sanlock_lv_extend": default_sanlock_lv_size,
+        "lvmlockd_lock_retries": lvmlockd_lock_retries,
+        "issue_discards": 0,
+        "reserved_stack": 256,
+        "reserved_memory": 131072,
+        "use_lvmetad": 1 if enable_lvmetad else 0
+    })
+
+    if host_os_type == "debian":
+        config.modify({"udev_rules": 0, "udev_sync": 0})
+    config.write_to_file(LVM_CONFIG_TMP_FILE)
+    config_lvm_filter([os.path.basename(LVM_CONFIG_TMP_FILE)], preserve_disks=all_disk_paths)
+
+    new_config = linux.read_file(LVM_CONFIG_TMP_FILE)
+    old_config = linux.read_file(LVM_LOCAL_CONFIG_FILE)
+    diff = list(difflib.unified_diff(old_config.splitlines() if old_config is not None else [], new_config.splitlines()))
+    if len(diff) == 0:
+        logger.debug("lvm config has not changed")
+    else:
+        linux.write_file(LVM_CONFIG_FILE, new_config, create_if_not_exist=True)
+        linux.write_file(LVM_LOCAL_CONFIG_FILE, new_config, create_if_not_exist=True)
+        logger.debug("lvm config has changed:\n %s" % '\n'.join(diff))
+        report_config_changed()
+
+    # max lock retries times = (external lvmlockd_lock_retries + 1) * (internal lock_retries + 1 after a lock conflict)
+    global lvm_cmd_timeout_with_locking
+    lvm_cmd_timeout_with_locking = ((lvmlockd_lock_retries + 1) * 6) * 5
+    modify_sanlock_config("sh_retries", 20)
+    modify_sanlock_config("logfile_priority", 7)
+    modify_sanlock_config("renewal_read_extend_sec", 24)
+    modify_sanlock_config("debug_renew", 1)
+    modify_sanlock_config("use_watchdog", 0)
+    modify_sanlock_config("max_sectors_kb", "ignore")
+    modify_sanlock_config("watchdog_fire_timeout", 1)
+    modify_sanlock_config("kill_grace_seconds", 40)
+    modify_sanlock_config("zstack_vglock_timeout", 0)
+    modify_sanlock_config("use_zstack_vglock_timeout", 0)
+    modify_sanlock_config("zstack_vglock_large_delay", 8)
+    modify_sanlock_config("use_zstack_vglock_large_delay", 0)
+
+    sanlock_hostname = "%s-%s-%s" % (vg_uuid[:8], host_uuid[:8], linux.get_hostname()[:20])
+    modify_sanlock_config("our_host_name", sanlock_hostname)
+    shell.call("sed -i 's/.*rotate .*/rotate 10/g' /etc/logrotate.d/sanlock", exception=False)
+    shell.call("sed -i 's/.*size .*/size 20M/g' /etc/logrotate.d/sanlock", exception=False)


### PR DESCRIPTION
Move config_lvm and get_retry_times_for_checking_vg_lockspace from
do_connect inline functions to lvm module-level functions. Extract
disk preparation code into prepare_disk method. Promote get_lock and
release_lock from connect-local closures to instance methods.

No logic changes - pure code movement and signature parameterization.

Resolves: ZSV-10000

Change-Id: I6f776c6273656b64776f617479646b767977696e

sync from gitlab !6799