### PR TITLE
<refactor>[shared_block]: move config_lvm and get_retry_times to lvm module

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -3,7 +3,6 @@ import os.path
 import re
 import random
 import traceback
-import difflib
 
 from kvmagent import kvmagent
 from kvmagent.plugins.imagestore import ImageStoreClient
@@ -624,57 +623,8 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             allDiskPaths.add("/dev/sd*")
             allDiskPaths.add("/dev/vd*")
 
-        def config_lvm(host_id, enableLvmetad=False):
-            lvm.backup_lvm_config()
-            config = lvm.get_lvm_default_config()
-            lvmlockd_lock_retries = 6
-            config.modify({
-                "use_lvmlockd": 1,
-                "host_id": host_id,
-                "sanlock_lv_extend": DEFAULT_SANLOCK_LV_SIZE,
-                "lvmlockd_lock_retries": lvmlockd_lock_retries,
-                "issue_discards": 0,
-                "reserved_stack": 256,
-                "reserved_memory": 131072,
-                "use_lvmetad": 1 if enableLvmetad else 0
-            })
-            if kvmagent.get_host_os_type() == "debian":
-                config.modify({"udev_rules": 0, "udev_sync": 0})
-            config.write_to_file(lvm.LVM_CONFIG_TMP_FILE)
-            lvm.config_lvm_filter([os.path.basename(lvm.LVM_CONFIG_TMP_FILE)], preserve_disks=allDiskPaths)
-
-            new_config = linux.read_file(lvm.LVM_CONFIG_TMP_FILE)
-            old_config = linux.read_file(lvm.LVM_LOCAL_CONFIG_FILE)
-            diff = list(difflib.unified_diff(old_config.splitlines() if old_config is not None else [], new_config.splitlines()))
-            if len(diff) == 0:
-                logger.debug("lvm config has not changed")
-            else:
-                linux.write_file(lvm.LVM_CONFIG_FILE, new_config, create_if_not_exist=True)
-                linux.write_file(lvm.LVM_LOCAL_CONFIG_FILE, new_config, create_if_not_exist=True)
-                logger.debug("lvm config has changed:\n %s" % '\n'.join(diff))
-                lvm.report_config_changed()
-
-            # max lock retries times = (external lvmlockd_lock_retries + 1) * (internal lock_retries + 1 after a lock conflict)
-            lvm.lvm_cmd_timeout_with_locking = ((lvmlockd_lock_retries + 1) * 6) * 5
-            lvm.modify_sanlock_config("sh_retries", 20)
-            lvm.modify_sanlock_config("logfile_priority", 7)
-            lvm.modify_sanlock_config("renewal_read_extend_sec", 24)
-            lvm.modify_sanlock_config("debug_renew", 1)
-            lvm.modify_sanlock_config("use_watchdog", 0)
-            lvm.modify_sanlock_config("max_sectors_kb", "ignore")
-            lvm.modify_sanlock_config("watchdog_fire_timeout", 1)
-            lvm.modify_sanlock_config("kill_grace_seconds", 40)
-            lvm.modify_sanlock_config("zstack_vglock_timeout", 0)
-            lvm.modify_sanlock_config("use_zstack_vglock_timeout", 0)
-            lvm.modify_sanlock_config("zstack_vglock_large_delay", 8)
-            lvm.modify_sanlock_config("use_zstack_vglock_large_delay", 0)
-
-            sanlock_hostname = "%s-%s-%s" % (cmd.vgUuid[:8], cmd.hostUuid[:8], linux.get_hostname()[:20])
-            lvm.modify_sanlock_config("our_host_name", sanlock_hostname)
-            shell.call("sed -i 's/.*rotate .*/rotate 10/g' /etc/logrotate.d/sanlock", exception=False)
-            shell.call("sed -i 's/.*size .*/size 20M/g' /etc/logrotate.d/sanlock", exception=False)
-
-        config_lvm(cmd.hostId, cmd.enableLvmetad)
+        lvm.config_lvm(cmd.hostId, allDiskPaths, cmd.vgUuid, cmd.hostUuid, DEFAULT_SANLOCK_LV_SIZE,
+                       kvmagent.get_host_os_type(), cmd.enableLvmetad)
 
         lvm.start_lock_service(cmd.ioTimeout)
         logger.debug("find/create vg %s lock..." % cmd.vgUuid)
@@ -697,18 +647,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
 #       utility in sanlock.conf. It's 0 second by default, so retry times can be reduced to
 #       3 in order to save time.
 
-        @bash.in_bash
-        def get_retry_times_for_checking_vg_lockspace():
-            r, sanlock_patch_version = bash.bash_ro("sanlock get_patch_version")
-            # if version is not a digit, e.g. "client action get_patch_version is unknown", it also means that sanlock patch version < 2
-            if sanlock_patch_version.strip().isdigit() is False:
-                return 15
-            elif int(sanlock_patch_version.strip()) >= 2:
-                return 3
-            else:
-                return 15
-
-        retry_times_for_checking_vg_lockspace = get_retry_times_for_checking_vg_lockspace()
+        retry_times_for_checking_vg_lockspace = lvm.get_retry_times_for_checking_vg_lockspace()
 
         lvm.check_stuck_vglk_and_gllk()
         logger.debug("starting vg %s lock..." % cmd.vgUuid)

--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -218,6 +218,18 @@ class CreateVolumeFromCacheRsp(AgentRsp):
         self.actualSize = None
         self.size = None
 
+
+class TakeoverRsp(AgentRsp):
+    def __init__(self):
+        super(TakeoverRsp, self).__init__()
+
+
+class GetVgsInfoRsp(AgentRsp):
+    def __init__(self):
+        super(GetVgsInfoRsp, self).__init__()
+        self.groupDiskInfos = {}
+
+
 def translate_absolute_path_from_install_path(path):
     if path is None:
         raise Exception("install path can not be null")
@@ -366,6 +378,8 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
     SHRINK_SNAPSHOT_PATH = "/sharedblock/snapshot/shrink"
     GET_QCOW2_HASH_VALUE_PATH = "/sharedblock/getqcow2hash"
     CHECK_STATE_PATH = "/sharedblock/vgstate/check"
+    TAKEOVER_PATH = "/sharedblock/takeover"
+    VGS_INFO_PATH = "/sharedblock/vgs/info"
 
     vgs_in_progress = set()
     vg_size = {}
@@ -418,6 +432,8 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         http_server.register_async_uri(self.SHRINK_SNAPSHOT_PATH, self.shrink_snapshot)
         http_server.register_async_uri(self.GET_QCOW2_HASH_VALUE_PATH, self.get_qcow2_hashvalue)
         http_server.register_async_uri(self.CHECK_STATE_PATH, self.check_vg_state)
+        http_server.register_async_uri(self.TAKEOVER_PATH, self.takeover)
+        http_server.register_async_uri(self.VGS_INFO_PATH, self.vgs_info)
 
         self.imagestore_client = ImageStoreClient()
 
@@ -1724,4 +1740,166 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             if error:
                 rsp.failedVgs.update({vg_uuid: error})
 
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def takeover(self, req):
+        def _takeover_get_lock(sblk_lock, retry_times=10, retry_interval=(1, 2)):
+            for i in range(retry_times):
+                sblk_lock.lock = lock._get_lock(sblk_lock.name)
+                if sblk_lock.lock.acquire(False):
+                    return
+                if i < retry_times - 1:
+                    sleep = random.uniform(*retry_interval)
+                    logger.debug(
+                        "cannot get %s lock, retry %d/%d after %.1fs" % (sblk_lock.name, i + 1, retry_times, sleep))
+                    time.sleep(sleep)
+            raise SharedBlockConnectException("can not get %s lock after %d retries" % (sblk_lock.name, retry_times))
+
+        def _takeover_release_lock(sblk_lock):
+            try:
+                sblk_lock.lock.release()
+            except Exception:
+                return
+
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        sblk_lock = lock.NamedLock("sharedblock-%s" % cmd.vgUuid)
+        rsp = None
+        try:
+            _takeover_get_lock(sblk_lock)
+            rsp = self.do_takeover(cmd)
+        except SharedBlockConnectException as e:
+            r = AgentRsp()
+            r.success = False
+            r.error = "can not take over sharedblock primary storage[uuid: %s] on host[uuid: %s], " \
+                      "because another sharedblock operation (connect or takeover) is in progress" % (cmd.vgUuid, cmd.hostUuid)
+            rsp = jsonobject.dumps(r)
+        except Exception as e:
+            if rsp is None:
+                r = AgentRsp()
+                r.success = False
+                content = traceback.format_exc()
+                r.error = "%s\n%s" % (str(e), content)
+                rsp = jsonobject.dumps(r)
+        finally:
+            _takeover_release_lock(sblk_lock)
+            return rsp
+
+    @lock.file_lock(LOCK_FILE)
+    def do_takeover(self, cmd):
+        rsp = TakeoverRsp()
+        logger.info("takeover starts: vgUuid=%s, hostId=%s, hostUuid=%s, disks=%s"
+                    % (cmd.vgUuid, cmd.hostId, cmd.hostUuid, cmd.sharedBlockUuids))
+
+        # Step 1: prepare disk paths - all disks are required (consistent with do_connect)
+        diskPaths = set()
+        allDiskPaths = set()
+
+        for diskUuid in cmd.sharedBlockUuids:
+            disk = CheckDisk(diskUuid)
+            diskPaths.add(disk.get_path())
+
+        for diskUuid in (cmd.allSharedBlockUuids or []):
+            disk = CheckDisk(diskUuid)
+            p = disk.get_path(raise_exception=False)
+            if p is not None:
+                allDiskPaths.add(p)
+
+        allDiskPaths = allDiskPaths.union(diskPaths)
+        try:
+            root_disks = ["%s[0-9]*" % d for d in linux.get_physical_disk()]
+            allDiskPaths = allDiskPaths.union(root_disks)
+        except Exception as e:
+            logger.warn("get exception: %s" % e.message)
+            allDiskPaths.add("/dev/sd*")
+            allDiskPaths.add("/dev/vd*")
+        logger.info("takeover[1/8] prepared %d disk paths" % len(allDiskPaths))
+
+        # Step 2: configure LVM
+        lvm.config_lvm(cmd.hostId, allDiskPaths, cmd.vgUuid, cmd.hostUuid, DEFAULT_SANLOCK_LV_SIZE,
+                       kvmagent.get_host_os_type(), cmd.enableLvmetad)
+        logger.info("takeover[2/8] LVM config applied")
+
+        # Step 3: start lock service
+        lvm.start_lock_service(cmd.ioTimeout)
+        logger.info("takeover[3/8] lock service started")
+
+        # Step 4: find VG on storage by exact WWID match
+        def get_vg_name_by_shared_block_uuid():
+            groupDiskInfos = lvm.get_vgs_info(tag=INIT_TAG)
+            target_wwids = set(w.strip().lower() for w in cmd.sharedBlockUuids if w and w.strip())
+            matched_vgs = []
+
+            for _vg_uuid, disk_info in groupDiskInfos.items():
+                block_devices = disk_info["disks"]
+                expected_pv_count = disk_info["diskCount"]
+                if any(not bd.wwid for bd in block_devices) or len(block_devices) != expected_pv_count:
+                    logger.warn("skip VG %s: incomplete WWID set" % _vg_uuid)
+                    continue
+                vg_wwids = set(bd.wwid.strip().lower() for bd in block_devices)
+                if target_wwids == vg_wwids:
+                    matched_vgs.append(_vg_uuid)
+
+            if len(matched_vgs) == 0:
+                available = {k: [bd.wwid for bd in v["disks"]]
+                             for k, v in groupDiskInfos.items()}
+                raise Exception("cannot find VG with tag prefix [%s] and exact WWID match. "
+                                "target=%s, available=%s" % (INIT_TAG, cmd.sharedBlockUuids, available))
+            if len(matched_vgs) > 1:
+                raise Exception("found multiple VGs matching the same WWID set: %s" % matched_vgs)
+            return matched_vgs[0]
+
+        vg_uuid_on_storage = get_vg_name_by_shared_block_uuid()
+        logger.info("takeover[4/8] matched VG: %s (target: %s)" % (vg_uuid_on_storage, cmd.vgUuid))
+
+        # Step 5: reset sanlock lockspace and re-establish lock
+        lvm.check_stuck_vglk_and_gllk()
+        retry_times = lvm.get_retry_times_for_checking_vg_lockspace()
+
+        active_vg_uuid = vg_uuid_on_storage
+        try:
+            lvm.start_vg_lock(vg_uuid_on_storage, cmd.hostId, retry_times)
+            lvm.reset_sanlock_lockspace(vg_uuid_on_storage)
+            lvm.drop_vg_lock(vg_uuid_on_storage)
+            lvm.start_vg_lock(vg_uuid_on_storage, cmd.hostId, retry_times)
+            logger.info("takeover[5/8] sanlock lockspace reset for %s" % vg_uuid_on_storage)
+
+            lvm.check_gl_lock()
+
+            # Step 6: rename VG to match the target platform's database UUID
+            if vg_uuid_on_storage != cmd.vgUuid:
+                lvm.rename_vg(vg_uuid_on_storage, cmd.vgUuid)
+                active_vg_uuid = cmd.vgUuid
+                logger.info("takeover[6/8] VG renamed %s -> %s" % (vg_uuid_on_storage, cmd.vgUuid))
+                lvm.start_vg_lock(cmd.vgUuid, cmd.hostId, retry_times)
+            else:
+                logger.info("takeover[6/8] VG name already matches, skip rename")
+
+            self.clear_stalled_qmp_socket()
+
+            # Step 7: fix PV state
+            lvm.check_missing_pv(cmd.vgUuid)
+            lvm.reset_pv_uuids(cmd.vgUuid)
+            logger.info("takeover[7/8] PV state fixed for %s" % cmd.vgUuid)
+
+            # Step 8: stamp VG tag with current host info
+            new_tag = "%s::%s::%s::%s" % (INIT_TAG, cmd.hostUuid, time.time(), linux.get_hostname())
+            lvm.update_vg_tag(cmd.vgUuid, INIT_TAG, new_tag)
+            logger.info("takeover[8/8] VG tag updated for %s" % cmd.vgUuid)
+        except Exception:
+            logger.warn("takeover failed after lockspace established, "
+                        "dropping vg lock for %s to allow next host to retry" % active_vg_uuid)
+            try:
+                lvm.drop_vg_lock(active_vg_uuid)
+            except Exception as drop_err:
+                logger.warn("drop vg lock failed for %s during takeover cleanup: %s" %
+                            (active_vg_uuid, str(drop_err)))
+            raise
+
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def vgs_info(self, req):
+        rsp = GetVgsInfoRsp()
+        rsp.groupDiskInfos = lvm.get_vgs_info(tag=INIT_TAG)
         return jsonobject.dumps(rsp)

--- a/kvmagent/kvmagent/test/shareblock_testsuite/test_sharedblock_takeover.py
+++ b/kvmagent/kvmagent/test/shareblock_testsuite/test_sharedblock_takeover.py
@@ -1,0 +1,186 @@
+# coding=utf-8
+from kvmagent.test.shareblock_testsuite.shared_block_plugin_teststub import SharedBlockPluginTestStub
+from kvmagent.test.utils import sharedblock_utils, pytest_utils, storage_device_utils
+from zstacklib.utils import bash, lvm, jsonobject
+from unittest import TestCase
+from zstacklib.test.utils import misc, env
+
+storage_device_utils.init_storagedevice_plugin()
+
+PKG_NAME = __name__
+
+# must create iSCSI storage before run test
+__ENV_SETUP__ = {
+    'self': {
+        'xml': 'http://smb.zstack.io/mirror/ztest/xml/twoDiskVm.xml',
+        'init': ['bash ./createiSCSIStroage.sh']
+    }
+}
+
+hostUuid = "8b12f74e6a834c5fa90304b8ea54b1dd"
+hostId = 24
+vgUuid = "36b02490bb944233b0b01990a450ba83"
+takeoverTargetVgUuid = "aabb0011223344556677889900112233"
+
+
+def _call_takeover(plugin, sharedBlockUuids, allSharedBlockUuids, vgUuid, hostId, hostUuid, enableLvmetad=False,
+                   ioTimeout=None):
+    rsp_str = plugin.takeover(misc.make_a_request({
+        "sharedBlockUuids": sharedBlockUuids,
+        "allSharedBlockUuids": allSharedBlockUuids,
+        "vgUuid": vgUuid,
+        "hostId": hostId,
+        "hostUuid": hostUuid,
+        "enableLvmetad": enableLvmetad,
+        "ioTimeout": ioTimeout
+    }))
+    return jsonobject.loads(rsp_str)
+
+
+def _call_vgs_info(plugin):
+    rsp_str = plugin.vgs_info(misc.make_a_request({}))
+    return jsonobject.loads(rsp_str)
+
+
+class TestSharedBlockPlugin(TestCase, SharedBlockPluginTestStub):
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @pytest_utils.ztest_decorater
+    def test_1_vgs_info_after_connect(self):
+        """vgs_info should return VG info including disk details after connect"""
+        iscsi_server = env.get_vm_metadata('self')
+        rsp = storage_device_utils.iscsi_login(iscsi_server.ip, "3260")
+        self.assertEqual(True, rsp.success, rsp.error)
+
+        r, o = bash.bash_ro("ls /dev/disk/by-id | grep scsi|awk -F '-' '{print $2}'")
+        blockUuid = o.strip().replace(' ', '').replace('\n', '').replace('\r', '')
+
+        rsp = self.connect([blockUuid], [blockUuid], vgUuid, hostUuid, hostId, forceWipe=True)
+        self.assertEqual(True, rsp.success, rsp.error)
+
+        # call vgs_info
+        plugin = sharedblock_utils.get_sharedblock_plugin()
+        rsp = _call_vgs_info(plugin)
+        self.assertEqual(True, rsp.success, rsp.error)
+        self.assertTrue(rsp.groupDiskInfos is not None, "groupDiskInfos should not be None")
+        self.assertTrue(rsp.groupDiskInfos.hasattr(vgUuid),
+                        "vgUuid %s not found in groupDiskInfos: %s" % (vgUuid, rsp.groupDiskInfos))
+
+    @pytest_utils.ztest_decorater
+    def test_2_takeover_same_vg_uuid(self):
+        """takeover with same vgUuid should succeed without rename"""
+        iscsi_server = env.get_vm_metadata('self')
+        rsp = storage_device_utils.iscsi_login(iscsi_server.ip, "3260")
+        self.assertEqual(True, rsp.success, rsp.error)
+
+        r, o = bash.bash_ro("ls /dev/disk/by-id | grep scsi|awk -F '-' '{print $2}'")
+        blockUuid = o.strip().replace(' ', '').replace('\n', '').replace('\r', '')
+
+        # connect VG normally first
+        rsp = self.connect([blockUuid], [blockUuid], vgUuid, hostUuid, hostId, forceWipe=True)
+        self.assertEqual(True, rsp.success, rsp.error)
+
+        # stop vg lock to simulate a takeover scenario (VG exists but lockspace stale)
+        lvm.stop_vg_lock(vgUuid)
+
+        # takeover with same vgUuid (no rename)
+        plugin = sharedblock_utils.get_sharedblock_plugin()
+        rsp = _call_takeover(plugin,
+                             sharedBlockUuids=[blockUuid],
+                             allSharedBlockUuids=[blockUuid],
+                             vgUuid=vgUuid,
+                             hostId=hostId,
+                             hostUuid=hostUuid)
+        self.assertEqual(True, rsp.success, rsp.error)
+
+        # verify VG is accessible after takeover
+        r, o = bash.bash_ro("vgs --nolocking -t %s" % vgUuid)
+        self.assertEqual(0, r, "VG %s not accessible after takeover: %s" % (vgUuid, o))
+
+    @pytest_utils.ztest_decorater
+    def test_3_takeover_wwid_not_found(self):
+        """takeover with non-existent WWIDs should fail gracefully"""
+        iscsi_server = env.get_vm_metadata('self')
+        rsp = storage_device_utils.iscsi_login(iscsi_server.ip, "3260")
+        self.assertEqual(True, rsp.success, rsp.error)
+
+        r, o = bash.bash_ro("ls /dev/disk/by-id | grep scsi|awk -F '-' '{print $2}'")
+        blockUuid = o.strip().replace(' ', '').replace('\n', '').replace('\r', '')
+
+        # connect VG so lock service is running
+        rsp = self.connect([blockUuid], [blockUuid], vgUuid, hostUuid, hostId, forceWipe=True)
+        self.assertEqual(True, rsp.success, rsp.error)
+
+        # takeover with a fake WWID that does not match any VG
+        plugin = sharedblock_utils.get_sharedblock_plugin()
+        rsp = _call_takeover(plugin,
+                             sharedBlockUuids=["nonexistent_wwid_00000"],
+                             allSharedBlockUuids=[blockUuid],
+                             vgUuid=vgUuid,
+                             hostId=hostId,
+                             hostUuid=hostUuid)
+        self.assertEqual(False, rsp.success, "takeover with fake WWID should fail")
+
+    @pytest_utils.ztest_decorater
+    def test_4_takeover_with_rename(self):
+        """takeover with different vgUuid should rename the VG"""
+        iscsi_server = env.get_vm_metadata('self')
+        rsp = storage_device_utils.iscsi_login(iscsi_server.ip, "3260")
+        self.assertEqual(True, rsp.success, rsp.error)
+
+        r, o = bash.bash_ro("ls /dev/disk/by-id | grep scsi|awk -F '-' '{print $2}'")
+        blockUuid = o.strip().replace(' ', '').replace('\n', '').replace('\r', '')
+
+        # connect VG with original uuid
+        rsp = self.connect([blockUuid], [blockUuid], vgUuid, hostUuid, hostId, forceWipe=True)
+        self.assertEqual(True, rsp.success, rsp.error)
+
+        # create some LVs via create_empty_volume to simulate real volumes before takeover
+        lv1 = misc.uuid()
+        lv2 = misc.uuid()
+        rsp = sharedblock_utils.shareblock_create_empty_volume(
+            installPath="sharedblock://%s/%s" % (vgUuid, lv1),
+            size=10485760,
+            volumeUuid=lv1,
+            hostUuid=hostUuid,
+            vgUuid=vgUuid
+        )
+        self.assertEqual(True, rsp.success, rsp.error)
+        rsp = sharedblock_utils.shareblock_create_empty_volume(
+            installPath="sharedblock://%s/%s" % (vgUuid, lv2),
+            size=10485760,
+            volumeUuid=lv2,
+            hostUuid=hostUuid,
+            vgUuid=vgUuid
+        )
+        self.assertEqual(True, rsp.success, rsp.error)
+
+        # stop vg lock to simulate takeover scenario
+        lvm.stop_vg_lock(vgUuid)
+
+        # takeover with a different target vgUuid => triggers rename
+        plugin = sharedblock_utils.get_sharedblock_plugin()
+        rsp = _call_takeover(plugin,
+                             sharedBlockUuids=[blockUuid],
+                             allSharedBlockUuids=[blockUuid],
+                             vgUuid=takeoverTargetVgUuid,
+                             hostId=hostId,
+                             hostUuid=hostUuid)
+        self.assertEqual(True, rsp.success, rsp.error)
+
+        # old VG name should be gone
+        r, _ = bash.bash_ro("vgs --nolocking -t %s" % vgUuid)
+        self.assertNotEqual(0, r, "old VG %s should not exist after rename" % vgUuid)
+
+        # new VG name should exist
+        r, o = bash.bash_ro("vgs --nolocking -t %s" % takeoverTargetVgUuid)
+        self.assertEqual(0, r, "new VG %s not accessible after takeover rename: %s" % (takeoverTargetVgUuid, o))
+
+        # LVs should now belong to the renamed VG
+        r, o = bash.bash_ro("lvs --nolocking -t --noheading -o lv_name -S vg_name=%s" % takeoverTargetVgUuid)
+        self.assertEqual(0, r, "failed to list LVs under renamed VG: %s" % o)
+        lv_names = o.strip().split()
+        self.assertIn(lv1, lv_names, "LV %s not found under renamed VG %s, got: %s" % (lv1, takeoverTargetVgUuid, lv_names))
+        self.assertIn(lv2, lv_names, "LV %s not found under renamed VG %s, got: %s" % (lv2, takeoverTargetVgUuid, lv_names))

--- a/kvmagent/kvmagent/test/unittest_tools/blacklist_aarch64
+++ b/kvmagent/kvmagent/test/unittest_tools/blacklist_aarch64
@@ -40,6 +40,7 @@ kvmagent/test/shareblock_testsuite/test_sharedblock_volume_migrate.py
 kvmagent/test/shareblock_testsuite/test_shareblock_create_data_volume_with_backing.py
 kvmagent/test/shareblock_testsuite/test_sharedblock_check_lock.py
 kvmagent/test/shareblock_testsuite/test_shareblock_get_qcow2_hashvalue.py
+kvmagent/test/shareblock_testsuite/test_sharedblock_takeover.py
 kvmagent/test/vm_plugin_testsuite/test_vm_cpu_model.py
 kvmagent/test/vm_plugin_testsuite/test_vm_max_vcpu.py
 kvmagent/test/nfs_testsuit/test_ha_nfs.py

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -168,6 +168,7 @@ class SharedBlockCandidateStruct:
         self.source = None  # type: str
         self.transport = None  # type: str
         self.targetIdentifier = None  # type: str
+        self.multipathPath = None  # type: str
 
 def get_vg_uuid(path):
     # type: (str) -> str
@@ -291,13 +292,14 @@ def get_mpath_block_devices(scsi_info):
 
     block_devices_list = [None] * len(mpath_devices)
 
-    def get_slave_block_devices(slave, dm, i):
+    def get_slave_block_devices(slave, dm, i, mpath_dev):
         try:
             struct = get_device_info(slave, scsi_info)
             if struct is None:
                 return
             struct.type = "mpath"
             struct.dev_name = slave
+            struct.multipathPath = mpath_dev
             block_devices_list[i] = struct
         except Exception as e:
             logger.warn(linux.get_exception_stacktrace())
@@ -315,11 +317,12 @@ def get_mpath_block_devices(scsi_info):
                 struct = SharedBlockCandidateStruct()
                 struct.wwid = get_dm_wwid(dm)
                 struct.type = "mpath"
+                struct.multipathPath = mpath_device
                 block_devices_list[idx] = struct
                 continue
 
             slave_devices.extend(slaves)
-            threads.append(thread.ThreadFacade.run_in_thread(get_slave_block_devices, [slaves[0], dm, idx]))
+            threads.append(thread.ThreadFacade.run_in_thread(get_slave_block_devices, [slaves[0], dm, idx, mpath_device]))
         except Exception as e:
             logger.warn(linux.get_exception_stacktrace())
             continue
@@ -2758,8 +2761,7 @@ def get_retry_times_for_checking_vg_lockspace():
         return 15
 
 
-def config_lvm(host_id, all_disk_paths, vg_uuid, host_uuid, default_sanlock_lv_size, host_os_type,
-               enable_lvmetad=False):
+def config_lvm(host_id, all_disk_paths, vg_uuid, host_uuid, default_sanlock_lv_size, host_os_type, enable_lvmetad):
     backup_lvm_config()
     config = get_lvm_default_config()
     lvmlockd_lock_retries = 6
@@ -2810,3 +2812,212 @@ def config_lvm(host_id, all_disk_paths, vg_uuid, host_uuid, default_sanlock_lv_s
     modify_sanlock_config("our_host_name", sanlock_hostname)
     shell.call("sed -i 's/.*rotate .*/rotate 10/g' /etc/logrotate.d/sanlock", exception=False)
     shell.call("sed -i 's/.*size .*/size 20M/g' /etc/logrotate.d/sanlock", exception=False)
+
+
+@bash.in_bash
+def get_vgs_info(tag):
+    groupDiskInfos = {}
+
+    block_devices = get_block_devices()
+
+    block_devices_by_dev_name = {}
+    for bd in block_devices:
+        if bd.dev_name:
+            block_devices_by_dev_name[bd.dev_name] = bd
+        if bd.multipathPath:
+            block_devices_by_dev_name[bd.multipathPath] = bd
+            try:
+                dm_name = os.path.basename(os.path.realpath("/dev/mapper/%s" % bd.multipathPath))
+                if dm_name:
+                    block_devices_by_dev_name[dm_name] = bd
+                    for slave in os.listdir("/sys/class/block/%s/slaves/" % dm_name):
+                        if slave and slave.strip():
+                            block_devices_by_dev_name[slave.strip()] = bd
+            except Exception:
+                logger.warn("resolve dm name failed for mpath device %s: %s" %
+                            (bd.multipathPath, linux.get_exception_stacktrace()))
+
+    r, o, e = bash.bash_roe("vgs --nolocking -t -o vg_name,pv_count,pv_name,tags --noheadings")
+    if r != 0:
+        raise Exception("get vgs info failed, error: %s" % e)
+
+    for info in form.load('vg_name pv_count pv_name tags\n' + o):
+        vg_name = info['vg_name']
+        pv_count = info['pv_count']
+        pv_name = info['pv_name']
+        tags = info['tags']
+
+        tag_list = [t.strip() for t in (tags or "").split(",") if t.strip()]
+        if not any(t.startswith(tag) for t in tag_list):
+            continue
+
+        pv_basename = os.path.basename(pv_name)
+        if vg_name not in groupDiskInfos:
+            groupDiskInfos[vg_name] = {"disks": [], "diskCount": int(pv_count)}
+
+        block_device = block_devices_by_dev_name.get(pv_basename)
+        if block_device is None:
+            # fallback: try resolving via realpath (e.g. /dev/mapper/mpathX -> dm-N)
+            try:
+                real_name = os.path.basename(os.path.realpath(pv_name))
+                block_device = block_devices_by_dev_name.get(real_name)
+            except Exception as e:
+                logger.warn("resolve realpath failed for pv %s: %s" % (pv_name, str(e)))
+        if block_device:
+            groupDiskInfos[vg_name]["disks"].append(block_device)
+        else:
+            logger.warn("PV %s belongs to VG %s but not found in block devices scan" % (pv_basename, vg_name))
+
+    for vg_name, info in groupDiskInfos.items():
+        actual_count = len(info["disks"])
+        expected_count = info["diskCount"]
+        if actual_count < expected_count:
+            logger.warn("VG %s has incomplete WWID set: expected %d PVs but resolved %d block devices. "
+                        "WWID matching may fail for this VG." % (vg_name, expected_count, actual_count))
+
+    return groupDiskInfos
+
+
+@bash.in_bash
+def reset_pv_uuids(vg_uuid):
+    """Reset all PV UUIDs in the VG to avoid collision with the source platform."""
+    r, o, e = bash.bash_roe(
+        "timeout -s SIGKILL 30 pvs --noheading --nolocking -t -Svg_name=%s -oname" % vg_uuid)
+    if r != 0:
+        raise Exception("failed to list PVs for VG %s: stdout=%s, stderr=%s" % (vg_uuid, o, e))
+    pv_names = [line.strip() for line in o.strip().splitlines() if line.strip()]
+    if not pv_names:
+        raise Exception("no PVs found for VG %s while resetting PV UUIDs" % vg_uuid)
+
+    all_pvs = " ".join(pv_names)
+    r, _, e = bash.bash_roe("timeout -s SIGKILL %s pvchange --yes --uuid %s" % (lvm_cmd_timeout_with_locking, all_pvs))
+    if r != 0:
+        raise Exception("failed to reset PV UUIDs for VG %s (pvs: %s): %s" % (vg_uuid, all_pvs, e))
+
+    logger.debug("reset PV UUIDs for VG %s: %s" % (vg_uuid, pv_names))
+
+
+@bash.in_bash
+def rename_vg(old_vg_uuid, new_vg_uuid):
+    if old_vg_uuid == new_vg_uuid:
+        logger.debug("rename vg skipped: old_vgUuid == new_vgUuid (%s)" % old_vg_uuid)
+        return
+
+    if vg_exists(new_vg_uuid) and not vg_exists(old_vg_uuid):
+        logger.debug("rename vg skipped: %s already exists and %s not found" % (new_vg_uuid, old_vg_uuid))
+        return
+
+    if vg_exists(new_vg_uuid) and vg_exists(old_vg_uuid):
+        raise Exception("both old VG %s and new VG %s exist on this host. "
+                        "Refusing to rename - manual investigation required." % (old_vg_uuid, new_vg_uuid))
+
+    @linux.retry(times=5, sleep_time=2)
+    def do_vg_rename():
+        # Guard: rename may have already succeeded in a previous retry
+        if vg_exists(new_vg_uuid) and not vg_exists(old_vg_uuid):
+            logger.debug("rename vg already completed: %s -> %s" % (old_vg_uuid, new_vg_uuid))
+            return
+
+        r, o, e = bash.bash_roe(
+            "timeout -s SIGKILL %s vgrename %s %s" %
+            (lvm_cmd_timeout_with_locking, old_vg_uuid, new_vg_uuid))
+        if r != 0:
+            raise Exception("unable to rename vg %s to %s, "
+                            "stdout:%s, stderr:%s" % (old_vg_uuid, new_vg_uuid, str(o), str(e)))
+
+        old_exists = vg_exists(old_vg_uuid)
+        new_exists = vg_exists(new_vg_uuid)
+        if old_exists or not new_exists:
+            raise RetryException(
+                "unexpected VG state after rename %s -> %s: old_exists=%s, new_exists=%s" % (
+                    old_vg_uuid, new_vg_uuid, old_exists, new_exists))
+
+        logger.debug("rename vg %s to %s successfully" % (old_vg_uuid, new_vg_uuid))
+
+    do_vg_rename()
+
+    old_exists = vg_exists(old_vg_uuid)
+    new_exists = vg_exists(new_vg_uuid)
+    if old_exists or not new_exists:
+        raise Exception("vg rename post-check failed: old_exists=%s, new_exists=%s for %s -> %s" %
+                        (old_exists, new_exists, old_vg_uuid, new_vg_uuid))
+
+
+@bash.in_bash
+def reset_sanlock_lockspace(vg_uuid):
+    lockspace_path = "/dev/mapper/%s-lvmlock" % vg_uuid
+
+    fix_vglk(vg_uuid)
+
+    # Reinit delta lease area (clears ALL host slots).
+    r, o, e = bash.bash_roe(
+        "timeout -s SIGKILL 60 sanlock direct init -s lvm_%s:0:%s:0" % (vg_uuid, lockspace_path))
+    if r != 0:
+        raise Exception("failed to init sanlock lockspace for %s: stdout=%s, stderr=%s"
+                        % (vg_uuid, o, e))
+
+    # Reinit GLLK and VGLK resource leases (clear source platform owner residue).
+    sector_size = sanlock.get_sector_size(vg_uuid)
+    align_size = sanlock.sector_size_to_align_size(sector_size)
+    gllk_offset = sanlock.GLLK_BEGIN * align_size
+    vglk_offset = sanlock.VGLK_BEGIN * align_size
+
+    r, o, e = bash.bash_roe(
+        "timeout -s SIGKILL 30 sanlock direct init -r lvm_%s:GLLK:%s:%s" % (vg_uuid, lockspace_path, gllk_offset))
+    if r != 0:
+        raise Exception("failed to reinit GLLK for %s: %s" % (vg_uuid, e))
+    logger.debug("reset_sanlock_lockspace: reinit GLLK at offset %s" % gllk_offset)
+
+    r, o, e = bash.bash_roe(
+        "timeout -s SIGKILL 30 sanlock direct init -r lvm_%s:VGLK:%s:%s" % (vg_uuid, lockspace_path, vglk_offset))
+    if r != 0:
+        raise Exception("failed to reinit VGLK for %s: %s" % (vg_uuid, e))
+    logger.debug("reset_sanlock_lockspace: reinit VGLK at offset %s" % vglk_offset)
+
+    # Reinit per-LV resource leases.
+    o = bash.bash_errorout("timeout -s SIGKILL 30 lvs -ouuid,lock_args -Svg_name=%s --noheading --nolocking -t" % vg_uuid)
+
+    failed_lvs = []
+    for line in o.strip().splitlines():
+        xs = line.strip().split()
+        if len(xs) < 2 or ":" not in xs[1]:
+            logger.warn("reset_sanlock_lockspace: skip unparseable LV lease line: %r" % line)
+            continue
+        uuid = xs[0]
+        offset = xs[1].split(":")[-1]
+        logger.debug("reset_sanlock_lockspace: reinit LV lease %s offset %s" % (uuid, offset))
+        r, _o, e = bash.bash_roe(
+            "timeout -s SIGKILL 30 sanlock direct init -r lvm_%s:%s:%s:%s" % (vg_uuid, uuid, lockspace_path, offset))
+        if r != 0:
+            failed_lvs.append(uuid)
+            logger.warn("failed to reinit LV lease %s for %s: %s" % (uuid, vg_uuid, e))
+
+    if failed_lvs:
+        raise Exception("failed to reinit %d LV lease(s) for %s: %s" % (len(failed_lvs), vg_uuid, failed_lvs))
+
+
+@bash.in_bash
+def update_vg_tag(vg_uuid, old_tag_prefix, new_tag):
+    """Update VG tag: find existing tag by old_tag_prefix and replace with new_tag."""
+    r, o, e = bash.bash_roe("timeout -s SIGKILL 30 vgs --nolocking -t -o tags --noheadings %s" % vg_uuid)
+    if r != 0:
+        raise Exception("failed to get VG tags for %s: %s" % (vg_uuid, e))
+
+    old_tags = [t.strip() for t in o.strip().split(",")
+                if t.strip().startswith(old_tag_prefix)]
+
+    # Add new tag first - ensures VG always has at least one matchable tag,
+    # even if the subsequent deltag fails. This makes retry safe: get_vgs_info(tag=INIT_TAG)
+    # can always find the VG.
+    bash.bash_errorout("timeout -s SIGKILL %s vgchange --addtag %s %s" % (lvm_cmd_timeout_with_locking, linux.shellquote(new_tag), vg_uuid))
+
+    # Remove all old tags (may be >1 if a previous attempt partially succeeded)
+    for old_tag in old_tags:
+        r, o, e = bash.bash_roe("timeout -s SIGKILL %s vgchange --deltag %s %s" % (lvm_cmd_timeout_with_locking, linux.shellquote(old_tag), vg_uuid))
+        if r != 0:
+            logger.warn("failed to remove old tag %s from VG %s: %s (non-fatal, new tag already set)"
+                        % (old_tag, vg_uuid, e))
+    if old_tags:
+        logger.debug("updated VG tag for %s: %s -> %s" % (vg_uuid, old_tags, new_tag))
+    else:
+        logger.warn("no tag with prefix [%s] found on VG %s, added new tag directly" % (old_tag_prefix, vg_uuid))

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -1,3 +1,4 @@
+import difflib
 import functools
 import random
 import os
@@ -2743,3 +2744,69 @@ class LvmlockdStatus(object):
         except Exception as e:
             logger.warn(str(e))
             self.failed = True
+
+
+@bash.in_bash
+def get_retry_times_for_checking_vg_lockspace():
+    _, sanlock_patch_version = bash.bash_ro("sanlock get_patch_version")
+    # if version is not a digit, e.g. "client action get_patch_version is unknown", it also means that sanlock patch version < 2
+    if sanlock_patch_version.strip().isdigit() is False:
+        return 15
+    elif int(sanlock_patch_version.strip()) >= 2:
+        return 3
+    else:
+        return 15
+
+
+def config_lvm(host_id, all_disk_paths, vg_uuid, host_uuid, default_sanlock_lv_size, host_os_type,
+               enable_lvmetad=False):
+    backup_lvm_config()
+    config = get_lvm_default_config()
+    lvmlockd_lock_retries = 6
+    config.modify({
+        "use_lvmlockd": 1,
+        "host_id": host_id,
+        "sanlock_lv_extend": default_sanlock_lv_size,
+        "lvmlockd_lock_retries": lvmlockd_lock_retries,
+        "issue_discards": 0,
+        "reserved_stack": 256,
+        "reserved_memory": 131072,
+        "use_lvmetad": 1 if enable_lvmetad else 0
+    })
+
+    if host_os_type == "debian":
+        config.modify({"udev_rules": 0, "udev_sync": 0})
+    config.write_to_file(LVM_CONFIG_TMP_FILE)
+    config_lvm_filter([os.path.basename(LVM_CONFIG_TMP_FILE)], preserve_disks=all_disk_paths)
+
+    new_config = linux.read_file(LVM_CONFIG_TMP_FILE)
+    old_config = linux.read_file(LVM_LOCAL_CONFIG_FILE)
+    diff = list(difflib.unified_diff(old_config.splitlines() if old_config is not None else [], new_config.splitlines()))
+    if len(diff) == 0:
+        logger.debug("lvm config has not changed")
+    else:
+        linux.write_file(LVM_CONFIG_FILE, new_config, create_if_not_exist=True)
+        linux.write_file(LVM_LOCAL_CONFIG_FILE, new_config, create_if_not_exist=True)
+        logger.debug("lvm config has changed:\n %s" % '\n'.join(diff))
+        report_config_changed()
+
+    # max lock retries times = (external lvmlockd_lock_retries + 1) * (internal lock_retries + 1 after a lock conflict)
+    global lvm_cmd_timeout_with_locking
+    lvm_cmd_timeout_with_locking = ((lvmlockd_lock_retries + 1) * 6) * 5
+    modify_sanlock_config("sh_retries", 20)
+    modify_sanlock_config("logfile_priority", 7)
+    modify_sanlock_config("renewal_read_extend_sec", 24)
+    modify_sanlock_config("debug_renew", 1)
+    modify_sanlock_config("use_watchdog", 0)
+    modify_sanlock_config("max_sectors_kb", "ignore")
+    modify_sanlock_config("watchdog_fire_timeout", 1)
+    modify_sanlock_config("kill_grace_seconds", 40)
+    modify_sanlock_config("zstack_vglock_timeout", 0)
+    modify_sanlock_config("use_zstack_vglock_timeout", 0)
+    modify_sanlock_config("zstack_vglock_large_delay", 8)
+    modify_sanlock_config("use_zstack_vglock_large_delay", 0)
+
+    sanlock_hostname = "%s-%s-%s" % (vg_uuid[:8], host_uuid[:8], linux.get_hostname()[:20])
+    modify_sanlock_config("our_host_name", sanlock_hostname)
+    shell.call("sed -i 's/.*rotate .*/rotate 10/g' /etc/logrotate.d/sanlock", exception=False)
+    shell.call("sed -i 's/.*size .*/size 20M/g' /etc/logrotate.d/sanlock", exception=False)


### PR DESCRIPTION
Move config_lvm and get_retry_times_for_checking_vg_lockspace from
do_connect inline functions to lvm module-level functions.

Resolves: ZSV-11559

Change-Id: I6f776c6273656b64776f617479646b767977696e

sync from gitlab !6933