### PR TITLE
<fix>[kvmagent]: support snapshot-backup path format

### DIFF
--- a/kvmagent/kvmagent/plugins/nvram/nvram_common.py
+++ b/kvmagent/kvmagent/plugins/nvram/nvram_common.py
@@ -26,7 +26,7 @@ def extract_vm_uuid_from_nvram_vm_host_file_path(path):
     if not path:
         return ''
     uuid_pattern = r'[a-fA-F0-9]{8}[a-fA-F0-9]{4}[a-fA-F0-9]{4}[a-fA-F0-9]{4}[a-fA-F0-9]{12}'
-    pattern = r'^/var/lib/libvirt/qemu/nvram/({0})-host-files/({0})\.fd$'.format(uuid_pattern)
+    pattern = r'^/var/lib/libvirt/qemu/nvram/({0})-host-files/({0})\.fd(\.snapshot-backup)?$'.format(uuid_pattern)
     match = re.match(pattern, path)
     if not match:
         return ''

--- a/kvmagent/kvmagent/plugins/vms/tpm.py
+++ b/kvmagent/kvmagent/plugins/vms/tpm.py
@@ -47,5 +47,5 @@ def check_tpm_state_vm_host_file_path_format(path):
     
     path = path.rstrip('/')
     uuid_pattern = r'[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}'
-    pattern = r'^/var/lib/libvirt/swtpm/({0})$'.format(uuid_pattern)
+    pattern = r'^/var/lib/libvirt/swtpm/({0})(\.snapshot-backup)?$'.format(uuid_pattern)
     return bool(re.match(pattern, path))


### PR DESCRIPTION
Allow .snapshot-backup suffix in TPM state and NvRam
vm host file path validation. This ensures backup paths
like /var/lib/libvirt/swtpm/<uuid>.snapshot-backup/ and
nvram .fd.snapshot-backup files pass format checks during
snapshot operations.

Related: ZSV-11310
Resolves: ZSV-11441

Change-Id: I6a7862636f6b7863666b666c796e7a656e657563

sync from gitlab !6833