### PR TITLE
<fix>[sharedblock]: only allow PV-bearing unmanaged LUNs into lvm filter

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -363,6 +363,25 @@ class CheckDisk(object):
         return None
 
 
+def filter_lvm_pv_wwids(candidate_wwids):
+    kept = []
+    if not candidate_wwids:
+        return kept
+    for wwid in candidate_wwids:
+        path = CheckDisk(wwid).get_path(raise_exception=False)
+        if path is None:
+            logger.info("filter_lvm_pv_wwids: skip %s, no by-id link or absolute path resolved" % wwid)
+            continue
+        ret, out, err = bash.bash_roe(
+            "timeout -s SIGKILL 10 blkid -p -s TYPE -o value %s" % linux.shellquote(path))
+        if ret != 0:
+            logger.info("filter_lvm_pv_wwids: skip %s (path %s), blkid ret=%s err=%s" % (wwid, path, ret, err))
+            continue
+        if (out or "").strip() == "LVM2_member":
+            kept.append(wwid)
+    return kept
+
+
 class SharedBlockPlugin(kvmagent.KvmAgent):
 
     PING_PATH = "/sharedblock/ping"
@@ -669,6 +688,13 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
                 if diskUuid in cmd.sharedBlockUuids:
                     self.vgs_path_and_wwid[cmd.vgUuid][p] = diskUuid
 
+        for wwid in filter_lvm_pv_wwids(cmd.candidateUnmanagedLunWwids):
+            disk = CheckDisk(wwid)
+            p = disk.get_path(raise_exception=False)
+            if p is not None:
+                allDiskPaths.add(p)
+                allDisks.add(disk)
+
         allDiskPaths = allDiskPaths.union(diskPaths)
         allDisks = allDisks.union(disks)
 
@@ -846,6 +872,13 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
                 allDisks.add(_disk)
                 if diskUuid == cmd.diskUuid:
                     self.vgs_path_and_wwid[cmd.vgUuid][p] = diskUuid
+
+        for wwid in filter_lvm_pv_wwids(cmd.candidateUnmanagedLunWwids):
+            _disk = CheckDisk(wwid)
+            p = _disk.get_path(raise_exception=False)
+            if p is not None:
+                allDiskPaths.add(p)
+                allDisks.add(_disk)
         allDiskPaths.add(disk.get_path())
         allDisks.add(disk)
         try:
@@ -1679,6 +1712,12 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             if p is not None:
                 allDiskPaths.add(p)
 
+        for wwid in filter_lvm_pv_wwids(cmd.candidateUnmanagedLunWwids):
+            disk = CheckDisk(wwid)
+            p = disk.get_path(raise_exception=False)
+            if p is not None:
+                allDiskPaths.add(p)
+
         try:
             root_disks = ["%s[0-9]*" % d for d in linux.get_physical_disk()]
             allDiskPaths = allDiskPaths.union(root_disks)
@@ -1846,6 +1885,12 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             if p is not None:
                 allDiskPaths.add(p)
 
+        for wwid in filter_lvm_pv_wwids(cmd.candidateUnmanagedLunWwids):
+            disk = CheckDisk(wwid)
+            p = disk.get_path(raise_exception=False)
+            if p is not None:
+                allDiskPaths.add(p)
+
         allDiskPaths = allDiskPaths.union(diskPaths)
         try:
             root_disks = ["%s[0-9]*" % d for d in linux.get_physical_disk()]
@@ -1942,6 +1987,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
     @kvmagent.replyerror
     def vgs_info(self, req):
         rsp = GetVgsInfoRsp()
+        bash.bash_roe("pvscan --cache")
         rsp.groupDiskInfos = lvm.get_vgs_info(tag=INIT_TAG)
         return jsonobject.dumps(rsp)
 

--- a/kvmagent/kvmagent/plugins/vms/vm_host_file_monitor.py
+++ b/kvmagent/kvmagent/plugins/vms/vm_host_file_monitor.py
@@ -22,7 +22,7 @@ from zstacklib.utils import thread
 
 logger = log.get_logger(__name__)
 
-KVM_REPORT_VM_HOST_FILE_CHANGED = '/vm/hostfile/changed'
+KVM_REPORT_VM_HOST_FILE_CHANGED = '/kvm/reporthostfilechanged'
 
 # Number of consecutive scan misses before removing a VM from the watch list.
 MISS_COUNT_THRESHOLD = 10

--- a/zstacklib/zstacklib/test/lvm/centos_default_lvm.conf
+++ b/zstacklib/zstacklib/test/lvm/centos_default_lvm.conf
@@ -1,0 +1,411 @@
+# This is an example configuration file for the LVM2 system.
+# It contains the default settings that would be used if there was no
+# /etc/lvm/lvm.conf file.
+#
+# Refer to 'man lvm.conf' for further information including the file layout.
+#
+# Refer to 'man lvm.conf' for information about how settings configured in
+# this file are combined with built-in values and command line options to
+# arrive at the final values used by LVM.
+#
+# Refer to 'man lvmconfig' for information about displaying the built-in
+# and configured values used by LVM.
+#
+# If a default value is set in this file (not commented out), then a
+# new version of LVM using this file will continue using that value,
+# even if the new version of LVM changes the built-in default value.
+#
+# To put this file in a different directory and override /etc/lvm set
+# the environment variable LVM_SYSTEM_DIR before running the tools.
+#
+# N.B. Take care that each setting only appears once if uncommenting
+# example settings in this file.
+
+
+# Configuration section config.
+# How LVM configuration settings are handled.
+config {
+
+        # Configuration option config/checks.
+        # If enabled, any LVM configuration mismatch is reported.
+        # This implies checking that the configuration key is understood by
+        # LVM and that the value of the key is the proper type. If disabled,
+        # any configuration mismatch is ignored and the default value is used
+        # without any warning (a message about the configuration key not being
+        # found is issued in verbose mode only).
+        checks = 1
+
+        # Configuration option config/abort_on_errors.
+        # Abort the LVM process if a configuration mismatch is found.
+        abort_on_errors = 0
+
+        # Configuration option config/profile_dir.
+        # Directory where LVM looks for configuration profiles.
+        profile_dir = "/etc/lvm/profile"
+}
+
+# Configuration section devices.
+# How LVM uses block devices.
+devices {
+
+        # Configuration option devices/dir.
+        # Directory in which to create volume group device nodes.
+        # Commands also accept this as a prefix on volume group names.
+        # This configuration option is advanced.
+        dir = "/dev"
+
+        # Configuration option devices/scan.
+        # Directories containing device nodes to use with LVM.
+        # This configuration option is advanced.
+        scan = [ "/dev" ]
+
+        # Configuration option devices/obtain_device_list_from_udev.
+        # Obtain the list of available devices from udev.
+        # This avoids opening or using any inapplicable non-block devices or
+        # subdirectories found in the udev directory. Any device node or
+        # symlink not managed by udev in the udev directory is ignored. This
+        # setting applies only to the udev-managed device directory; other
+        # directories will be scanned fully. LVM needs to be compiled with
+        # udev support for this setting to apply.
+        obtain_device_list_from_udev = 1
+
+        # Configuration option devices/external_device_info_source.
+        # Select an external device information source.
+        # Some information may already be available in the system and LVM can
+        # use this information to determine the exact type or use of devices it
+        # processes. Using an existing external device information source can
+        # speed up device processing as LVM does not need to run its own native
+        # routines to acquire this information. For example, this information
+        # is used to drive LVM filtering like MD component detection, multipath
+        # component detection, partition detection and others.
+        #
+        # Accepted values:
+        #   none
+        #     No external device information source is used.
+        #   udev
+        #     Reuse existing udev database records. Applicable only if LVM is
+        #     compiled with udev support.
+        #
+        external_device_info_source = "none"
+
+        # Configuration option devices/hints.
+        # Use a local file to remember which devices have PVs on them.
+        # Some commands will use this as an optimization to reduce device
+        # scanning, and will only scan the listed PVs. Removing the hint file
+        # will cause lvm to generate a new one. Disable hints if PVs will
+        # be copied onto devices using non-lvm commands, like dd.
+        #
+        # Accepted values:
+        #   all
+        #     Use all hints.
+        #   none
+        #     Use no hints.
+        #
+        # This configuration option has an automatic default value.
+        # hints = "all"
+
+        # Configuration option devices/preferred_names.
+        # Select which path name to display for a block device.
+        # If multiple path names exist for a block device, and LVM needs to
+        # display a name for the device, the path names are matched against
+        # each item in this list of regular expressions. The first match is
+        # used. Try to avoid using undescriptive /dev/dm-N names, if present.
+        # If no preferred name matches, or if preferred_names are not defined,
+        # the following built-in preferences are applied in order until one
+        # produces a preferred name:
+        # Prefer names with path prefixes in the order of:
+        # /dev/mapper, /dev/disk, /dev/dm-*, /dev/block.
+        # Prefer the name with the least number of slashes.
+        # Prefer a name that is a symlink.
+        # Prefer the path with least value in lexicographical order.
+        #
+        # Example
+        # preferred_names = [ "^/dev/mpath/", "^/dev/mapper/mpath", "^/dev/[hs]d" ]
+        #
+        # This configuration option has an automatic default value.
+        # preferred_names = [ "^/dev/mpath/", "^/dev/mapper/mpath", "^/dev/[hs]d" ]
+
+        # Configuration option devices/use_devicesfile.
+        # Enable or disable the use of a devices file.
+        # When enabled, lvm will only use devices that
+        # are lised in the devices file. A devices file will
+        # be used, regardless of this setting, when the --devicesfile
+        # option is set to a specific file name.
+        # This configuration option has an automatic default value.
+        # use_devicesfile = 0
+
+        # Configuration option devices/devicesfile.
+        # The name of the system devices file, listing devices that LVM should use.
+        # This should not be used to select a non-system devices file.
+        # The --devicesfile option is intended for alternative devices files.
+        # This configuration option has an automatic default value.
+        # devicesfile = "system.devices"
+
+        # Configuration option devices/search_for_devnames.
+        # Look outside of the devices file for missing devname entries.
+        # A devname entry is used for a device that does not have a stable
+        # device id, e.g. wwid, so the unstable device name is used as
+        # the device id. After reboot, or if the device is reattached,
+        # the device name may change, in which case lvm will not find
+        # the expected PV on the device listed in the devices file.
+        # This setting controls whether lvm will search other devices,
+        # outside the devices file, to look for the missing PV on a
+        # renamed device. If "none", lvm will not look at other devices,
+        # and the PV may appear to be missing. If "auto", lvm will look
+        # at other devices, but only those that are likely to have the PV.
+        # If "all", lvm will look at all devices on the system.
+        # This configuration option has an automatic default value.
+        # search_for_devnames = "auto"
+
+        # Configuration option devices/filter.
+        # Limit the block devices that are used by LVM commands.
+        # This is a list of regular expressions used to accept or reject block
+        # device path names. Each regex is delimited by a vertical bar '|'
+        # (or any character) and is preceded by 'a' to accept the path, or
+        # by 'r' to reject the path. The first regex in the list to match the
+        # path is used, producing the 'a' or 'r' result for the device.
+        # When multiple path names exist for a block device, if any path name
+        # matches an 'a' pattern before an 'r' pattern, then the device is
+        # accepted. If all the path names match an 'r' pattern first, then the
+        # device is rejected. Unmatching path names do not affect the accept
+        # or reject decision. If no path names for a device match a pattern,
+        # then the device is accepted. Be careful mixing 'a' and 'r' patterns,
+        # as the combination might produce unexpected results (test changes.)
+        # Run vgscan after changing the filter to regenerate the cache.
+        #
+        # Example
+        # Accept every block device:
+        # filter = [ "a|.*|" ]
+        # Reject the cdrom drive:
+        # filter = [ "r|/dev/cdrom|" ]
+        # Work with just loopback devices, e.g. for testing:
+        # filter = [ "a|loop|", "r|.*|" ]
+        # Accept all loop devices and ide drives except hdc:
+        # filter = [ "a|loop|", "r|/dev/hdc|", "a|/dev/ide|", "r|.*|" ]
+        # Use anchors to be very specific:
+        # filter = [ "a|^/dev/hda8$|", "r|.*|" ]
+        #
+        # This configuration option has an automatic default value.
+        # filter = [ "a|.*|" ]
+
+        # Configuration option devices/global_filter.
+        # Limit the block devices that are used by LVM system components.
+        # Because devices/filter may be overridden from the command line, it is
+        # not suitable for system-wide device filtering, e.g. udev.
+        # Use global_filter to hide devices from these LVM system components.
+        # The syntax is the same as devices/filter. Devices rejected by
+        # global_filter are not opened by LVM.
+        # This configuration option has an automatic default value.
+        # global_filter = [ "a|.*|" ]
+
+        # Configuration option devices/types.
+        # List of additional acceptable block device types.
+        # These are of device type names from /proc/devices, followed by the
+        # maximum number of partitions.
+        #
+        # Example
+        # types = [ "fd", 16 ]
+        #
+        # This configuration option is advanced.
+        # This configuration option does not have a default value defined.
+
+        # Configuration option devices/sysfs_scan.
+        # Restrict device scanning to block devices appearing in sysfs.
+        # This is a quick way of filtering out block devices that are not
+        # present on the system. sysfs must be part of the kernel and mounted.)
+        sysfs_scan = 1
+
+        # Configuration option devices/scan_lvs.
+        # Scan LVM LVs for layered PVs, allowing LVs to be used as PVs.
+        # When 1, LVM will detect PVs layered on LVs, and caution must be
+        # taken to avoid a host accessing a layered VG that may not belong
+        # to it, e.g. from a guest image. This generally requires excluding
+        # the LVs with device filters. Also, when this setting is enabled,
+        # every LVM command will scan every active LV on the system (unless
+        # filtered), which can cause performance problems on systems with
+        # many active LVs. When this setting is 0, LVM will not detect or
+        # use PVs that exist on LVs, and will not allow a PV to be created on
+        # an LV. The LVs are ignored using a built in device filter that
+        # identifies and excludes LVs.
+        scan_lvs = 0
+
+        # Configuration option devices/multipath_component_detection.
+        # Ignore devices that are components of DM multipath devices.
+        multipath_component_detection = 1
+
+        # Configuration option devices/md_component_detection.
+        # Enable detection and exclusion of MD component devices.
+        # An MD component device is a block device that MD uses as part
+        # of a software RAID virtual device. When an LVM PV is created
+        # on an MD device, LVM must only use the top level MD device as
+        # the PV, and should ignore the underlying component devices.
+        # In cases where the MD superblock is located at the end of the
+        # component devices, it is more difficult for LVM to consistently
+        # identify an MD component, see the md_component_checks setting.
+        md_component_detection = 1
+
+        # Configuration option devices/md_component_checks.
+        # The checks LVM should use to detect MD component devices.
+        # MD component devices are block devices used by MD software RAID.
+        #
+        # Accepted values:
+        #   auto
+        #     LVM will skip scanning the end of devices when it has other
+        #     indications that the device is not an MD component.
+        #   start
+        #     LVM will only scan the start of devices for MD superblocks.
+        #     This does not incur extra I/O by LVM.
+        #   full
+        #     LVM will scan the start and end of devices for MD superblocks.
+        #     This requires an extra read at the end of devices.
+        #
+        # This configuration option has an automatic default value.
+        # md_component_checks = "auto"
+
+        # Configuration option devices/fw_raid_component_detection.
+        # Ignore devices that are components of firmware RAID devices.
+        # LVM must use an external_device_info_source other than none for this
+        # detection to execute.
+        fw_raid_component_detection = 0
+
+        # Configuration option devices/md_chunk_alignment.
+        # Align the start of a PV data area with md device's stripe-width.
+        # This applies if a PV is placed directly on an md device.
+        # default_data_alignment will be overridden if it is not aligned
+        # with the value detected for this setting.
+        # This setting is overridden by data_alignment_detection,
+        # data_alignment, and the --dataalignment option.
+        md_chunk_alignment = 1
+
+        # Configuration option devices/default_data_alignment.
+        # Align the start of a PV data area with this number of MiB.
+        # Set to 1 for 1MiB, 2 for 2MiB, etc. Set to 0 to disable.
+        # This setting is overridden by data_alignment and the --dataalignment
+        # option.
+        # This configuration option has an automatic default value.
+        # default_data_alignment = 1
+
+        # Configuration option devices/data_alignment_detection.
+        # Align the start of a PV data area with sysfs io properties.
+        # The start of a PV data area will be a multiple of minimum_io_size or
+        # optimal_io_size exposed in sysfs. minimum_io_size is the smallest
+        # request the device can perform without incurring a read-modify-write
+        # penalty, e.g. MD chunk size. optimal_io_size is the device's
+        # preferred unit of receiving I/O, e.g. MD stripe width.
+        # minimum_io_size is used if optimal_io_size is undefined (0).
+        # If md_chunk_alignment is enabled, that detects the optimal_io_size.
+        # default_data_alignment and md_chunk_alignment will be overridden
+        # if they are not aligned with the value detected for this setting.
+        # This setting is overridden by data_alignment and the --dataalignment
+        # option.
+        data_alignment_detection = 1
+
+        # Configuration option devices/data_alignment.
+        # Align the start of a PV data area with this number of KiB.
+        # When non-zero, this setting overrides default_data_alignment.
+        # Set to 0 to disable, in which case default_data_alignment
+        # is used to align the first PE in units of MiB.
+        # This setting is overridden by the --dataalignment option.
+        data_alignment = 0
+
+        # Configuration option devices/data_alignment_offset_detection.
+        # Shift the start of an aligned PV data area based on sysfs information.
+        # After a PV data area is aligned, it will be shifted by the
+        # alignment_offset exposed in sysfs. This offset is often 0, but may
+        # be non-zero. Certain 4KiB sector drives that compensate for windows
+        # partitioning will have an alignment_offset of 3584 bytes (sector 7
+        # is the lowest aligned logical block, the 4KiB sectors start at
+        # LBA -1, and consequently sector 63 is aligned on a 4KiB boundary).
+        # This setting is overridden by the --dataalignmentoffset option.
+        data_alignment_offset_detection = 1
+
+        # Configuration option devices/ignore_suspended_devices.
+        # Ignore DM devices that have I/O suspended while scanning devices.
+        # Otherwise, LVM waits for a suspended device to become accessible.
+        # This should only be needed in recovery situations.
+        ignore_suspended_devices = 0
+
+        # Configuration option devices/ignore_lvm_mirrors.
+        # Do not scan 'mirror' LVs to avoid possible deadlocks.
+        # This avoids possible deadlocks when using the 'mirror' segment type.
+        # This setting determines whether LVs using the 'mirror' segment type
+        # are scanned for LVM labels. This affects the ability of mirrors to
+        # be used as physical volumes. If this setting is enabled, it is
+        # impossible to create VGs on top of mirror LVs, i.e. to stack VGs on
+        # mirror LVs. If this setting is disabled, allowing mirror LVs to be
+        # scanned, it may cause LVM processes and I/O to the mirror to become
+        # blocked. This is due to the way that the mirror segment type handles
+        # failures. In order for the hang to occur, an LVM command must be run
+        # just after a failure and before the automatic LVM repair process
+        # takes place, or there must be failures in multiple mirrors in the
+        # same VG at the same time with write failures occurring moments before
+        # a scan of the mirror's labels. The 'mirror' scanning problems do not
+        # apply to LVM RAID types like 'raid1' which handle failures in a
+        # different way, making them a better choice for VG stacking.
+        ignore_lvm_mirrors = 1
+
+        # Configuration option devices/require_restorefile_with_uuid.
+        # Allow use of pvcreate --uuid without requiring --restorefile.
+        require_restorefile_with_uuid = 1
+
+        # Configuration option devices/pv_min_size.
+        # Minimum size in KiB of block devices which can be used as PVs.
+        # In a clustered environment all nodes must use the same value.
+        # Any value smaller than 512KiB is ignored. The previous built-in
+        # value was 512.
+        pv_min_size = 2048
+
+        # Configuration option devices/issue_discards.
+        # Issue discards to PVs that are no longer used by an LV.
+        # Discards are sent to an LV's underlying physical volumes when the LV
+        # is no longer using the physical volumes' space, e.g. lvremove,
+        # lvreduce. Discards inform the storage that a region is no longer
+        # used. Storage that supports discards advertise the protocol-specific
+        # way discards should be issued by the kernel (TRIM, UNMAP, or
+        # WRITE SAME with UNMAP bit set). Not all storage will support or
+        # benefit from discards, but SSDs and thinly provisioned LUNs
+        # generally do. If enabled, discards will only be issued if both the
+        # storage and kernel provide support.
+        issue_discards = 0
+
+        # Configuration option devices/allow_changes_with_duplicate_pvs.
+        # Allow VG modification while a PV appears on multiple devices.
+        # When a PV appears on multiple devices, LVM attempts to choose the
+        # best device to use for the PV. If the devices represent the same
+        # underlying storage, the choice has minimal consequence. If the
+        # devices represent different underlying storage, the wrong choice
+        # can result in data loss if the VG is modified. Disabling this
+        # setting is the safest option because it prevents modifying a VG
+        # or activating LVs in it while a PV appears on multiple devices.
+        # Enabling this setting allows the VG to be used as usual even with
+        # uncertain devices.
+        allow_changes_with_duplicate_pvs = 0
+
+        # Configuration option devices/allow_mixed_block_sizes.
+        # Allow PVs in the same VG with different logical block sizes.
+        # When allowed, the user is responsible to ensure that an LV is
+        # using PVs with matching block sizes when necessary.
+        allow_mixed_block_sizes = 0
+}
+
+# Configuration section global.
+# Miscellaneous global LVM settings.
+global {
+
+        # Configuration option global/use_lvmlockd.
+        # Use lvmlockd for locking among hosts using LVM on shared storage.
+        use_lvmlockd = 0
+
+        # Configuration option global/system_id_source.
+        system_id_source = "none"
+}
+
+# Configuration section activation.
+activation {
+        udev_sync = 1
+        udev_rules = 1
+        retry_deactivation = 1
+        missing_stripe_filler = "error"
+        raid_region_size = 2048
+        activation_mode = "degraded"
+}

--- a/zstacklib/zstacklib/test/lvm/test_config_lvm_filter.py
+++ b/zstacklib/zstacklib/test/lvm/test_config_lvm_filter.py
@@ -1,0 +1,307 @@
+import os
+import re
+import shutil
+import tempfile
+import unittest
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+from zstacklib.utils import lvm
+from zstacklib.utils import bash
+from zstacklib.utils import linux
+
+
+DEFAULT_LVM_CONF_FRAGMENT = """\
+# This is a default lvm.conf fragment.
+
+# Configuration option devices/filter.
+# Limit the block devices that are used by LVM commands.
+# This is a list of regular expressions used to accept or reject block
+# device path names. Each regex is delimited by a vertical bar '|'
+# (or any character) and is preceded by 'a' to accept the path, or
+# by 'r' to reject the path. The first regex in the list to match the
+# path is used, producing the 'a' or 'r' result for the device.
+# Example:
+# filter = [ "a|.*|" ]
+
+# Configuration option devices/global_filter.
+# Limit the block devices that are used by LVM system components.
+# Example:
+# global_filter = [ "a|.*|" ]
+
+devices {
+    dir = "/dev"
+    scan = [ "/dev" ]
+}
+"""
+
+CONF_WITH_ACTIVE_FILTER = """\
+# leading comment mentioning filter
+devices {
+    dir = "/dev"
+    filter = [ "a|.*|", "r|/dev/cdrom|" ]
+    global_filter = [ "a|.*|" ]
+}
+# trailing comment about filter and global_filter
+"""
+
+
+def _count_active_filter_lines(text, key):
+    pat = re.compile(r'^\s*%s(?:\s|=)' % re.escape(key))
+    n = 0
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        if pat.match(line):
+            n += 1
+    return n
+
+
+class TestConfigLvmFilter(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="lvmconf-")
+        self._orig_lvm_path = lvm.LVM_CONFIG_PATH
+        lvm.LVM_CONFIG_PATH = self.tmpdir
+
+        self._orig_bash_o = bash.bash_o
+        bash.bash_o = mock.Mock(return_value="")
+
+    def tearDown(self):
+        lvm.LVM_CONFIG_PATH = self._orig_lvm_path
+        bash.bash_o = self._orig_bash_o
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write(self, name, content):
+        path = os.path.join(self.tmpdir, name)
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+    def _read(self, name):
+        with open(os.path.join(self.tmpdir, name)) as f:
+            return f.read()
+
+    def test_preserve_disks_does_not_touch_comments(self):
+        self._write("lvm.conf", DEFAULT_LVM_CONF_FRAGMENT)
+        self._write("lvmlocal.conf", DEFAULT_LVM_CONF_FRAGMENT)
+
+        with mock.patch.object(linux, "sync_file"):
+            lvm.config_lvm_filter(
+                ["lvm.conf", "lvmlocal.conf"],
+                preserve_disks={"/dev/sda", "/dev/nvme0n1"},
+            )
+
+        for name in ("lvm.conf", "lvmlocal.conf"):
+            new = self._read(name)
+            self.assertEqual(1, _count_active_filter_lines(new, "filter"),
+                             "unexpected active filter lines in %s:\n%s" % (name, new))
+            self.assertEqual(1, _count_active_filter_lines(new, "global_filter"))
+            for marker in (
+                "# Configuration option devices/filter.",
+                "# Configuration option devices/global_filter.",
+                "# Example:",
+                '# filter = [ "a|.*|" ]',
+                '# global_filter = [ "a|.*|" ]',
+            ):
+                self.assertIn(marker, new, "lost comment %r in %s" % (marker, name))
+            self.assertIn('"a|^/dev/sda$|"', new)
+            self.assertIn('"a|^/dev/nvme0n1$|"', new)
+            self.assertIn('"r|.*|"', new)
+
+    def test_replaces_existing_active_filter_only(self):
+        self._write("lvm.conf", CONF_WITH_ACTIVE_FILTER)
+
+        with mock.patch.object(linux, "sync_file"):
+            lvm.config_lvm_filter(["lvm.conf"], preserve_disks={"/dev/sda"})
+
+        new = self._read("lvm.conf")
+        self.assertEqual(1, _count_active_filter_lines(new, "filter"))
+        self.assertEqual(1, _count_active_filter_lines(new, "global_filter"))
+        self.assertIn('"a|^/dev/sda$|"', new)
+        self.assertIn("# leading comment mentioning filter", new)
+        self.assertIn("# trailing comment about filter and global_filter", new)
+
+    def test_default_branch_appends_filter_only(self):
+        self._write("lvm.conf", DEFAULT_LVM_CONF_FRAGMENT)
+        bash.bash_o = mock.Mock(return_value="vg1\nvg2\n")
+
+        with mock.patch.object(linux, "sync_file"):
+            lvm.config_lvm_filter(["lvm.conf"], no_drbd=True)
+
+        new = self._read("lvm.conf")
+        self.assertEqual(1, _count_active_filter_lines(new, "filter"))
+        self.assertEqual(0, _count_active_filter_lines(new, "global_filter"))
+        self.assertIn('"r|/dev/cdrom|"', new)
+        self.assertIn('"r|/dev/mapper/vg1.*|"', new)
+        self.assertIn('"r|/dev/mapper/vg2.*|"', new)
+        self.assertIn('"r|/dev/drbd.*|"', new)
+        self.assertIn("# Configuration option devices/filter.", new)
+
+    def test_skip_missing_file(self):
+        self._write("lvm.conf", DEFAULT_LVM_CONF_FRAGMENT)
+
+        with mock.patch.object(linux, "sync_file"):
+            lvm.config_lvm_filter(
+                ["lvm.conf", "lvmlocal.conf"],
+                preserve_disks={"/dev/sda"},
+            )
+
+        self.assertEqual(1, _count_active_filter_lines(self._read("lvm.conf"), "filter"))
+        self.assertFalse(os.path.exists(os.path.join(self.tmpdir, "lvmlocal.conf")))
+
+    def test_idempotent_on_second_run(self):
+        self._write("lvm.conf", DEFAULT_LVM_CONF_FRAGMENT)
+
+        with mock.patch.object(linux, "sync_file"):
+            lvm.config_lvm_filter(["lvm.conf"], preserve_disks={"/dev/sda"})
+            after_first = self._read("lvm.conf")
+            lvm.config_lvm_filter(["lvm.conf"], preserve_disks={"/dev/sda"})
+            after_second = self._read("lvm.conf")
+
+        self.assertEqual(after_first, after_second)
+        self.assertEqual(1, _count_active_filter_lines(after_second, "filter"))
+        self.assertEqual(1, _count_active_filter_lines(after_second, "global_filter"))
+
+    def test_dedup_existing_duplicate_filter_lines(self):
+        corrupted = (
+            DEFAULT_LVM_CONF_FRAGMENT
+            + 'filter = [ "a|.*|" ]\n'
+            + 'filter = [ "a|.*|" ]\n'
+            + 'global_filter = [ "a|.*|" ]\n'
+            + 'global_filter = [ "a|.*|" ]\n'
+        )
+        self._write("lvm.conf", corrupted)
+
+        with mock.patch.object(linux, "sync_file"):
+            lvm.config_lvm_filter(["lvm.conf"], preserve_disks={"/dev/sda"})
+
+        new = self._read("lvm.conf")
+        self.assertEqual(1, _count_active_filter_lines(new, "filter"))
+        self.assertEqual(1, _count_active_filter_lines(new, "global_filter"))
+
+    def test_multiline_filter_value_consumed(self):
+        multi = (
+            "# header\n"
+            "filter = [\n"
+            '    "a|.*|",\n'
+            '    "r|/dev/cdrom|"\n'
+            "]\n"
+            'other = "x"\n'
+            "global_filter = [\n"
+            '    "a|.*|"\n'
+            "]\n"
+            'trailer = "y"\n'
+        )
+        self._write("lvm.conf", multi)
+
+        with mock.patch.object(linux, "sync_file"):
+            lvm.config_lvm_filter(["lvm.conf"], preserve_disks={"/dev/sda"})
+
+        new = self._read("lvm.conf")
+        self.assertEqual(1, _count_active_filter_lines(new, "filter"))
+        self.assertEqual(1, _count_active_filter_lines(new, "global_filter"))
+        self.assertNotIn('"r|/dev/cdrom|"', new)
+        self.assertNotIn("    \"a|", new)
+        self.assertIn('other = "x"\n', new)
+        self.assertIn('trailer = "y"\n', new)
+        self.assertEqual(new.count('['), new.count(']'),
+                         "unbalanced brackets in:\n%s" % new)
+
+    def test_near_name_keys_not_matched(self):
+        near = (
+            "filter_a = 1\n"
+            "filterX = 2\n"
+            "globalfilter = 3\n"
+            'filter_types = "abc"\n'
+        )
+        self._write("lvm.conf", near)
+
+        with mock.patch.object(linux, "sync_file"):
+            lvm.config_lvm_filter(["lvm.conf"], preserve_disks={"/dev/sda"})
+
+        new = self._read("lvm.conf")
+        self.assertIn("filter_a = 1\n", new)
+        self.assertIn("filterX = 2\n", new)
+        self.assertIn("globalfilter = 3\n", new)
+        self.assertIn('filter_types = "abc"\n', new)
+        self.assertEqual(1, _count_active_filter_lines(new, "filter"))
+        self.assertEqual(1, _count_active_filter_lines(new, "global_filter"))
+
+    def test_lvmconfig_default_style_no_spaces(self):
+        text = (
+            "# expanded\n"
+            'filter=["a|.*|"]\n'
+            'global_filter=["a|.*|"]\n'
+            "issue_discards=0\n"
+        )
+        self._write("lvm.conf", text)
+
+        with mock.patch.object(linux, "sync_file"):
+            lvm.config_lvm_filter(["lvm.conf"], preserve_disks={"/dev/sda"})
+
+        new = self._read("lvm.conf")
+        self.assertEqual(1, _count_active_filter_lines(new, "filter"))
+        self.assertEqual(1, _count_active_filter_lines(new, "global_filter"))
+        self.assertIn("issue_discards=0\n", new)
+        self.assertIn('"a|^/dev/sda$|"', new)
+
+    def test_real_centos_default_lvm_conf_fixture(self):
+        fixture_path = os.path.join(os.path.dirname(__file__),
+                                    "centos_default_lvm.conf")
+        with open(fixture_path) as f:
+            original = f.read()
+        self._write("lvm.conf", original)
+
+        preserve = {"/dev/sda", "/dev/nvme0n1", "/dev/nvme0n2",
+                    "/dev/nvme0n3", "/dev/vda1"}
+        with mock.patch.object(linux, "sync_file"):
+            lvm.config_lvm_filter(["lvm.conf"], preserve_disks=preserve)
+
+        new = self._read("lvm.conf")
+
+        self.assertEqual(1, _count_active_filter_lines(new, "filter"),
+                         "expected exactly one active filter line")
+        self.assertEqual(1, _count_active_filter_lines(new, "global_filter"),
+                         "expected exactly one active global_filter line")
+
+        for disk in preserve:
+            self.assertIn('"a|^%s$|"' % disk, new,
+                          "missing accept entry for %s" % disk)
+        self.assertIn('"r|.*|"', new)
+
+        for raw in original.splitlines():
+            if raw.lstrip().startswith("#") and ("filter" in raw or "global_filter" in raw):
+                self.assertIn(raw, new,
+                              "lost stock comment line: %r" % raw)
+
+        for noisy in ("# Example:", "# filter = [", "# global_filter = ["):
+            self.assertTrue(any(noisy in l and l.lstrip().startswith("#")
+                                for l in new.splitlines()),
+                            "fixture sanity: %r should still appear as comment" % noisy)
+
+        self.assertEqual(new.count('['), new.count(']'),
+                         "unbalanced brackets after filter rewrite")
+
+        with mock.patch.object(linux, "sync_file"):
+            lvm.config_lvm_filter(["lvm.conf"], preserve_disks=preserve)
+        self.assertEqual(new, self._read("lvm.conf"),
+                         "config_lvm_filter is not idempotent on real fixture")
+
+    def test_no_trailing_newline(self):
+        self._write("lvm.conf", "foo = 1")
+
+        with mock.patch.object(linux, "sync_file"):
+            lvm.config_lvm_filter(["lvm.conf"], preserve_disks={"/dev/sda"})
+
+        new = self._read("lvm.conf")
+        self.assertIn("foo = 1\n", new)
+        self.assertNotIn("1filter", new)
+        self.assertEqual(1, _count_active_filter_lines(new, "filter"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -649,36 +649,130 @@ def config_lvm_by_sed(keyword, entry, files):
     logger.debug(bash.bash_o("lvmconfig --type diff"))
 
 
+# Match active "filter = [...]" / "global_filter = [...]" lines.
+# Reject any line whose first non-whitespace char is '#' (comments).
+# Anchored to start-of-line; key name must be followed by whitespace or '='
+# so that hypothetical neighbours like "filter_a" cannot be matched.
+_ACTIVE_FILTER_RE = re.compile(r'^\s*filter(?:\s|=)')
+_ACTIVE_GLOBAL_FILTER_RE = re.compile(r'^\s*global_filter(?:\s|=)')
+_COMMENT_RE = re.compile(r'^\s*#')
+
+
+def _build_filter_value(preserve_disks=None, no_drbd=False, vgs=None):
+    """Build the bracketed filter value string, e.g. '["a|^/dev/sda$|", "r|.*|"]'.
+
+    Caller decides whether to put it on a 'filter = ...' or 'global_filter = ...' line.
+    """
+    if preserve_disks is not None and len(preserve_disks) != 0:
+        accept = ['"a|^%s$|"' % disk for disk in preserve_disks]
+        return '[' + ', '.join(accept + ['"r|.*|"']) + ']'
+
+    rejects = ['"r|/dev/cdrom|"']
+    for vg in (vgs or []):
+        rejects.append('"r|/dev/mapper/%s.*|"' % vg.strip())
+    if no_drbd:
+        rejects.append('"r|/dev/drbd.*|"')
+    return '[' + ', '.join(rejects) + ']'
+
+
+def _apply_filter_on_text(text, filter_value, write_global_filter):
+    """Surgical replacement on a lvm.conf-style text.
+
+    - Replaces only the FIRST active 'filter = ...' / 'global_filter = ...' line
+      (anchored ^, skips comments). Subsequent duplicates are dropped entirely.
+    - If the existing active value spans multiple lines (e.g. "filter = [\n  ...\n ]"),
+      ALL continuation lines are consumed by tracking bracket depth so no orphan
+      lines like "]" are left behind.
+    - If no active line exists, the directive is appended at end-of-file. Comments
+      (any line whose first non-whitespace char is '#') are preserved verbatim,
+      including lines that happen to mention the word 'filter' inside descriptions.
+    - Adjacent keys whose name only PREFIXES 'filter' (e.g. 'filter_a') are NOT
+      matched, because the regex requires '=' or whitespace immediately after the
+      key name.
+    """
+    lines = text.splitlines(True)  # keep line endings (\n or \r\n)
+    out_lines = []
+    filter_written = False
+    global_written = False
+
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+
+        if _COMMENT_RE.match(line):
+            out_lines.append(line)
+            i += 1
+            continue
+
+        m_filter = _ACTIVE_FILTER_RE.match(line)
+        m_global = _ACTIVE_GLOBAL_FILTER_RE.match(line) if write_global_filter else None
+
+        if m_filter or m_global:
+            # Consume continuation lines until square-bracket depth returns to 0.
+            depth = line.count('[') - line.count(']')
+            j = i + 1
+            while depth > 0 and j < n:
+                depth += lines[j].count('[') - lines[j].count(']')
+                j += 1
+
+            if m_filter:
+                if not filter_written:
+                    out_lines.append("filter = %s\n" % filter_value)
+                    filter_written = True
+                # else: drop duplicate (and its continuation lines)
+            else:
+                if not global_written:
+                    out_lines.append("global_filter = %s\n" % filter_value)
+                    global_written = True
+                # else: drop duplicate
+
+            i = j
+            continue
+
+        out_lines.append(line)
+        i += 1
+
+    if not filter_written:
+        if out_lines and not out_lines[-1].endswith("\n"):
+            out_lines.append("\n")
+        out_lines.append("filter = %s\n" % filter_value)
+    if write_global_filter and not global_written:
+        out_lines.append("global_filter = %s\n" % filter_value)
+
+    return "".join(out_lines)
+
+
 @bash.in_bash
 def config_lvm_filter(files, no_drbd=False, preserve_disks=None):
     # type: (list[str], bool, set[str]) -> object
+    """Configure devices/filter (and devices/global_filter when preserving disks) in
+    the given lvm config files (relative to LVM_CONFIG_PATH).
+
+    Replaces ONLY active 'filter = ...' / 'global_filter = ...' lines. Comments and
+    every other directive are preserved. Appends the directive if the file has none.
+    """
     if not os.path.exists(LVM_CONFIG_PATH):
         raise Exception("can not find lvm config path: %s, config lvm failed" % LVM_CONFIG_PATH)
 
     if preserve_disks is not None and len(preserve_disks) != 0:
-        filter_str = 'filter=['
-        for disk in preserve_disks:
-            filter_str += '"a|^%s$|", ' % disk.replace("/", "\\/")
-        filter_str += '"r\/.*\/"]'
-
-        for f in files:
-            bash.bash_r("sed -i 's/.*\\b%s.*/%s/g' %s/%s" % ("filter", filter_str, LVM_CONFIG_PATH, f))
-            bash.bash_r("sed -i 's/.*\\b%s.*/global_%s/g' %s/%s" % ("global_filter", filter_str, LVM_CONFIG_PATH, f))
-            linux.sync_file(os.path.join(LVM_CONFIG_PATH, f))
-        return
-
-    filter_str = 'filter=["r|\\/dev\\/cdrom|"'
-    vgs = bash.bash_o("vgs --nolocking -t -oname --noheading").splitlines()
-    for vg in vgs:
-        filter_str += ', "r\\/dev\\/mapper\\/%s.*\\/"' % vg.strip()
-    if no_drbd:
-        filter_str += ', "r\\/dev\\/drbd.*\\/"'
-
-    filter_str += ']'
+        filter_value = _build_filter_value(preserve_disks=preserve_disks)
+        write_global_filter = True
+    else:
+        vgs = bash.bash_o("vgs --nolocking -t -oname --noheading").splitlines()
+        filter_value = _build_filter_value(no_drbd=no_drbd, vgs=vgs)
+        write_global_filter = False
 
     for f in files:
-        bash.bash_r("sed -i 's/.*\\b%s.*/%s/g' %s/%s" % ("filter", filter_str, LVM_CONFIG_PATH, f))
-        linux.sync_file(os.path.join(LVM_CONFIG_PATH, f))
+        path = os.path.join(LVM_CONFIG_PATH, f)
+        if not os.path.exists(path):
+            logger.warn("config_lvm_filter: skip %s, file does not exist" % path)
+            continue
+        original = linux.read_file(path) or ""
+        updated = _apply_filter_on_text(original, filter_value, write_global_filter)
+        if updated != original:
+            linux.write_file(path, updated, create_if_not_exist=True)
+        linux.sync_file(path)
 
 
 def modify_sanlock_config(key, value):
@@ -2837,7 +2931,7 @@ def get_vgs_info(tag):
                 logger.warn("resolve dm name failed for mpath device %s: %s" %
                             (bd.multipathPath, linux.get_exception_stacktrace()))
 
-    r, o, e = bash.bash_roe("vgs --nolocking -t -o vg_name,pv_count,pv_name,tags --noheadings")
+    r, o, e = bash.bash_roe("vgs --nolocking --shared --foreign -t -o vg_name,pv_count,pv_name,tags --noheadings")
     if r != 0:
         raise Exception("get vgs info failed, error: %s" % e)
 


### PR DESCRIPTION
Move filter_lvm_pv_wwids() into zstacklib.utils.lvm so that the
helper lives next to the rest of the LVM utilities, and wire it
into the four dispatch consumers (do_connect, add_disk,
config_filter, do_takeover) so that the unmanaged LUN candidates
carried in the new cmd.candidateUnmanagedLunWwids field are
probed with blkid and only those that actually carry an
LVM2_member header are merged with cmd.allSharedBlockUuids when
building the lvm.conf filter allow-list.

This fixes pre-existing VG visibility on a host newly attached to
an iSCSI server while keeping unrelated unmanaged LUNs (which may
number in the hundreds) out of the filter.

Backwards compatible: getattr() guards against older Java MNs
that do not yet send the candidate field.

Test: covered by zstacklib/test/test_filter_lvm_pv_wwids.py

Resolves: ZSV-11734

Change-Id: I7a77677273656b776a6f6366637a7a7278787575

sync from gitlab !6993