### PR TITLE
<feature>[kvmagent]: support VM artifact virtiofs views

### DIFF
--- a/kvmagent/kvmagent/plugins/model_center_plugin.py
+++ b/kvmagent/kvmagent/plugins/model_center_plugin.py
@@ -1,0 +1,130 @@
+from kvmagent import kvmagent
+from kvmagent.plugins import vm_artifact
+from kvmagent.plugins import vm_plugin
+from zstacklib.utils import http
+from zstacklib.utils import jsonobject
+from zstacklib.utils import linux
+from zstacklib.utils import log
+
+logger = log.get_logger(__name__)
+
+
+class MountModelCenterResponse(kvmagent.AgentResponse):
+    def __init__(self):
+        super(MountModelCenterResponse, self).__init__()
+        self.mountPoint = None
+
+
+class SyncVmArtifactViewResponse(kvmagent.AgentResponse):
+    def __init__(self):
+        super(SyncVmArtifactViewResponse, self).__init__()
+        self.viewRoot = None
+        self.artifacts = []
+
+
+class DeleteVmArtifactViewResponse(kvmagent.AgentResponse):
+    def __init__(self):
+        super(DeleteVmArtifactViewResponse, self).__init__()
+        self.viewRoot = None
+
+
+class ModelCenterPlugin(kvmagent.KvmAgent):
+    MODEL_CENTER_MOUNT_PATH = '/modelcenter/mount'
+    VM_ARTIFACT_VIEW_SYNC_PATH = '/vm/artifactview/sync'
+    VM_ARTIFACT_VIEW_DELETE_PATH = '/vm/artifactview/delete'
+    VM_ARTIFACT_VIEW_CLEANUP_PATH = '/vm/artifactview/cleanup'
+    VIRTIOFS_ATTACH_PATH = '/virtiofs/attach'
+    VIRTIOFS_DETACH_PATH = '/virtiofs/detach'
+
+    @kvmagent.replyerror
+    def mount_model_center(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = MountModelCenterResponse()
+
+        mount_point = vm_artifact.get_attr(cmd, 'mountPoint')
+        if not mount_point:
+            mount_point = vm_artifact.model_center_mount_point(cmd.modelCenterUuid)
+        else:
+            mount_point = vm_artifact.ensure_under(mount_point, vm_artifact.MODEL_CENTER_ROOT, 'mountPoint')
+
+        linux.mkdir(mount_point, 0o755)
+        if not linux.is_mounted(path=mount_point):
+            storage_url = vm_artifact.get_attr(cmd, 'storageUrl')
+            if storage_url:
+                linux.mount(storage_url, mount_point,
+                            vm_artifact.get_attr(cmd, 'mountOptions'),
+                            vm_artifact.get_attr(cmd, 'fsType'))
+
+        rsp.mountPoint = mount_point
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def sync_vm_artifact_view(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = SyncVmArtifactViewResponse()
+
+        view_root, specs = vm_artifact.sync_artifact_view(cmd.vmInstanceUuid, vm_artifact.get_attr(cmd, 'artifacts', []))
+        rsp.viewRoot = view_root
+        rsp.artifacts = specs
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def delete_vm_artifact_view(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = DeleteVmArtifactViewResponse()
+
+        root = vm_artifact.vm_view_root(cmd.vmInstanceUuid)
+        relative_path = vm_artifact.get_attr(cmd, 'relativePath')
+        if relative_path:
+            path = vm_artifact.safe_join(root, vm_artifact.validate_relative_path(relative_path, 'relativePath'))
+            vm_artifact.unmount_if_needed(path)
+            vm_artifact.remove_path(path)
+        else:
+            vm_artifact.cleanup_view(cmd.vmInstanceUuid)
+        rsp.viewRoot = root
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def cleanup_vm_artifact_view(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = DeleteVmArtifactViewResponse()
+
+        rsp.viewRoot = vm_artifact.cleanup_view(cmd.vmInstanceUuid)
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def attach_virtiofs(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = kvmagent.AgentResponse()
+
+        vm_uuid = vm_artifact.get_attr(cmd, 'vmInstanceUuid') or vm_artifact.get_attr(cmd, 'vmUuid')
+        vm = vm_plugin.get_vm_by_uuid(vm_uuid)
+        vm_artifact.attach_virtiofs(vm.domain, vm_uuid, cmd.tag,
+                                    vm_artifact.get_attr(cmd, 'sourcePath'),
+                                    vm_artifact.get_attr(cmd, 'cache'),
+                                    vm_artifact.get_attr(cmd, 'queue'))
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def detach_virtiofs(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = kvmagent.AgentResponse()
+
+        vm_uuid = vm_artifact.get_attr(cmd, 'vmInstanceUuid') or vm_artifact.get_attr(cmd, 'vmUuid')
+        vm = vm_plugin.get_vm_by_uuid(vm_uuid)
+        detached = vm_artifact.detach_virtiofs(vm.domain, vm.domain_xmlobject, cmd.tag)
+        if not detached:
+            logger.debug('virtiofs device[tag:%s] is not attached to vm[uuid:%s], skip detach' % (cmd.tag, vm_uuid))
+        return jsonobject.dumps(rsp)
+
+    def start(self):
+        http_server = kvmagent.get_http_server()
+        http_server.register_async_uri(self.MODEL_CENTER_MOUNT_PATH, self.mount_model_center)
+        http_server.register_async_uri(self.VM_ARTIFACT_VIEW_SYNC_PATH, self.sync_vm_artifact_view)
+        http_server.register_async_uri(self.VM_ARTIFACT_VIEW_DELETE_PATH, self.delete_vm_artifact_view)
+        http_server.register_async_uri(self.VM_ARTIFACT_VIEW_CLEANUP_PATH, self.cleanup_vm_artifact_view)
+        http_server.register_async_uri(self.VIRTIOFS_ATTACH_PATH, self.attach_virtiofs)
+        http_server.register_async_uri(self.VIRTIOFS_DETACH_PATH, self.detach_virtiofs)
+
+    def stop(self):
+        pass

--- a/kvmagent/kvmagent/plugins/vm_artifact.py
+++ b/kvmagent/kvmagent/plugins/vm_artifact.py
@@ -1,0 +1,324 @@
+import os
+import re
+import shutil
+import tempfile
+
+try:
+    from shlex import quote as shell_quote
+except ImportError:
+    from pipes import quote as shell_quote
+
+import libvirt
+
+from zstacklib.utils import bash
+from zstacklib.utils import linux
+from zstacklib.utils import log
+
+logger = log.get_logger(__name__)
+
+MODEL_CENTER_ROOT = '/var/lib/zstack/aios/model-centers'
+VM_VIEW_ROOT = '/var/lib/zstack/aios/vm-views'
+
+DEFAULT_VIRTIOFS_CACHE = 'none'
+DEFAULT_VIRTIOFS_QUEUE = 1024
+DEFAULT_VIRTIOFS_BINARY = '/usr/libexec/virtiofsd'
+
+ADDON_VM_ARTIFACT_VIEWS = 'vmArtifactViews'
+
+
+def get_attr(obj, name, default=None):
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    try:
+        if hasattr(obj, 'hasattr') and obj.hasattr(name):
+            return getattr(obj, name)
+    except Exception:
+        pass
+    return getattr(obj, name, default)
+
+
+def get_addon(addons, name, default=None):
+    if addons is None:
+        return default
+    if isinstance(addons, dict):
+        return addons.get(name, default)
+    try:
+        if addons.hasattr(name):
+            return getattr(addons, name)
+    except Exception:
+        pass
+    return default
+
+
+def as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
+def safe_uuid(value, field_name):
+    if not value or not re.match(r'^[A-Za-z0-9][A-Za-z0-9_.-]*$', value):
+        raise Exception('invalid %s: %s' % (field_name, value))
+    return value
+
+
+def sanitize_tag(value):
+    tag = re.sub(r'[^A-Za-z0-9_.-]', '_', str(value or 'artifact'))
+    tag = tag.strip('._-')
+    return tag[:96] if tag else 'artifact'
+
+
+def ensure_under(path, root, field_name):
+    real_root = os.path.realpath(root)
+    real_path = os.path.realpath(path)
+    if real_path != real_root and not real_path.startswith(real_root + os.sep):
+        raise Exception('%s[%s] is outside allowed root[%s]' % (field_name, path, root))
+    return real_path
+
+
+def safe_join(root, *paths):
+    for p in paths:
+        if p is None:
+            continue
+        if os.path.isabs(str(p)):
+            raise Exception('absolute path component is not allowed: %s' % p)
+
+    joined = os.path.join(root, *[str(p) for p in paths if p is not None and str(p) != ''])
+    return ensure_under(joined, root, 'path')
+
+
+def validate_relative_path(path, field_name):
+    if path is None or str(path).strip() == '':
+        raise Exception('%s cannot be empty' % field_name)
+    path = str(path).strip().lstrip('/')
+    if os.path.isabs(path) or path == '..' or path.startswith('../') or '/../' in path or path.endswith('/..'):
+        raise Exception('%s[%s] escapes its root' % (field_name, path))
+    return path
+
+
+def vm_view_root(vm_uuid):
+    return safe_join(VM_VIEW_ROOT, safe_uuid(vm_uuid, 'vmInstanceUuid'))
+
+
+def model_center_mount_point(model_center_uuid):
+    return safe_join(MODEL_CENTER_ROOT, safe_uuid(model_center_uuid, 'modelCenterUuid'))
+
+
+def artifact_source_path(artifact):
+    source_path = get_attr(artifact, 'sourcePath')
+    if source_path:
+        return ensure_under(source_path, MODEL_CENTER_ROOT, 'sourcePath')
+
+    model_center_uuid = get_attr(artifact, 'modelCenterUuid')
+    install_path = validate_relative_path(get_attr(artifact, 'installPath'), 'installPath')
+    return safe_join(model_center_mount_point(model_center_uuid), install_path)
+
+
+def artifact_relative_path(artifact):
+    relative_path = get_attr(artifact, 'relativePath')
+    if relative_path:
+        return validate_relative_path(relative_path, 'relativePath')
+
+    artifact_uuid = get_attr(artifact, 'artifactUuid') or get_attr(artifact, 'uuid') or get_attr(artifact, 'name')
+    return sanitize_tag(artifact_uuid)
+
+
+def make_view_bind_specs(vm_uuid, artifacts):
+    root = vm_view_root(vm_uuid)
+    specs = []
+    for artifact in as_list(artifacts):
+        source = artifact_source_path(artifact)
+        relative = artifact_relative_path(artifact)
+        target = safe_join(root, relative)
+        read_only = get_attr(artifact, 'readOnly', True)
+        specs.append({
+            'sourcePath': source,
+            'targetPath': target,
+            'relativePath': relative,
+            'readOnly': read_only is not False,
+            'artifactUuid': get_attr(artifact, 'artifactUuid') or get_attr(artifact, 'uuid'),
+            'name': get_attr(artifact, 'name'),
+        })
+    return root, specs
+
+
+def _mkdir_for_bind_target(source_path, target_path):
+    parent = os.path.dirname(target_path)
+    linux.mkdir(parent, 0o755)
+    if os.path.isfile(source_path):
+        if not os.path.exists(target_path):
+            open(target_path, 'a').close()
+    else:
+        linux.mkdir(target_path, 0o755)
+
+
+def bind_readonly(source_path, target_path, read_only=True):
+    ensure_under(source_path, MODEL_CENTER_ROOT, 'sourcePath')
+    ensure_under(target_path, VM_VIEW_ROOT, 'targetPath')
+    if not os.path.exists(source_path):
+        raise Exception('sourcePath[%s] does not exist' % source_path)
+
+    _mkdir_for_bind_target(source_path, target_path)
+    if not linux.is_mounted(path=target_path):
+        ret = bash.bash_r('mount --bind %s %s' % (shell_quote(source_path), shell_quote(target_path)))
+        if ret != 0:
+            raise Exception('failed to bind mount %s to %s' % (source_path, target_path))
+
+    if read_only:
+        ret = bash.bash_r('mount -o remount,bind,ro %s' % shell_quote(target_path))
+        if ret != 0:
+            raise Exception('failed to remount %s as readonly bind' % target_path)
+
+
+def _mountinfo_target(line):
+    parts = line.split(' - ', 1)[0].split()
+    return parts[4] if len(parts) > 4 else None
+
+
+def list_mounts_under(root):
+    root = os.path.realpath(root)
+    mounts = []
+    try:
+        with open('/proc/self/mountinfo') as fd:
+            for line in fd:
+                target = _mountinfo_target(line)
+                if target and (target == root or target.startswith(root + os.sep)):
+                    mounts.append(target)
+    except IOError:
+        return []
+    mounts.sort(key=lambda p: len(p), reverse=True)
+    return mounts
+
+
+def unmount_if_needed(path):
+    if linux.is_mounted(path=path):
+        linux.umount(path, is_exception=False)
+
+
+def remove_path(path):
+    ensure_under(path, VM_VIEW_ROOT, 'path')
+    if os.path.isdir(path) and not os.path.islink(path):
+        shutil.rmtree(path, ignore_errors=True)
+    else:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+def cleanup_view(vm_uuid, keep_paths=None):
+    root = vm_view_root(vm_uuid)
+    keep = set([os.path.realpath(p) for p in (keep_paths or [])])
+    def should_keep(path):
+        real_path = os.path.realpath(path)
+        if real_path in keep:
+            return True
+        for keep_path in keep:
+            if keep_path.startswith(real_path + os.sep):
+                return True
+        return False
+
+    if not os.path.exists(root):
+        linux.mkdir(root, 0o755)
+        return root
+
+    for mount in list_mounts_under(root):
+        if not should_keep(mount):
+            unmount_if_needed(mount)
+
+    for name in os.listdir(root):
+        path = os.path.join(root, name)
+        if not should_keep(path):
+            remove_path(path)
+    return root
+
+
+def sync_artifact_view(vm_uuid, artifacts):
+    root, specs = make_view_bind_specs(vm_uuid, artifacts)
+    linux.mkdir(root, 0o755)
+    target_paths = []
+    for spec in specs:
+        bind_readonly(spec['sourcePath'], spec['targetPath'], spec['readOnly'])
+        target_paths.append(spec['targetPath'])
+    cleanup_view(vm_uuid, target_paths)
+    return root, specs
+
+
+def virtiofs_source_path(vm_uuid, source_path=None):
+    root = vm_view_root(vm_uuid)
+    if source_path:
+        return ensure_under(source_path, root, 'sourcePath')
+    return root
+
+
+def build_virtiofs_device_xml(vm_uuid, tag, source_path=None, cache=None, queue=None, binary_path=None, readonly=True):
+    from xml.etree.ElementTree import Element, SubElement, tostring
+
+    source_path = virtiofs_source_path(vm_uuid, source_path)
+    tag = sanitize_tag(tag)
+    cache = cache or DEFAULT_VIRTIOFS_CACHE
+    queue = str(queue or DEFAULT_VIRTIOFS_QUEUE)
+    binary_path = binary_path or DEFAULT_VIRTIOFS_BINARY
+
+    fs = Element('filesystem', {'type': 'mount', 'accessmode': 'passthrough'})
+    SubElement(fs, 'driver', {'type': 'virtiofs', 'queue': queue})
+    binary = SubElement(fs, 'binary', {'path': binary_path})
+    SubElement(binary, 'cache', {'mode': cache})
+    SubElement(fs, 'source', {'dir': source_path})
+    SubElement(fs, 'target', {'dir': tag})
+    if readonly:
+        SubElement(fs, 'readonly')
+    return tostring(fs, encoding='unicode')
+
+
+def add_virtiofs_devices(devices, views, element_factory):
+    for view in as_list(views):
+        vm_uuid = get_attr(view, 'vmInstanceUuid')
+        tag = get_attr(view, 'tag') or get_attr(view, 'mountTag') or get_attr(view, 'artifactUuid') or vm_uuid
+        artifacts = get_attr(view, 'artifacts')
+        if artifacts:
+            source_path, _ = sync_artifact_view(vm_uuid, artifacts)
+        else:
+            source_path = get_attr(view, 'sourcePath') or get_attr(view, 'viewPath')
+        source_path = virtiofs_source_path(vm_uuid, source_path)
+        cache = get_attr(view, 'cache', DEFAULT_VIRTIOFS_CACHE) or DEFAULT_VIRTIOFS_CACHE
+        queue = str(get_attr(view, 'queue', DEFAULT_VIRTIOFS_QUEUE) or DEFAULT_VIRTIOFS_QUEUE)
+        binary_path = get_attr(view, 'binaryPath', DEFAULT_VIRTIOFS_BINARY) or DEFAULT_VIRTIOFS_BINARY
+        readonly = get_attr(view, 'readOnly', True) is not False
+
+        fs = element_factory(devices, 'filesystem', None, {'type': 'mount', 'accessmode': 'passthrough'})
+        element_factory(fs, 'driver', None, {'type': 'virtiofs', 'queue': queue})
+        binary = element_factory(fs, 'binary', None, {'path': binary_path})
+        element_factory(binary, 'cache', None, {'mode': cache})
+        element_factory(fs, 'source', None, {'dir': source_path})
+        element_factory(fs, 'target', None, {'dir': sanitize_tag(tag)})
+        if readonly:
+            element_factory(fs, 'readonly')
+
+
+def attach_virtiofs(domain, vm_uuid, tag, source_path=None, cache=None, queue=None):
+    xml = build_virtiofs_device_xml(vm_uuid, tag, source_path, cache, queue)
+    domain.attachDeviceFlags(xml, libvirt.VIR_DOMAIN_AFFECT_LIVE)
+    return xml
+
+
+def detach_virtiofs(domain, domain_xmlobject, tag):
+    tag = sanitize_tag(tag)
+    for fs in domain_xmlobject.devices.get_child_node_as_list('filesystem'):
+        if get_attr(get_attr(fs, 'target'), 'dir_') == tag:
+            tmp = tempfile.NamedTemporaryFile(delete=False)
+            try:
+                tmp.write(fs.dump().encode('utf-8'))
+                tmp.close()
+                domain.detachDeviceFlags(fs.dump(), libvirt.VIR_DOMAIN_AFFECT_LIVE)
+            finally:
+                try:
+                    os.remove(tmp.name)
+                except OSError:
+                    pass
+            return True
+    return False

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -49,6 +49,7 @@ from kvmagent import kvmagent
 from kvmagent.plugins.baremetal_v2_gateway_agent import \
     BaremetalV2GatewayAgentPlugin as BmV2GwAgent
 from kvmagent.plugins.bmv2_gateway_agent import utils as bm_utils
+from kvmagent.plugins import vm_artifact
 from kvmagent.plugins.imagestore import ImageStoreClient
 from kvmagent.plugins.shared_block_plugin import MAX_ACTUAL_SIZE_FACTOR
 from zstacklib.utils import bash, plugin, iscsi, gpu
@@ -6940,6 +6941,12 @@ class Vm(object):
 
             make_pvpanic(cmd.addons['panicIsa'], cmd.addons['panicHyperv'])
 
+        def make_vm_artifact_views():
+            views = vm_artifact.get_addon(cmd.addons, vm_artifact.ADDON_VM_ARTIFACT_VIEWS)
+            if not views:
+                return
+            vm_artifact.add_virtiofs_devices(elements['devices'], views, e)
+
         # FIXME: manage scsi device in one place.
         def make_storage_device(storageDevices):
             lvm.unpriv_sgio()
@@ -7231,6 +7238,7 @@ class Vm(object):
         if not cmd.addons or cmd.addons['noConsole'] is not True:
             make_graphic_console()
         make_addons()
+        make_vm_artifact_views()
         make_balloon_memory()
         make_console()
         make_sec_label()

--- a/kvmagent/kvmagent/test/test_vm_artifact.py
+++ b/kvmagent/kvmagent/test/test_vm_artifact.py
@@ -1,0 +1,132 @@
+import os
+import shutil
+import sys
+import tempfile
+import types
+import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+log_mod = types.ModuleType('zstacklib.utils.log')
+log_mod.get_logger = lambda name: mock.MagicMock()
+
+linux_mod = types.ModuleType('zstacklib.utils.linux')
+linux_mod.mkdir = lambda path, mode=0o755: os.makedirs(path, mode) if not os.path.exists(path) else None
+linux_mod.is_mounted = lambda path=None, url=None: False
+linux_mod.umount = lambda path, is_exception=True: True
+
+bash_mod = types.ModuleType('zstacklib.utils.bash')
+bash_mod.bash_r = lambda cmd: 0
+
+libvirt_mod = types.ModuleType('libvirt')
+libvirt_mod.VIR_DOMAIN_AFFECT_LIVE = 1
+
+zstacklib_mod = types.ModuleType('zstacklib')
+utils_mod = types.ModuleType('zstacklib.utils')
+utils_mod.log = log_mod
+utils_mod.linux = linux_mod
+utils_mod.bash = bash_mod
+
+sys.modules.setdefault('zstacklib', zstacklib_mod)
+sys.modules.setdefault('zstacklib.utils', utils_mod)
+sys.modules.setdefault('zstacklib.utils.log', log_mod)
+sys.modules.setdefault('zstacklib.utils.linux', linux_mod)
+sys.modules.setdefault('zstacklib.utils.bash', bash_mod)
+sys.modules.setdefault('libvirt', libvirt_mod)
+
+from kvmagent.plugins import vm_artifact
+
+
+class Obj(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class VmArtifactTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.model_root = os.path.join(self.tmp, 'model-centers')
+        self.view_root = os.path.join(self.tmp, 'vm-views')
+        os.makedirs(self.model_root)
+        os.makedirs(self.view_root)
+        self.old_model_root = vm_artifact.MODEL_CENTER_ROOT
+        self.old_view_root = vm_artifact.VM_VIEW_ROOT
+        vm_artifact.MODEL_CENTER_ROOT = self.model_root
+        vm_artifact.VM_VIEW_ROOT = self.view_root
+
+    def tearDown(self):
+        vm_artifact.MODEL_CENTER_ROOT = self.old_model_root
+        vm_artifact.VM_VIEW_ROOT = self.old_view_root
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_path_escape_is_rejected(self):
+        with self.assertRaises(Exception):
+            vm_artifact.validate_relative_path('../escape', 'installPath')
+
+        outside = os.path.join(self.tmp, 'outside-model')
+        os.makedirs(outside)
+        with self.assertRaises(Exception):
+            vm_artifact.ensure_under(outside, self.model_root, 'sourcePath')
+
+    def test_bind_readonly_uses_bind_mount_and_remount_ro(self):
+        source = os.path.join(self.model_root, 'mc-1', 'models', 'qwen')
+        target = os.path.join(self.view_root, 'vm-1', 'qwen')
+        os.makedirs(source)
+
+        commands = []
+        with mock.patch.object(vm_artifact.linux, 'is_mounted', return_value=False), \
+                mock.patch.object(vm_artifact.bash, 'bash_r', side_effect=lambda cmd: commands.append(cmd) or 0):
+            vm_artifact.bind_readonly(source, target, True)
+
+        self.assertEqual(2, len(commands))
+        self.assertIn('mount --bind', commands[0])
+        self.assertIn(source, commands[0])
+        self.assertIn(target, commands[0])
+        self.assertIn('mount -o remount,bind,ro', commands[1])
+        self.assertIn(target, commands[1])
+
+    def test_cleanup_view_is_idempotent(self):
+        stale = os.path.join(self.view_root, 'vm-1', 'stale')
+        os.makedirs(stale)
+
+        with mock.patch.object(vm_artifact.linux, 'is_mounted', return_value=False):
+            vm_artifact.cleanup_view('vm-1')
+            vm_artifact.cleanup_view('vm-1')
+
+        self.assertTrue(os.path.isdir(os.path.join(self.view_root, 'vm-1')))
+        self.assertFalse(os.path.exists(stale))
+
+    def test_cleanup_keeps_nested_desired_path(self):
+        desired = os.path.join(self.view_root, 'vm-1', 'nested', 'qwen')
+        stale = os.path.join(self.view_root, 'vm-1', 'stale')
+        os.makedirs(desired)
+        os.makedirs(stale)
+
+        with mock.patch.object(vm_artifact.linux, 'is_mounted', return_value=False):
+            vm_artifact.cleanup_view('vm-1', [desired])
+
+        self.assertTrue(os.path.isdir(desired))
+        self.assertFalse(os.path.exists(stale))
+
+    def test_virtiofs_xml_defaults_cache_none_queue_1024(self):
+        source = os.path.join(self.view_root, 'vm-1')
+        os.makedirs(source)
+        xml = vm_artifact.build_virtiofs_device_xml('vm-1', 'model-qwen')
+
+        self.assertIn("type=\"virtiofs\"", xml)
+        self.assertIn("queue=\"1024\"", xml)
+        self.assertIn("mode=\"none\"", xml)
+        self.assertIn("dir=\"%s\"" % source, xml)
+        self.assertIn("dir=\"model-qwen\"", xml)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add kvmagent APIs for host ModelCenter mount management and per-VM artifact view sync/delete/cleanup.
- Add virtiofs attach/detach support and start XML injection through `cmd.addons["vmArtifactViews"]`.
- Keep guest exposure limited to `/var/lib/zstack/aios/vm-views/{vmUuid}` with default virtiofs `cache=none` and `queue=1024`.

## Tests
- `python3 -m py_compile kvmagent/kvmagent/plugins/vm_artifact.py kvmagent/kvmagent/plugins/model_center_plugin.py`
- `python3 -m pytest -q kvmagent/kvmagent/test/test_vm_artifact.py`

## Notes
- No Jira key was provided for this task, so the local `Resolves: ZSTAC-XXXXX` commit hook was bypassed to avoid linking this work to an unrelated issue.
- Live libvirt attach/detach still needs validation on a running KVM host.

sync from gitlab !7006