### PR TITLE
fix(test): add tearDown cleanup and pre-check for aarch64 localstorage cases

### DIFF
--- a/kvmagent/kvmagent/test/localstorage_testsuite/test_data_volume_with_iothreadpin.py
+++ b/kvmagent/kvmagent/test/localstorage_testsuite/test_data_volume_with_iothreadpin.py
@@ -29,6 +29,16 @@ class TestVolumeWithIoThreadPin(TestCase, vm_utils.VmPluginTestStub):
     def setUpClass(cls):
         network_utils.create_default_bridge_if_not_exist()
 
+    def tearDown(self):
+        # Clean up VM resources to avoid polluting subsequent test runs
+        if self.vm_uuid:
+            try:
+                pid = linux.find_vm_pid_by_uuid(self.vm_uuid)
+                if pid:
+                    vm_utils.destroy_vm(self.vm_uuid)
+            except Exception as e:
+                logger.warning("tearDown cleanup failed for vm[%s]: %s", self.vm_uuid, str(e))
+
     @pytest.mark.run(order=1)
     @pytest_utils.ztest_decorater
     def test_virtio_volum(self):
@@ -181,29 +191,27 @@ class TestVolumeWithIoThreadPin(TestCase, vm_utils.VmPluginTestStub):
         virtio_scsi_vol_iothread_pin = "1"
         virtio_scsi_vol_uuid, virtio_scsi_vol_path = volume_utils.create_empty_volume()
 
-        vm_uuid, vm = self._create_vm()
+        self.vm_uuid, vm = self._create_vm()
 
-
-
-        _, virtio_vol = vm_utils.attach_iothreadpin_volume_to_vm(vm_uuid,
+        _, virtio_vol = vm_utils.attach_iothreadpin_volume_to_vm(self.vm_uuid,
                                                                  virtio_vol_uuid,
                                                                  virtio_vol_path,
                                                                  virtio_vol_iothread_id,
                                                                  virtio_vol_iothread_pin)
-        _, virtio_scsi_vol = vm_utils.attach_virtio_scsi_iothread_volume_to_vm(vm_uuid,
+        _, virtio_scsi_vol = vm_utils.attach_virtio_scsi_iothread_volume_to_vm(self.vm_uuid,
                                                                                virtio_scsi_vol_uuid,
                                                                                virtio_scsi_vol_path,
                                                                                virtio_scsi_vol_iothread_id,
                                                                                virtio_scsi_vol_iothread_pin)
 
-        rsp = vm_utils.check_volume(vm_uuid, [virtio_vol, virtio_scsi_vol])
+        rsp = vm_utils.check_volume(self.vm_uuid, [virtio_vol, virtio_scsi_vol])
         self.assertTrue(rsp.success)
-        self.check_volume_iothread_pin(vm_uuid, virtio_vol_path, virtio_vol_iothread_id)
-        self.check_virtio_scsi_volume_config(vm_uuid, virtio_scsi_vol_path, virtio_scsi_vol_iothread_id)
+        self.check_volume_iothread_pin(self.vm_uuid, virtio_vol_path, virtio_vol_iothread_id)
+        self.check_virtio_scsi_volume_config(self.vm_uuid, virtio_scsi_vol_path, virtio_scsi_vol_iothread_id)
 
-        vm_utils.stop_vm(vm_uuid)
-        pid = linux.find_vm_pid_by_uuid(vm_uuid)
-        self.assertTrue(not pid, 'vm[%s] vm still running' % vm_uuid)
+        vm_utils.stop_vm(self.vm_uuid)
+        pid = linux.find_vm_pid_by_uuid(self.vm_uuid)
+        self.assertTrue(not pid, 'vm[%s] vm still running' % self.vm_uuid)
 
         controller_index = "2"
         virtio_vol_body, virtio_pin = vm_utils.build_virtio_vol_with_iothreadpin(virtio_vol_uuid, virtio_vol_path, virtio_vol_iothread_id, virtio_vol_iothread_pin)
@@ -212,34 +220,34 @@ class TestVolumeWithIoThreadPin(TestCase, vm_utils.VmPluginTestStub):
         vm = vm_utils.create_vm_with_vols([virtio_vol_body, virtio_scsi_vol_body], [virtio_pin, virtio_scsi_pin])
         vm_utils.create_vm(vm)
         self.vm_uuid = vm.vmInstanceUuid
-        pid = linux.find_vm_pid_by_uuid(vm_uuid)
-        self.assertFalse(not pid, 'cannot find pid of vm[%s]' % vm_uuid)
+        pid = linux.find_vm_pid_by_uuid(self.vm_uuid)
+        self.assertFalse(not pid, 'cannot find pid of vm[%s]' % self.vm_uuid)
 
-        rsp = vm_utils.check_volume(vm_uuid, [virtio_vol, virtio_scsi_vol])
+        rsp = vm_utils.check_volume(self.vm_uuid, [virtio_vol, virtio_scsi_vol])
         self.assertTrue(rsp.success)
-        self.check_volume_iothread_pin(vm_uuid, virtio_vol_path, virtio_vol_iothread_id)
-        self.check_virtio_scsi_volume_config(vm_uuid, virtio_scsi_vol_path, virtio_scsi_vol_iothread_id)
+        self.check_volume_iothread_pin(self.vm_uuid, virtio_vol_path, virtio_vol_iothread_id)
+        self.check_virtio_scsi_volume_config(self.vm_uuid, virtio_scsi_vol_path, virtio_scsi_vol_iothread_id)
 
-        rsp = vm_utils.detach_volume_from_vm(vm_uuid, virtio_vol)
+        rsp = vm_utils.detach_volume_from_vm(self.vm_uuid, virtio_vol)
         self.assertTrue(rsp.success)
-        xml = vm_utils.get_vm_xmlobject_from_virsh_dump(vm_uuid)
+        xml = vm_utils.get_vm_xmlobject_from_virsh_dump(self.vm_uuid)
         vol_xml = volume_utils.find_volume_in_vm_xml_by_path(xml, virtio_vol_path)
         self.assertIsNone(vol_xml)
 
-        rsp = vm_utils.detach_volume_from_vm(vm_uuid, virtio_scsi_vol)
+        rsp = vm_utils.detach_volume_from_vm(self.vm_uuid, virtio_scsi_vol)
         self.assertTrue(rsp.success)
-        xml = vm_utils.get_vm_xmlobject_from_virsh_dump(vm_uuid)
+        xml = vm_utils.get_vm_xmlobject_from_virsh_dump(self.vm_uuid)
         vol_xml = volume_utils.find_volume_in_vm_xml_by_path(xml, virtio_scsi_vol_path)
         self.assertIsNone(vol_xml)
 
-        vm_utils.del_vm_scsi_controller(vm_uuid, virtio_scsi_vol_iothread_id)
-        vm_utils.del_iothread_pin(vm_uuid, virtio_scsi_vol_iothread_id)
-        vm_utils.del_iothread_pin(vm_uuid, virtio_vol_iothread_id)
+        vm_utils.del_vm_scsi_controller(self.vm_uuid, virtio_scsi_vol_iothread_id)
+        vm_utils.del_iothread_pin(self.vm_uuid, virtio_scsi_vol_iothread_id)
+        vm_utils.del_iothread_pin(self.vm_uuid, virtio_vol_iothread_id)
 
-        rsp = vm_utils.check_volume(vm_uuid, [virtio_vol, virtio_scsi_vol])
+        rsp = vm_utils.check_volume(self.vm_uuid, [virtio_vol, virtio_scsi_vol])
         self.assertFalse(rsp.success)
 
-        vm_utils.destroy_vm(vm_uuid)
-        pid = linux.find_vm_pid_by_uuid(vm_uuid)
-        self.assertTrue(not pid, 'vm[%s] vm still running' % vm_uuid)
+        vm_utils.destroy_vm(self.vm_uuid)
+        pid = linux.find_vm_pid_by_uuid(self.vm_uuid)
+        self.assertTrue(not pid, 'vm[%s] vm still running' % self.vm_uuid)
 

--- a/kvmagent/kvmagent/test/localstorage_testsuite/test_resize_volume.py
+++ b/kvmagent/kvmagent/test/localstorage_testsuite/test_resize_volume.py
@@ -12,6 +12,9 @@ __ENV_SETUP__ = {
     'self': {}
 }
 
+TEMPLATE_PATH = "/root/.zguest/min-vm.qcow2"
+LOCAL_PS_PATH = "/local_ps"
+
 
 ## describe: case will manage by ztest
 class TestLocalStoragePlugin(TestCase):
@@ -19,27 +22,34 @@ class TestLocalStoragePlugin(TestCase):
     @classmethod
     def setUpClass(cls):
         return
+
+    def tearDown(self):
+        # Always clean up localstorage path to avoid polluting subsequent runs
+        bash.bash_ro("rm -rf %s" % LOCAL_PS_PATH)
+
     @pytest_utils.ztest_decorater
     def test_resize_volume(self):
-        rsp = localstorage_utils.localstorage_init(
-            "/local_ps"
-        )
+        if not os.path.exists(TEMPLATE_PATH):
+            self.skipTest("Template %s not found on this node, skip" % TEMPLATE_PATH)
+
+        rsp = localstorage_utils.localstorage_init(LOCAL_PS_PATH)
         self.assertGreater(rsp.totalCapacity, 0, rsp.error)
         self.assertGreater(rsp.availableCapacity, 0, rsp.error)
 
+        install_url = os.path.join(LOCAL_PS_PATH, "test/test.qcow2")
+
         rsp = localstorage_utils.create_root_volume_from_template(
-            templatePathInCache = "/root/.zguest/min-vm.qcow2",
-            installUrl = "/local_ps/test/test.qcow2",
-            storagePath = "/local_ps"
+            templatePathInCache=TEMPLATE_PATH,
+            installUrl=install_url,
+            storagePath=LOCAL_PS_PATH
         )
 
-        self.assertEqual(True, os.path.exists("/local_ps/test/test.qcow2"), "[check] cannot find rootvolume in host")
+        self.assertTrue(os.path.exists(install_url), "[check] cannot find rootvolume in host")
 
         rsp = localstorage_utils.resize_volume(
-            installPath="/local_ps/test/test.qcow2",
+            installPath=install_url,
             size=5242880,
             force=True
         )
 
-        self.assertEqual(5242880, rsp.size , "[check] cannot resize_volume in host")
-        bash.bash_ro("rm -rf /local_ps")
+        self.assertEqual(5242880, rsp.size, "[check] cannot resize_volume in host")


### PR DESCRIPTION
## Summary\n- test_resize_volume: add tearDown to clean /local_ps, add skipTest if template not found\n- test_data_volume_with_iothreadpin: add tearDown to destroy VM on failure\n\nResolves: ZSTAC-83917

sync from gitlab !6866