### PR TITLE
<fix>[utility]: add pre-check, temp unzip for HA/MN; halt on backup failure abort on HA backup failure

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -4063,7 +4063,7 @@ load_install_conf() {
 
 load_install_conf
 OPTIND=1
-TEMP=`getopt -o f:H:I:n:p:P:r:R:t:y:acC:L:T:dDEFhiklmMNoOqsuz --long chrony-server-ip:,grayscale:,mini,zsv,cube,SY,sds,no-zops,skip-pjnum,choose-database: -- "$@"`
+TEMP=`getopt -o f:H:I:n:p:P:r:R:t:y:acC:L:T:dDEFhiklmMNoOqsuz --long chrony-server-ip:,grayscale:,mini,zsv,cube,SY,sds,no-zops,skip-pjnum,choose-database:,precheck -- "$@"`
 if [ $? != 0 ]; then
     usage
 fi
@@ -4127,6 +4127,7 @@ do
         --sds) SDS_INSTALL='y';shift;;
         --no-zops) SKIP_ZOPS_INSTALL='y';shift;;
         --skip-pjnum) SKIP_PJNUM_CHECK='y';shift;;
+        --precheck) PRECHECK='y';UPGRADE='y';shift;;
         --choose-database )
             check_myarg $1 $2;
             if [[ "$2" != "MariaDB" && "$2" != "GreatDB" ]]; then
@@ -4506,6 +4507,14 @@ source ~/.bashrc >/dev/null 2>&1
 
 #Do preinstallation checking for CentOS and Ubuntu
 check_system
+
+if [ x"$PRECHECK" = x'y' ]; then
+    iptables -L INPUT | grep -q 'zstack allow login mysql from 127.0.0.1' && post_scripts_to_restore_iptables_rules
+    [ -n "$upgrade_folder" ] && rm -rf "$upgrade_folder"
+    cleanup_function
+    echo "Pre-upgrade checks passed."
+    exit 0
+fi
 
 if [ "$IS_YUM" = "y" ]; then
      install_sync_repo_dependences

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -3962,6 +3962,7 @@ class UpgradeHACmd(Command):
 
     def install_argparse_arguments(self, parser):
         parser.add_argument('--zstack-enterprise-installer','--enterprise',
+                            dest='mevoco_installer',
                             help="The new zstack-enterprise installer package, get it from http://cdn.zstack.io/product_downloads/zstack-enterprise/",
                             required=True)
         parser.add_argument('--iso',

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -4092,6 +4092,18 @@ class UpgradeHACmd(Command):
         for file in [args.mevoco_installer, community_iso]:
             self.check_file_exist(file, UpgradeHACmd.host_post_info_list)
 
+        # pre-check all HA nodes before stopping any node
+        mevoco_dir = os.path.dirname(args.mevoco_installer)
+        mevoco_bin = os.path.basename(args.mevoco_installer)
+        for host_post_info in UpgradeHACmd.host_post_info_list:
+            command = "rm -rf /tmp/zstack_upgrade.lock && cd %s && bash %s -u -i --precheck" % (
+                mevoco_dir, mevoco_bin)
+            (status, output) = subprocess.getstatusoutput(
+                "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i %s root@%s '%s'" %
+                (UpgradeHACmd.private_key_name, host_post_info.host, command))
+            if status != 0:
+                error("Pre-upgrade check failed on HA node %s\n %s" % (host_post_info.host, output))
+
         spinner_info = SpinnerInfo()
         spinner_info.output = "Starting to upgrade repo"
         spinner_info.name = "upgrade_repo"
@@ -4119,7 +4131,9 @@ class UpgradeHACmd(Command):
         SpinnerInfo.spinner_status = reset_dict_value(SpinnerInfo.spinner_status,False)
         SpinnerInfo.spinner_status['backup_db'] = True
         ZstackSpinner(spinner_info)
-        (status, output) =  subprocess.getstatusoutput("zstack-ctl dump_mysql >> /dev/null 2>&1")
+        (status, output) =  subprocess.getstatusoutput("zstack-ctl dump_mysql")
+        if status != 0:
+            error("Backup database failed: %s" % output)
 
         spinner_info = SpinnerInfo()
         spinner_info.output = "Starting to upgrade mevoco"
@@ -8917,14 +8931,19 @@ class UpgradeManagementNodeCmd(Command):
 
             def upgrade():
                 info('start to upgrade the management node ...')
-                linux.rm_dir_force(ctl.zstack_home)
                 if ctl.zstack_home.endswith('/'):
                     webapp_dir = os.path.dirname(os.path.dirname(ctl.zstack_home))
                 else:
                     webapp_dir = os.path.dirname(ctl.zstack_home)
 
+                # unzip to temp dir first, only remove old after success
+                tmp_new_zstack = os.path.join(webapp_dir, 'zstack_upgrade_tmp')
+                linux.rm_dir_force(tmp_new_zstack)
                 shell('cp %s %s' % (new_war.path, webapp_dir))
-                ShellCmd('unzip %s -d zstack' % os.path.basename(new_war.path), workdir=webapp_dir)()
+                ShellCmd('unzip %s -d %s' % (os.path.basename(new_war.path), os.path.basename(tmp_new_zstack)),
+                         workdir=webapp_dir)()
+                linux.rm_dir_force(ctl.zstack_home)
+                os.rename(tmp_new_zstack, ctl.zstack_home)
                 #create local repo folder for possible zstack local yum repo
                 zstack_dvd_repo = '{}/zstack/static/zstack-repo'.format(webapp_dir)
                 shell('rm -f {0}; mkdir -p {0};ln -s /opt/zstack-dvd/x86_64 {0}/x86_64; ln -s /opt/zstack-dvd/aarch64 {0}/aarch64; ln -s /opt/zstack-dvd/mips64el {0}/mips64el; ln -s /opt/zstack-dvd/loongarch64 {0}/loongarch64; chown -R zstack:zstack {0}'.format(zstack_dvd_repo))
@@ -8985,6 +9004,15 @@ class UpgradeManagementNodeCmd(Command):
                 info('change permission to user zstack')
                 shell('chown -R zstack:zstack %s' % os.path.join(ctl.zstack_home, '../../'))
 
+            if not need_download and new_war.path:
+                ret = subprocess.run(
+                    ['unzip', '-t', new_war.path],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                ).returncode
+                if ret != 0:
+                    raise CtlError('WAR file %s is corrupted or not a valid zip file' % new_war.path)
+
             backup()
             download_war_if_needed()
             stop_node()
@@ -9031,7 +9059,7 @@ fi
             t = string.Template(upgrade_script)
             upgrade_script = t.substitute({
                 'war_file': dst_war,
-                'need_copy': need_copy
+                'need_copy': need_copy,
             })
 
             fd, upgrade_script_path = tempfile.mkstemp(suffix='.sh')
@@ -9133,6 +9161,13 @@ class UpgradeMultiManagementNodeCmd(Command):
         ssh_key = ctl.zstack_home + "/WEB-INF/classes/ansible/rsaKeys/id_rsa.pub"
         private_key = ssh_key.split('.')[0]
         inventory_file = ctl.zstack_home + "/../../../ansible/hosts"
+
+        # pre-check local node before stopping any node
+        linux.rm_dir_force("/tmp/zstack_upgrade.lock")
+        ret = shell_return("bash %s -u --precheck" % args.installer_bin)
+        if ret != 0:
+            error("Pre-upgrade check failed on local node %s" % local_mn_ip)
+
         for mn_ip in mn_ip_list:
             if mn_ip != local_mn_ip:
                 host_info = HostPostInfo()
@@ -9542,8 +9577,17 @@ class RollbackManagementNodeCmd(Command):
 
             def rollback():
                 info('start to rollback the management node ...')
+                if ctl.zstack_home.endswith('/'):
+                    webapp_dir = os.path.dirname(os.path.dirname(ctl.zstack_home))
+                else:
+                    webapp_dir = os.path.dirname(ctl.zstack_home)
+
+                # unzip to temp dir first, only remove old after success
+                tmp_rollback = os.path.join(webapp_dir, 'zstack_rollback_tmp')
+                linux.rm_dir_force(tmp_rollback)
+                shell('unzip %s -d %s' % (rollbackinfo.war_path, tmp_rollback))
                 linux.rm_dir_force(ctl.zstack_home)
-                shell('unzip %s -d %s' % (rollbackinfo.war_path, ctl.zstack_home))
+                os.rename(tmp_rollback, ctl.zstack_home)
 
             def restore_config():
                 info('restoring the zstack.properties ...')


### PR DESCRIPTION
<fix>[utility]: add pre-check, temp unzip for HA/MN; halt on backup failure abort on HA backup failure

1.precheck before upgrade(single node, multi,HA)
2.delete old files after the upgrade
3.block the upgrade if the backup fails

http://confluence.zstack.io/pages/viewpage.action?pageId=207295019
Resolves: ZSTAC-83970

Change-Id: I6e776f626b79766666766368736e6a6275756f65

sync from gitlab !6928