### PR TITLE
<fix>[kvmagent]: set MALLOC_ARENA_MAX to curb glibc arena fragmentation

### DIFF
--- a/kvmagent/zstack-kvmagent
+++ b/kvmagent/zstack-kvmagent
@@ -118,7 +118,7 @@ else
 		config_journal
 		install_i40e_driver
 	fi
-
+	export MALLOC_ARENA_MAX=4
 	. /var/lib/zstack/virtualenv/kvm/bin/activate && python -c "from kvmagent import kdaemon; kdaemon.main()" "$@"
 fi
 


### PR DESCRIPTION
glibc defaults arena count to 8 * CPU cores. Each arena retains
freed memory indefinitely, causing kvmagent RSS to grow monotonically
over long-running periods. Limiting arenas to 4 reduces fragmentation
while maintaining acceptable concurrency for kvmagent workload.

Resolves: ZSTAC-83735
Change-Id: I634d57202dcc0e69542d9a534019614570a8cc96


(cherry picked from commit 0e0a97ef025f6e730a24eeb270d157af5cc45ba8)

sync from gitlab !6973