### PR TITLE
<fix>[ctl]: align enterprise installer argparse dest with args.mevoco_installer

### DIFF
--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -3956,6 +3956,7 @@ class UpgradeHACmd(Command):
 
     def install_argparse_arguments(self, parser):
         parser.add_argument('--zstack-enterprise-installer','--enterprise',
+                            dest='mevoco_installer',
                             help="The new zstack-enterprise installer package, get it from http://cdn.zstack.io/product_downloads/zstack-enterprise/",
                             required=True)
         parser.add_argument('--iso',


### PR DESCRIPTION
Add dest='mevoco_installer' so --zstack-enterprise-installer
and --enterprise populate the attribute the rest of the command expects.

Resolves: ZSTAC-83970

Change-Id: I6e776f626b79766666766368736e6a6275756f65

sync from gitlab !6927