### PR TITLE
<fix>[shared_block]: preserve unmanaged host LUNs in lvm.conf filter

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -660,7 +660,9 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             disks.add(disk)
             diskPaths.add(disk.get_path())
 
-        for diskUuid in cmd.allSharedBlockUuids:
+        effective_wwids = list(cmd.allSharedBlockUuids or [])
+        effective_wwids.extend(lvm.filter_lvm_pv_wwids(getattr(cmd, 'candidateUnmanagedLunWwids', None)))
+        for diskUuid in effective_wwids:
             disk = CheckDisk(diskUuid)
             p = disk.get_path(raise_exception=False)
             if p is not None:
@@ -838,7 +840,10 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         allDiskPaths = set()
         allDisks = set()
 
-        for diskUuid in cmd.allSharedBlockUuids:
+        effective_wwids = list(cmd.allSharedBlockUuids or [])
+        effective_wwids.extend(lvm.filter_lvm_pv_wwids(
+            getattr(cmd, 'candidateUnmanagedLunWwids', None)))
+        for diskUuid in effective_wwids:
             _disk = CheckDisk(diskUuid)
             p = _disk.get_path(raise_exception=False)
             if p is not None:
@@ -1673,7 +1678,10 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
 
         allDiskPaths = set()
 
-        for diskUuid in cmd.allSharedBlockUuids:
+        effective_wwids = list(cmd.allSharedBlockUuids or [])
+        effective_wwids.extend(lvm.filter_lvm_pv_wwids(
+            getattr(cmd, 'candidateUnmanagedLunWwids', None)))
+        for diskUuid in effective_wwids:
             disk = CheckDisk(diskUuid)
             p = disk.get_path(raise_exception=False)
             if p is not None:
@@ -1840,7 +1848,10 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             disk = CheckDisk(diskUuid)
             diskPaths.add(disk.get_path())
 
-        for diskUuid in (cmd.allSharedBlockUuids or []):
+        effective_wwids = list(cmd.allSharedBlockUuids or [])
+        effective_wwids.extend(lvm.filter_lvm_pv_wwids(
+            getattr(cmd, 'candidateUnmanagedLunWwids', None)))
+        for diskUuid in effective_wwids:
             disk = CheckDisk(diskUuid)
             p = disk.get_path(raise_exception=False)
             if p is not None:

--- a/kvmagent/kvmagent/plugins/vms/vm_host_file_monitor.py
+++ b/kvmagent/kvmagent/plugins/vms/vm_host_file_monitor.py
@@ -22,7 +22,7 @@ from zstacklib.utils import thread
 
 logger = log.get_logger(__name__)
 
-KVM_REPORT_VM_HOST_FILE_CHANGED = '/vm/hostfile/changed'
+KVM_REPORT_VM_HOST_FILE_CHANGED = '/kvm/reporthostfilechanged'
 
 # Number of consecutive scan misses before removing a VM from the watch list.
 MISS_COUNT_THRESHOLD = 10

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -3021,3 +3021,26 @@ def update_vg_tag(vg_uuid, old_tag_prefix, new_tag):
         logger.debug("updated VG tag for %s: %s -> %s" % (vg_uuid, old_tags, new_tag))
     else:
         logger.warn("no tag with prefix [%s] found on VG %s, added new tag directly" % (old_tag_prefix, vg_uuid))
+
+
+def filter_lvm_pv_wwids(candidate_wwids):
+    """Return the subset of unmanaged LUN wwids whose device carries an LVM2_member header.
+
+    Probe failures and missing devices are skipped (not added to filter). This avoids
+    expanding the forceWipe blast radius to LUNs we cannot positively identify as PVs.
+    """
+    kept = []
+    if not candidate_wwids:
+        return kept
+    for wwid in candidate_wwids:
+        dev_path = "/dev/disk/by-id/%s" % wwid
+        if not os.path.exists(dev_path):
+            logger.info("filter_lvm_pv_wwids: skip %s, device %s not present" % (wwid, dev_path))
+            continue
+        ret, out, err = bash.bash_roe("blkid -p -s TYPE -o value %s" % dev_path)
+        if ret != 0:
+            logger.info("filter_lvm_pv_wwids: skip %s, blkid ret=%s err=%s" % (wwid, ret, err))
+            continue
+        if (out or "").strip() == "LVM2_member":
+            kept.append(wwid)
+    return kept


### PR DESCRIPTION
Extend do_connect / add_shared_block / takeover / config_filter to
read cmd.unmanagedHostLunWwids (LUNs visible on the host but not
managed by any SharedBlock PS, reported by the controller via the
new HostAllScsiLunWwidsExtensionPoint) and include their device
paths when building allDiskPaths / allDisks.

This keeps unmanaged LUNs in the lvm.conf/lvmlocal.conf preserve
filter so they are not filtered out by LVM, and also covers the
forceWipe branch of create_vg_if_not_found which rewrites the filter
using get_disk_paths(allDisks).

Resolves: ZSV-11734

Change-Id: I796a717962616f6977777273646d71746d6c7677

sync from gitlab !6983