### PR TITLE
<fix>[sharedblock]: bypass host lvm filter on read-only VG discover

### DIFF
--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -2837,7 +2837,12 @@ def get_vgs_info(tag):
                 logger.warn("resolve dm name failed for mpath device %s: %s" %
                             (bd.multipathPath, linux.get_exception_stacktrace()))
 
-    r, o, e = bash.bash_roe("vgs --nolocking -t -o vg_name,pv_count,pv_name,tags --noheadings")
+    accept_all_config = (
+        '--config \'devices/filter=["a|.*|"] devices/global_filter=["a|.*|"]\''
+    )
+    r, o, e = bash.bash_roe(
+        "timeout -s SIGKILL 120 vgs --nolocking --shared --foreign -t %s "
+        "-o vg_name,pv_count,pv_name,tags --noheadings" % accept_all_config)
     if r != 0:
         raise Exception("get vgs info failed, error: %s" % e)
 


### PR DESCRIPTION
Background. ZSV-11734: a customer attaches an iSCSI server to a
cluster on platform B; the LUNs on that server were created and
later released by another platform, so they still carry LVM2_member
metadata for VGs created elsewhere. On a host whose
/etc/lvm/lvm.conf has the distro-default narrow filter (e.g. only
/dev/vda*, /dev/sda accepted, the rest rejected), pvs/vgs cannot
see those LUNs even though lsblk does. The discover path
APIDiscoverStrangePrimaryStorageMsg therefore returns nothing.

Fix: lvm.get_vgs_info() drives the discover path. Pass an inline
LVM --config that overrides devices/filter and devices/global_filter
to accept-all for this single read-only invocation:

    vgs --nolocking --shared --foreign -t \
        --config 'devices/filter=["a|.*|"] devices/global_filter=["a|.*|"]' \
        -o vg_name,pv_count,pv_name,tags --noheadings

-t keeps it test mode (read-only), so no metadata is touched and no
host config is persisted. --shared --foreign widen visibility for
shared/foreign VGs created on another platform. Tag filter on the
sblk init tag is unchanged, so VGs that are not sblk-created (root
VG, customer's own VGs without our tag) are still skipped.

Resolves: ZSV-11734

Change-Id: I72637270757069726b6f736b6d766a6362636277

sync from gitlab !6996