### PR TITLE
add local volume encryption (LUKS) creation path

### DIFF
--- a/kvmagent/kvmagent/keyagent/key_agent.proto
+++ b/kvmagent/kvmagent/keyagent/key_agent.proto
@@ -9,6 +9,7 @@ service KeyAgentService {
   rpc EnsureSecret(EnsureSecretRequest) returns (EnsureSecretResponse);
   rpc GetSecret(GetSecretRequest) returns (GetSecretResponse);
   rpc DeleteSecret(DeleteSecretRequest) returns (DeleteSecretResponse);
+  rpc PrepareLuksSecretMaterialChannel(PrepareLuksSecretMaterialChannelRequest) returns (PrepareLuksSecretMaterialChannelResponse);
 }
 
 message CreateEnvelopeKeyRequest {}
@@ -64,3 +65,11 @@ message DeleteSecretRequest {
 }
 
 message DeleteSecretResponse {}
+
+message PrepareLuksSecretMaterialChannelRequest {
+  bytes encrypted_dek = 1;
+}
+
+message PrepareLuksSecretMaterialChannelResponse {
+  string channel_path = 1;
+}

--- a/kvmagent/kvmagent/keyagent/key_agent_pb2.py
+++ b/kvmagent/kvmagent/keyagent/key_agent_pb2.py
@@ -18,7 +18,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='keyagent.v1',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=b'\n\x0fkey_agent.proto\x12\x0bkeyagent.v1\"\x1a\n\x18\x43reateEnvelopeKeyRequest\",\n\x19\x43reateEnvelopeKeyResponse\x12\x0f\n\x07\x63reated\x18\x01 \x01(\x08\"\x1a\n\x18RotateEnvelopeKeyRequest\"\x1b\n\x19RotateEnvelopeKeyResponse\"\x15\n\x13GetPublicKeyRequest\"*\n\x14GetPublicKeyResponse\x12\x12\n\npublic_key\x18\x01 \x01(\x0c\"\x19\n\x17\x43heckEnvelopeKeyRequest\"\x1a\n\x18\x43heckEnvelopeKeyResponse\"\xa5\x01\n\x13\x45nsureSecretRequest\x12\x15\n\rencrypted_dek\x18\x01 \x01(\x0c\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x0f\n\x07vm_uuid\x18\x03 \x01(\t\x12\x0f\n\x07purpose\x18\x04 \x01(\t\x12\x13\n\x0bkey_version\x18\x05 \x01(\x05\x12\x16\n\x0eusage_instance\x18\x06 \x01(\t\x12\x13\n\x0bsecret_uuid\x18\x07 \x01(\t\"+\n\x14\x45nsureSecretResponse\x12\x13\n\x0bsecret_uuid\x18\x01 \x01(\t\"a\n\x10GetSecretRequest\x12\x0f\n\x07vm_uuid\x18\x01 \x01(\t\x12\x13\n\x0bkey_version\x18\x02 \x01(\x05\x12\x0f\n\x07purpose\x18\x03 \x01(\t\x12\x16\n\x0eusage_instance\x18\x04 \x01(\t\"(\n\x11GetSecretResponse\x12\x13\n\x0bsecret_uuid\x18\x01 \x01(\t\"d\n\x13\x44\x65leteSecretRequest\x12\x0f\n\x07vm_uuid\x18\x01 \x01(\t\x12\x13\n\x0bkey_version\x18\x02 \x01(\x05\x12\x0f\n\x07purpose\x18\x03 \x01(\t\x12\x16\n\x0eusage_instance\x18\x04 \x01(\t\"\x16\n\x14\x44\x65leteSecretResponse2\x85\x05\n\x0fKeyAgentService\x12\x62\n\x11\x43reateEnvelopeKey\x12%.keyagent.v1.CreateEnvelopeKeyRequest\x1a&.keyagent.v1.CreateEnvelopeKeyResponse\x12\x62\n\x11RotateEnvelopeKey\x12%.keyagent.v1.RotateEnvelopeKeyRequest\x1a&.keyagent.v1.RotateEnvelopeKeyResponse\x12S\n\x0cGetPublicKey\x12 .keyagent.v1.GetPublicKeyRequest\x1a!.keyagent.v1.GetPublicKeyResponse\x12_\n\x10\x43heckEnvelopeKey\x12$.keyagent.v1.CheckEnvelopeKeyRequest\x1a%.keyagent.v1.CheckEnvelopeKeyResponse\x12S\n\x0c\x45nsureSecret\x12 .keyagent.v1.EnsureSecretRequest\x1a!.keyagent.v1.EnsureSecretResponse\x12J\n\tGetSecret\x12\x1d.keyagent.v1.GetSecretRequest\x1a\x1e.keyagent.v1.GetSecretResponse\x12S\n\x0c\x44\x65leteSecret\x12 .keyagent.v1.DeleteSecretRequest\x1a!.keyagent.v1.DeleteSecretResponseb\x06proto3'
+  serialized_pb=b'\n\x0fkey_agent.proto\x12\x0bkeyagent.v1\"\x1a\n\x18\x43reateEnvelopeKeyRequest\",\n\x19\x43reateEnvelopeKeyResponse\x12\x0f\n\x07\x63reated\x18\x01 \x01(\x08\"\x1a\n\x18RotateEnvelopeKeyRequest\"\x1b\n\x19RotateEnvelopeKeyResponse\"\x15\n\x13GetPublicKeyRequest\"*\n\x14GetPublicKeyResponse\x12\x12\n\npublic_key\x18\x01 \x01(\x0c\"\x19\n\x17\x43heckEnvelopeKeyRequest\"\x1a\n\x18\x43heckEnvelopeKeyResponse\"\xa5\x01\n\x13\x45nsureSecretRequest\x12\x15\n\rencrypted_dek\x18\x01 \x01(\x0c\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x0f\n\x07vm_uuid\x18\x03 \x01(\t\x12\x0f\n\x07purpose\x18\x04 \x01(\t\x12\x13\n\x0bkey_version\x18\x05 \x01(\x05\x12\x16\n\x0eusage_instance\x18\x06 \x01(\t\x12\x13\n\x0bsecret_uuid\x18\x07 \x01(\t\"+\n\x14\x45nsureSecretResponse\x12\x13\n\x0bsecret_uuid\x18\x01 \x01(\t\"a\n\x10GetSecretRequest\x12\x0f\n\x07vm_uuid\x18\x01 \x01(\t\x12\x13\n\x0bkey_version\x18\x02 \x01(\x05\x12\x0f\n\x07purpose\x18\x03 \x01(\t\x12\x16\n\x0eusage_instance\x18\x04 \x01(\t\"(\n\x11GetSecretResponse\x12\x13\n\x0bsecret_uuid\x18\x01 \x01(\t\"d\n\x13\x44\x65leteSecretRequest\x12\x0f\n\x07vm_uuid\x18\x01 \x01(\t\x12\x13\n\x0bkey_version\x18\x02 \x01(\x05\x12\x0f\n\x07purpose\x18\x03 \x01(\t\x12\x16\n\x0eusage_instance\x18\x04 \x01(\t\"\x16\n\x14\x44\x65leteSecretResponse\"@\n\'PrepareLuksSecretMaterialChannelRequest\x12\x15\n\rencrypted_dek\x18\x01 \x01(\x0c\"@\n(PrepareLuksSecretMaterialChannelResponse\x12\x14\n\x0c\x63hannel_path\x18\x01 \x01(\t2\x97\x06\n\x0fKeyAgentService\x12\x62\n\x11\x43reateEnvelopeKey\x12%.keyagent.v1.CreateEnvelopeKeyRequest\x1a&.keyagent.v1.CreateEnvelopeKeyResponse\x12\x62\n\x11RotateEnvelopeKey\x12%.keyagent.v1.RotateEnvelopeKeyRequest\x1a&.keyagent.v1.RotateEnvelopeKeyResponse\x12S\n\x0cGetPublicKey\x12 .keyagent.v1.GetPublicKeyRequest\x1a!.keyagent.v1.GetPublicKeyResponse\x12_\n\x10\x43heckEnvelopeKey\x12$.keyagent.v1.CheckEnvelopeKeyRequest\x1a%.keyagent.v1.CheckEnvelopeKeyResponse\x12S\n\x0c\x45nsureSecret\x12 .keyagent.v1.EnsureSecretRequest\x1a!.keyagent.v1.EnsureSecretResponse\x12J\n\tGetSecret\x12\x1d.keyagent.v1.GetSecretRequest\x1a\x1e.keyagent.v1.GetSecretResponse\x12S\n\x0c\x44\x65leteSecret\x12 .keyagent.v1.DeleteSecretRequest\x1a!.keyagent.v1.DeleteSecretResponse\x12\x8f\x01\n PrepareLuksSecretMaterialChannel\x12\x34.keyagent.v1.PrepareLuksSecretMaterialChannelRequest\x1a\x35.keyagent.v1.PrepareLuksSecretMaterialChannelResponseb\x06proto3'
 )
 
 
@@ -492,6 +492,68 @@ _DELETESECRETRESPONSE = _descriptor.Descriptor(
   serialized_end=763,
 )
 
+
+_PREPARELUKSSECRETMATERIALCHANNELREQUEST = _descriptor.Descriptor(
+  name='PrepareLuksSecretMaterialChannelRequest',
+  full_name='keyagent.v1.PrepareLuksSecretMaterialChannelRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='encrypted_dek', full_name='keyagent.v1.PrepareLuksSecretMaterialChannelRequest.encrypted_dek', index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=765,
+  serialized_end=829,
+)
+
+
+_PREPARELUKSSECRETMATERIALCHANNELRESPONSE = _descriptor.Descriptor(
+  name='PrepareLuksSecretMaterialChannelResponse',
+  full_name='keyagent.v1.PrepareLuksSecretMaterialChannelResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='channel_path', full_name='keyagent.v1.PrepareLuksSecretMaterialChannelResponse.channel_path', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=831,
+  serialized_end=895,
+)
+
 DESCRIPTOR.message_types_by_name['CreateEnvelopeKeyRequest'] = _CREATEENVELOPEKEYREQUEST
 DESCRIPTOR.message_types_by_name['CreateEnvelopeKeyResponse'] = _CREATEENVELOPEKEYRESPONSE
 DESCRIPTOR.message_types_by_name['RotateEnvelopeKeyRequest'] = _ROTATEENVELOPEKEYREQUEST
@@ -506,6 +568,8 @@ DESCRIPTOR.message_types_by_name['GetSecretRequest'] = _GETSECRETREQUEST
 DESCRIPTOR.message_types_by_name['GetSecretResponse'] = _GETSECRETRESPONSE
 DESCRIPTOR.message_types_by_name['DeleteSecretRequest'] = _DELETESECRETREQUEST
 DESCRIPTOR.message_types_by_name['DeleteSecretResponse'] = _DELETESECRETRESPONSE
+DESCRIPTOR.message_types_by_name['PrepareLuksSecretMaterialChannelRequest'] = _PREPARELUKSSECRETMATERIALCHANNELREQUEST
+DESCRIPTOR.message_types_by_name['PrepareLuksSecretMaterialChannelResponse'] = _PREPARELUKSSECRETMATERIALCHANNELRESPONSE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 CreateEnvelopeKeyRequest = _reflection.GeneratedProtocolMessageType('CreateEnvelopeKeyRequest', (_message.Message,), {
@@ -606,6 +670,20 @@ DeleteSecretResponse = _reflection.GeneratedProtocolMessageType('DeleteSecretRes
   })
 _sym_db.RegisterMessage(DeleteSecretResponse)
 
+PrepareLuksSecretMaterialChannelRequest = _reflection.GeneratedProtocolMessageType('PrepareLuksSecretMaterialChannelRequest', (_message.Message,), {
+  'DESCRIPTOR' : _PREPARELUKSSECRETMATERIALCHANNELREQUEST,
+  '__module__' : 'key_agent_pb2'
+  # @@protoc_insertion_point(class_scope:keyagent.v1.PrepareLuksSecretMaterialChannelRequest)
+  })
+_sym_db.RegisterMessage(PrepareLuksSecretMaterialChannelRequest)
+
+PrepareLuksSecretMaterialChannelResponse = _reflection.GeneratedProtocolMessageType('PrepareLuksSecretMaterialChannelResponse', (_message.Message,), {
+  'DESCRIPTOR' : _PREPARELUKSSECRETMATERIALCHANNELRESPONSE,
+  '__module__' : 'key_agent_pb2'
+  # @@protoc_insertion_point(class_scope:keyagent.v1.PrepareLuksSecretMaterialChannelResponse)
+  })
+_sym_db.RegisterMessage(PrepareLuksSecretMaterialChannelResponse)
+
 
 
 _KEYAGENTSERVICE = _descriptor.ServiceDescriptor(
@@ -614,8 +692,8 @@ _KEYAGENTSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=766,
-  serialized_end=1411,
+  serialized_start=898,
+  serialized_end=1689,
   methods=[
   _descriptor.MethodDescriptor(
     name='CreateEnvelopeKey',
@@ -678,6 +756,15 @@ _KEYAGENTSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_DELETESECRETREQUEST,
     output_type=_DELETESECRETRESPONSE,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='PrepareLuksSecretMaterialChannel',
+    full_name='keyagent.v1.KeyAgentService.PrepareLuksSecretMaterialChannel',
+    index=7,
+    containing_service=None,
+    input_type=_PREPARELUKSSECRETMATERIALCHANNELREQUEST,
+    output_type=_PREPARELUKSSECRETMATERIALCHANNELRESPONSE,
     serialized_options=None,
   ),
 ])

--- a/kvmagent/kvmagent/keyagent/key_agent_pb2_grpc.py
+++ b/kvmagent/kvmagent/keyagent/key_agent_pb2_grpc.py
@@ -49,6 +49,11 @@ class KeyAgentServiceStub(object):
         request_serializer=key__agent__pb2.DeleteSecretRequest.SerializeToString,
         response_deserializer=key__agent__pb2.DeleteSecretResponse.FromString,
         )
+    self.PrepareLuksSecretMaterialChannel = channel.unary_unary(
+        '/keyagent.v1.KeyAgentService/PrepareLuksSecretMaterialChannel',
+        request_serializer=key__agent__pb2.PrepareLuksSecretMaterialChannelRequest.SerializeToString,
+        response_deserializer=key__agent__pb2.PrepareLuksSecretMaterialChannelResponse.FromString,
+        )
 
 
 class KeyAgentServiceServicer(object):
@@ -104,6 +109,13 @@ class KeyAgentServiceServicer(object):
     context.set_details('Method not implemented!')
     raise NotImplementedError('Method not implemented!')
 
+  def PrepareLuksSecretMaterialChannel(self, request, context):
+    # missing associated documentation comment in .proto file
+    pass
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
 
 def add_KeyAgentServiceServicer_to_server(servicer, server):
   rpc_method_handlers = {
@@ -141,6 +153,11 @@ def add_KeyAgentServiceServicer_to_server(servicer, server):
           servicer.DeleteSecret,
           request_deserializer=key__agent__pb2.DeleteSecretRequest.FromString,
           response_serializer=key__agent__pb2.DeleteSecretResponse.SerializeToString,
+      ),
+      'PrepareLuksSecretMaterialChannel': grpc.unary_unary_rpc_method_handler(
+          servicer.PrepareLuksSecretMaterialChannel,
+          request_deserializer=key__agent__pb2.PrepareLuksSecretMaterialChannelRequest.FromString,
+          response_serializer=key__agent__pb2.PrepareLuksSecretMaterialChannelResponse.SerializeToString,
       ),
   }
   generic_handler = grpc.method_handlers_generic_handler(

--- a/kvmagent/kvmagent/plugins/ceph_storage_plugin.py
+++ b/kvmagent/kvmagent/plugins/ceph_storage_plugin.py
@@ -1,6 +1,11 @@
+import os
+import uuid as uuidlib
+
 from kvmagent import kvmagent
+from kvmagent.plugins import volume_secret
 from zstacklib.utils import http
 from zstacklib.utils import jsonobject
+from zstacklib.utils import linux
 from zstacklib.utils import log
 from zstacklib.utils import shell
 from zstacklib.utils import qemu_img
@@ -22,11 +27,30 @@ class CheckHostStorageConnectionRsp(kvmagent.AgentResponse):
         super(CheckHostStorageConnectionRsp, self).__init__()
 
 
+class CephLuksRsp(kvmagent.AgentResponse):
+    def __init__(self):
+        super(CephLuksRsp, self).__init__()
+        self.actualSize = None
+
+
 class CephStoragePlugin(kvmagent.KvmAgent):
     CHECK_HOST_STORAGE_CONNECTION_PATH = "/ceph/primarystorage/check/host/connection"
+    LUKS_CLONE_PATH = "/ceph/primarystorage/kvmhost/luksclone"
+    LUKS_CREATE_EMPTY_PATH = "/ceph/primarystorage/kvmhost/lukscreateempty"
+    LUKS_ENCRYPT_IN_PLACE_PATH = "/ceph/primarystorage/kvmhost/encryptinplace"
+    LUKS_RESIZE_PATH = "/ceph/primarystorage/kvmhost/luksresize"
+    LUKS_CONVERT_PATH = "/ceph/primarystorage/kvmhost/luksconvert"
+
+    CEPH_CLIENT_CONF_ROOT = "/var/lib/zstack/ceph"
+
     def start(self):
         http_server = kvmagent.get_http_server()
         http_server.register_async_uri(self.CHECK_HOST_STORAGE_CONNECTION_PATH, self.check_host_storage_connection)
+        http_server.register_async_uri(self.LUKS_CLONE_PATH, self.luks_clone)
+        http_server.register_async_uri(self.LUKS_CREATE_EMPTY_PATH, self.luks_create_empty)
+        http_server.register_async_uri(self.LUKS_ENCRYPT_IN_PLACE_PATH, self.luks_encrypt_in_place)
+        http_server.register_async_uri(self.LUKS_RESIZE_PATH, self.luks_resize)
+        http_server.register_async_uri(self.LUKS_CONVERT_PATH, self.luks_convert)
 
     @kvmagent.replyerror
     def check_host_storage_connection(self, req):
@@ -86,6 +110,373 @@ class CephStoragePlugin(kvmagent.KvmAgent):
         rsp.success = False
         return jsonobject.dumps(rsp)
     
+    @staticmethod
+    def _rbd_uri(install_path, conf_path, extra=None):
+        s = "rbd:%s:conf=%s" % (install_path, conf_path)
+        if extra:
+            s += ":" + extra
+        return s
+
+    @staticmethod
+    def _rbd_image_opts(install_path, conf_path):
+        image_path = install_path
+        snapshot = None
+        if "@" in image_path:
+            image_path, snapshot = image_path.split("@", 1)
+        pool, image = image_path.split("/", 1)
+        opts = "file.driver=rbd,file.pool=%s,file.image=%s,file.conf=%s" % (pool, image, conf_path)
+        if snapshot:
+            opts += ",file.snapshot=%s" % snapshot
+        return opts
+
+    def _is_luks_rbd(self, install_path, conf_path):
+        # Do not pass the one-shot LUKS secret FIFO here: qemu-img info would
+        # consume it before the real convert command. The LUKS header is enough
+        # for qemu-img to report the source format without opening the payload.
+        try:
+            out = shell.call("/usr/bin/qemu-img info %s" % self._rbd_uri(install_path, conf_path))
+            return "file format: luks" in out
+        except Exception as e:
+            logger.warn("failed to probe RBD source format for %s: %s" % (install_path, e))
+            return False
+
+    @staticmethod
+    def _rbd_actual_size(install_path, conf_path):
+        try:
+            du_output = shell.call("rbd --conf %s du %s --format json" % (conf_path, install_path))
+            du_result = jsonobject.loads(du_output)
+            images = getattr(du_result, "images", None)
+            if not images:
+                return None
+            # rbd du json returns a list; first row is the image itself when no
+            # snapshots are queried. Pick the first numeric used_size_ we see.
+            for image_usage in images:
+                used = getattr(image_usage, "used_size_", None)
+                if used is not None:
+                    return long(used)
+            return None
+        except Exception as e:
+            logger.warn("failed to read rbd du for %s: %s" % (install_path, e))
+            return None
+
+    def _validate_luks_cmd(self, cmd, rsp, encrypted_dek=False):
+        if not getattr(cmd, "psUuid", None):
+            rsp.success = False
+            rsp.error = "psUuid is required for LUKS ceph operation on KVM host"
+            return None
+        if encrypted_dek:
+            if not getattr(cmd, "encryptedDek", None):
+                rsp.success = False
+                rsp.error = "encryptedDek is required for LUKS ceph operation on KVM host"
+                return None
+        elif not getattr(cmd, "secFilePath", None):
+            rsp.success = False
+            rsp.error = "secFilePath is required for LUKS ceph operation on KVM host"
+            return None
+        # ZStack pushes per-PS ceph.conf + client.zstack.keyring to every
+        # attached KVM host under /var/lib/zstack/ceph/<ps>/. We reuse that
+        # so LUKS clone on a KVM host can talk to ceph without depending on
+        # /etc/ceph/ceph.conf (which may not exist on non-converged hosts).
+        conf = os.path.join(self.CEPH_CLIENT_CONF_ROOT, cmd.psUuid, "ceph.conf")
+        if not os.path.exists(conf):
+            rsp.success = False
+            rsp.error = (
+                "ceph client config not found on host: %s. "
+                "Re-attach the primary storage to this host." % conf
+            )
+            return None
+        return conf
+
+    @kvmagent.replyerror
+    def luks_clone(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = CephLuksRsp()
+        conf = self._validate_luks_cmd(cmd, rsp, encrypted_dek=True)
+        if conf is None:
+            return jsonobject.dumps(rsp)
+        src_path = cmd.srcPath.replace("ceph://", "")
+        dst_path = cmd.dstPath.replace("ceph://", "")
+
+        def do_luks_convert(sec):
+            if self._is_luks_rbd(src_path, conf):
+                src_arg = (
+                    "--image-opts driver=luks,key-secret=luks_sec,%s" % self._rbd_image_opts(src_path, conf)
+                )
+            else:
+                src_arg = "-f raw %s" % self._rbd_uri(src_path, conf)
+
+            shell.call(
+                "/usr/bin/qemu-img convert "
+                "--object secret,id=luks_sec,format=raw,file=%s "
+                "-m 16 -W %s -O luks -o key-secret=luks_sec %s" % (
+                    sec,
+                    src_arg,
+                    self._rbd_uri(dst_path, conf, "rbd_cache=false:rbd_concurrent_management_ops=20"),
+                )
+            )
+
+        def do_luks_resize(sec, virtual_size):
+            dst_pool, dst_image = dst_path.split("/", 1)
+            shell.call(
+                "/usr/bin/qemu-img resize "
+                "--object secret,id=luks_sec,format=raw,file=%s "
+                "--image-opts driver=luks,key-secret=luks_sec,"
+                "file.driver=rbd,file.pool=%s,file.image=%s,file.conf=%s %s" % (
+                    sec, dst_pool, dst_image, conf, virtual_size,
+                )
+            )
+
+        try:
+            with volume_secret.luks_secret_channel(cmd.encryptedDek) as sec:
+                do_luks_convert(sec)
+            virtual_size = getattr(cmd, "virtualSizeForLuksClone", None)
+            if virtual_size:
+                with volume_secret.luks_secret_channel(cmd.encryptedDek) as sec:
+                    do_luks_resize(sec, virtual_size)
+        finally:
+            pass
+
+        rsp.actualSize = self._rbd_actual_size(dst_path, conf)
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def luks_create_empty(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = CephLuksRsp()
+        conf = self._validate_luks_cmd(cmd, rsp, encrypted_dek=True)
+        if conf is None:
+            return jsonobject.dumps(rsp)
+        install_path = cmd.installPath.replace("ceph://", "")
+        try:
+            with volume_secret.luks_secret_channel(cmd.encryptedDek) as sec:
+                shell.call(
+                    "/usr/bin/qemu-img create "
+                    "--object secret,id=luks_sec,format=raw,file=%s "
+                    "-f luks -o key-secret=luks_sec %s %s" % (
+                        sec, self._rbd_uri(install_path, conf), cmd.size,
+                    )
+                )
+        finally:
+            pass
+        rsp.actualSize = self._rbd_actual_size(install_path, conf)
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def luks_convert(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = CephLuksRsp()
+        conf = self._validate_luks_cmd(cmd, rsp, encrypted_dek=True)
+        if conf is None:
+            return jsonobject.dumps(rsp)
+
+        src_path = cmd.installPath.replace("ceph://", "")
+        target_path = getattr(cmd, "targetInstallPath", None) or cmd.installPath
+        target_path = target_path.replace("ceph://", "")
+        trash_path = getattr(cmd, "sourceTrashInstallPath", None)
+        if trash_path:
+            trash_path = trash_path.replace("ceph://", "")
+        else:
+            trash_path = "%s-trash-%s" % (src_path, uuidlib.uuid4().hex[:8])
+
+        if "@" in src_path or "@" in target_path or "@" in trash_path:
+            rsp.success = False
+            rsp.error = "RBD LUKS conversion only supports active image paths, got source[%s], target[%s], trash[%s]" % (
+                src_path, target_path, trash_path,
+            )
+            return jsonobject.dumps(rsp)
+
+        tmp_path = "%s-converting-%s" % (target_path, uuidlib.uuid4().hex[:8])
+        rbd_prefix = "rbd --conf %s" % conf
+        moved_original = False
+        converted = False
+
+        try:
+            if shell.run("%s info %s" % (rbd_prefix, trash_path)) == 0:
+                rsp.success = False
+                rsp.error = "RBD trash image already exists: %s" % trash_path
+                return jsonobject.dumps(rsp)
+            if target_path != src_path and shell.run("%s info %s" % (rbd_prefix, target_path)) == 0:
+                rsp.success = False
+                rsp.error = "RBD target image already exists: %s" % target_path
+                return jsonobject.dumps(rsp)
+
+            source_is_luks = self._is_luks_rbd(src_path, conf)
+            if source_is_luks:
+                src_arg = "--image-opts driver=luks,key-secret=luks_sec,%s" % self._rbd_image_opts(src_path, conf)
+            else:
+                if not cmd.targetEncrypted:
+                    rsp.success = False
+                    rsp.error = "RBD image is not LUKS formatted: %s" % cmd.installPath
+                    return jsonobject.dumps(rsp)
+                src_arg = "-f raw %s" % self._rbd_uri(src_path, conf)
+
+            with volume_secret.luks_secret_channel(cmd.encryptedDek) as sec:
+                if cmd.targetEncrypted:
+                    target_format = "-O luks -o key-secret=luks_sec"
+                else:
+                    target_format = "-O raw"
+                shell.call(
+                    "/usr/bin/qemu-img convert "
+                    "--object secret,id=luks_sec,format=raw,file=%s "
+                    "-m 16 -W %s %s %s" % (
+                        sec,
+                        src_arg,
+                        target_format,
+                        self._rbd_uri(tmp_path, conf, "rbd_cache=false:rbd_concurrent_management_ops=20"),
+                    )
+                )
+
+            virtual_size = getattr(cmd, "virtualSize", None)
+            if cmd.targetEncrypted and virtual_size:
+                pool, image = tmp_path.split("/", 1)
+                with volume_secret.luks_secret_channel(cmd.encryptedDek) as sec:
+                    shell.call(
+                        "/usr/bin/qemu-img resize "
+                        "--object secret,id=luks_sec,format=raw,file=%s "
+                        "--image-opts driver=luks,key-secret=luks_sec,"
+                        "file.driver=rbd,file.pool=%s,file.image=%s,file.conf=%s %s" % (
+                            sec, pool, image, conf, virtual_size,
+                        )
+                    )
+
+            shell.call("%s mv %s %s" % (rbd_prefix, src_path, trash_path))
+            moved_original = True
+            try:
+                shell.call("%s mv %s %s" % (rbd_prefix, tmp_path, target_path))
+                converted = True
+                moved_original = False
+            except Exception:
+                shell.call("%s mv %s %s" % (rbd_prefix, trash_path, src_path))
+                moved_original = False
+                raise
+        finally:
+            if shell.run("%s info %s" % (rbd_prefix, tmp_path)) == 0:
+                shell.run("%s rm %s" % (rbd_prefix, tmp_path))
+            if moved_original:
+                shell.run("%s mv %s %s" % (rbd_prefix, trash_path, src_path))
+
+        if converted:
+            rsp.actualSize = self._rbd_actual_size(target_path, conf)
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def luks_resize(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = CephLuksRsp()
+        conf = self._validate_luks_cmd(cmd, rsp, encrypted_dek=True)
+        if conf is None:
+            return jsonobject.dumps(rsp)
+        install_path = cmd.installPath.replace("ceph://", "")
+        try:
+            with volume_secret.luks_secret_channel(cmd.encryptedDek) as sec:
+                if not self._is_luks_rbd(install_path, conf):
+                    rsp.success = False
+                    rsp.error = "RBD image is not LUKS formatted: %s" % cmd.installPath
+                    return jsonobject.dumps(rsp)
+
+                virtual_size = getattr(cmd, "virtualSize", None)
+                pool, image = install_path.split("/", 1)
+                if virtual_size:
+                    shell.call(
+                        "/usr/bin/qemu-img resize "
+                        "--object secret,id=luks_sec,format=raw,file=%s "
+                        "--image-opts driver=luks,key-secret=luks_sec,"
+                        "file.driver=rbd,file.pool=%s,file.image=%s,file.conf=%s %s" % (
+                            sec, pool, image, conf, virtual_size,
+                        )
+                    )
+                else:
+                    shell.call(
+                        "/usr/bin/qemu-img info "
+                        "--object secret,id=luks_sec,format=raw,file=%s "
+                        "--image-opts driver=luks,key-secret=luks_sec,"
+                        "file.driver=rbd,file.pool=%s,file.image=%s,file.conf=%s" % (
+                            sec, pool, image, conf,
+                        )
+                    )
+        finally:
+            pass
+
+        rsp.actualSize = self._rbd_actual_size(install_path, conf)
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def luks_encrypt_in_place(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = CephLuksRsp()
+        conf = self._validate_luks_cmd(cmd, rsp, encrypted_dek=True)
+        if conf is None:
+            return jsonobject.dumps(rsp)
+        install_path = cmd.installPath.replace("ceph://", "")
+        tmp_path = "%s-encrypting-%s" % (install_path, uuidlib.uuid4().hex[:8])
+        old_path = "%s-plain-%s" % (install_path, uuidlib.uuid4().hex[:8])
+        moved_original = False
+        rbd_prefix = "rbd --conf %s" % conf
+        try:
+            logger.info("start in-place LUKS encryption for RBD image: image[%s], temporary[%s], original-backup[%s]" % (
+                install_path, tmp_path, old_path,
+            ))
+            with volume_secret.luks_secret_channel(cmd.encryptedDek) as sec:
+                shell.call(
+                    "/usr/bin/qemu-img convert "
+                    "--object secret,id=luks_sec,format=raw,file=%s "
+                    "-m 16 -W -O luks -o key-secret=luks_sec %s %s" % (
+                        sec,
+                        self._rbd_uri(install_path, conf),
+                        self._rbd_uri(tmp_path, conf, "rbd_cache=false:rbd_concurrent_management_ops=20"),
+                    )
+                )
+            logger.info("created temporary encrypted RBD image: source[%s], temporary[%s]" % (install_path, tmp_path))
+
+            logger.info("move original RBD image to backup before replacement: source[%s], backup[%s]" % (
+                install_path, old_path,
+            ))
+            shell.call("%s mv %s %s" % (rbd_prefix, install_path, old_path))
+            moved_original = True
+            logger.info("moved original RBD image to backup: backup[%s]" % old_path)
+            try:
+                logger.info("move temporary encrypted RBD image into place: temporary[%s], target[%s]" % (
+                    tmp_path, install_path,
+                ))
+                shell.call("%s mv %s %s" % (rbd_prefix, tmp_path, install_path))
+                logger.info("moved temporary encrypted RBD image into place: target[%s]" % install_path)
+            except Exception as e:
+                logger.warn("failed to move temporary encrypted RBD image into place, rollback original RBD image: temporary[%s], target[%s], backup[%s], error[%s]" % (
+                    tmp_path, install_path, old_path, e,
+                ))
+                shell.call("%s mv %s %s" % (rbd_prefix, old_path, install_path))
+                moved_original = False
+                logger.info("rolled back original RBD image after failed replacement: backup[%s], target[%s]" % (
+                    old_path, install_path,
+                ))
+                raise
+            logger.info("remove old plain RBD image after successful in-place encryption: backup[%s]" % old_path)
+            shell.call("%s rm %s" % (rbd_prefix, old_path))
+            moved_original = False
+            logger.info("removed old plain RBD image after successful in-place encryption: backup[%s]" % old_path)
+        finally:
+            if shell.run("%s info %s" % (rbd_prefix, tmp_path)) == 0:
+                logger.info("cleanup remaining temporary RBD image: temporary[%s]" % tmp_path)
+                if shell.run("%s rm %s" % (rbd_prefix, tmp_path)) == 0:
+                    logger.info("cleaned remaining temporary RBD image: temporary[%s]" % tmp_path)
+                else:
+                    logger.warn("failed to cleanup remaining temporary RBD image: temporary[%s]" % tmp_path)
+            if moved_original:
+                logger.warn("original RBD image was moved but not restored, rollback in finally: backup[%s], target[%s]" % (
+                    old_path, install_path,
+                ))
+                if shell.run("%s mv %s %s" % (rbd_prefix, old_path, install_path)) == 0:
+                    logger.info("rolled back original RBD image in finally: backup[%s], target[%s]" % (
+                        old_path, install_path,
+                    ))
+                else:
+                    logger.warn("failed to rollback original RBD image in finally: backup[%s], target[%s]" % (
+                        old_path, install_path,
+                    ))
+
+        rsp.actualSize = self._rbd_actual_size(install_path, conf)
+        return jsonobject.dumps(rsp)
+
     def stop(self):
         pass
         

--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -81,7 +81,7 @@ KEY_AGENT_ERR_KEYS_NOT_ON_DISK = 'KEY_AGENT_KEYS_NOT_ON_DISK'
 KEY_AGENT_ERR_KEY_FILES_INTEGRITY_MISMATCH = 'KEY_AGENT_KEY_FILES_INTEGRITY_MISMATCH'
 KEY_AGENT_ERR_SECRET_NOT_FOUND = 'KEY_AGENT_SECRET_NOT_FOUND'
 
-KEY_AGENT_SUPPORTED_SECRET_PURPOSES = ('vtpm',)
+KEY_AGENT_SUPPORTED_SECRET_PURPOSES = ('vtpm', 'volume')
 
 
 def is_valid_key_agent_secret_purpose(purpose):
@@ -1086,6 +1086,7 @@ class HostPlugin(kvmagent.KvmAgent):
     GET_ENVELOPE_PUBLIC_KEY_PATH = '/host/key/envelope/getEnvelopePublicKey'
     CHECK_ENVELOPE_KEY_PATH = '/host/key/envelope/checkEnvelopeKey'
     ENSURE_SECRET_PATH = '/host/key/envelope/ensureSecret'
+    WRITE_SECRET_MATERIAL_FILE_PATH = '/host/key/envelope/writeSecretMaterialFile'
     GET_SECRET_PATH = '/host/key/envelope/getSecret'
     DELETE_SECRET_PATH = '/host/key/envelope/deleteSecret'
     CHECK_FILE_ON_HOST_PATH = '/host/checkfile'
@@ -1345,6 +1346,39 @@ class HostPlugin(kvmagent.KvmAgent):
             return (None, None, details or str(e))
         except Exception as e:
             logger.debug('key-agent EnsureSecret failed: %s' % e)
+            return (None, None, str(e))
+
+    def _prepare_luks_secret_material_channel(self, encrypted_dek):
+        if not KEY_AGENT_GRPC_AVAILABLE:
+            return (None, None, 'key_agent grpc not available')
+        if not encrypted_dek:
+            return (None, None, 'encrypted_dek is required')
+        try:
+            if not os.path.exists('/var/run/key-agent/key-agent.sock'):
+                logger.debug('key-agent unix socket not found, skip PrepareLuksSecretMaterialChannel')
+                return (None, None, 'key-agent socket not found')
+            channel = grpc.insecure_channel(KEY_AGENT_UNIX_SOCKET)
+            try:
+                stub = key_agent_pb2_grpc.KeyAgentServiceStub(channel)
+                req = key_agent_pb2.PrepareLuksSecretMaterialChannelRequest(encrypted_dek=encrypted_dek)
+                resp = stub.PrepareLuksSecretMaterialChannel(req, timeout=60)
+                path = getattr(resp, 'channel_path', None) if resp else None
+                path = str(path).strip() if path else ''
+                if path:
+                    return (path, None, None)
+                return (None, None, 'key-agent PrepareLuksSecretMaterialChannel returned empty channel_path')
+            finally:
+                channel.close()
+        except grpc.RpcError as e:
+            details = e.details() if hasattr(e, 'details') and callable(getattr(e, 'details')) else str(e)
+            logger.debug('key-agent PrepareLuksSecretMaterialChannel gRPC error: %s' % details)
+            if KEY_AGENT_ERR_KEYS_NOT_ON_DISK in details:
+                return (None, KEY_AGENT_ERR_KEYS_NOT_ON_DISK, details)
+            if KEY_AGENT_ERR_KEY_FILES_INTEGRITY_MISMATCH in details:
+                return (None, KEY_AGENT_ERR_KEY_FILES_INTEGRITY_MISMATCH, details)
+            return (None, None, details or str(e))
+        except Exception as e:
+            logger.debug('key-agent PrepareLuksSecretMaterialChannel failed: %s' % e)
             return (None, None, str(e))
 
     def _get_secret_via_key_agent(self, vm_uuid, key_version, purpose, usage_instance=''):
@@ -1667,6 +1701,57 @@ class HostPlugin(kvmagent.KvmAgent):
                 rsp.error = err_msg or err_code
             else:
                 rsp.error = err_msg or 'key-agent EnsureSecret failed or no secret_uuid'
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def write_secret_material_file(self, req):
+        """
+        MN -> kvmagent: HPKE-sealed encryptedDek (base64); kvmagent -> key-agent PrepareLuksSecretMaterialChannel.
+        Response secFilePath is a FIFO under /tmp for qemu-img --object secret,...,file= (MN filePath on cmd is ignored).
+        """
+        rsp = kvmagent.AgentResponse()
+        if not KEY_AGENT_GRPC_AVAILABLE:
+            rsp.success = False
+            rsp.error = 'key_agent grpc not available'
+            return jsonobject.dumps(rsp)
+        try:
+            cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        except Exception as e:
+            rsp.success = False
+            rsp.error = 'invalid request body: %s' % e
+            return jsonobject.dumps(rsp)
+        encrypted_dek_b64 = getattr(cmd, 'encryptedDek', None)
+        if not encrypted_dek_b64:
+            rsp.success = False
+            rsp.error = 'missing encryptedDek (non-empty)'
+            return jsonobject.dumps(rsp)
+        normalized_b64 = encrypted_dek_b64.strip()
+        if not re.match(r'^[A-Za-z0-9+/]+={0,2}$', normalized_b64) or len(normalized_b64) % 4 != 0:
+            rsp.success = False
+            rsp.error = 'encryptedDek must be valid base64'
+            return jsonobject.dumps(rsp)
+        try:
+            encrypted_dek = base64.b64decode(normalized_b64)
+            enc_again = base64.b64encode(encrypted_dek)
+            if not isinstance(enc_again, str):
+                enc_again = enc_again.decode('ascii')
+            if enc_again.rstrip('=') != normalized_b64.rstrip('='):
+                raise ValueError('non-canonical base64 input')
+        except Exception as e:
+            rsp.success = False
+            rsp.error = 'encryptedDek must be base64: %s' % e
+            return jsonobject.dumps(rsp)
+        channel_path, err_code, err_msg = self._prepare_luks_secret_material_channel(encrypted_dek)
+        if channel_path:
+            rsp.success = True
+            rsp.secFilePath = channel_path
+        else:
+            rsp.success = False
+            if err_code:
+                rsp.errorCode = err_code
+                rsp.error = err_msg or err_code
+            else:
+                rsp.error = err_msg or 'key-agent PrepareLuksSecretMaterialChannel failed'
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror
@@ -4654,6 +4739,7 @@ done
         http_server.register_async_uri(self.GET_ENVELOPE_PUBLIC_KEY_PATH, self.get_envelope_public_key)
         http_server.register_async_uri(self.CHECK_ENVELOPE_KEY_PATH, self.check_envelope_key)
         http_server.register_async_uri(self.ENSURE_SECRET_PATH, self.ensure_secret)
+        http_server.register_async_uri(self.WRITE_SECRET_MATERIAL_FILE_PATH, self.write_secret_material_file)
         http_server.register_async_uri(self.GET_SECRET_PATH, self.get_secret)
         http_server.register_async_uri(self.DELETE_SECRET_PATH, self.delete_secret)
 

--- a/kvmagent/kvmagent/plugins/localstorage.py
+++ b/kvmagent/kvmagent/plugins/localstorage.py
@@ -3,9 +3,12 @@ __author__ = 'frank'
 import os
 import os.path
 import traceback
+import base64
+from xml.sax.saxutils import escape as xml_escape
 
 import zstacklib.utils.uuidhelper as uuidhelper
 from kvmagent import kvmagent
+from kvmagent.plugins import volume_secret
 from kvmagent.plugins.imagestore import ImageStoreClient
 from kvmagent.plugins.nvram import nvram
 from zstacklib.utils import jsonobject
@@ -282,6 +285,8 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
     SCAN_VM_METADATA_PATH = "/localstorage/vm/metadata/scan"
     CLEANUP_VM_METADATA_PATH = "/localstorage/vm/metadata/cleanup"
     PREFIX_REBASE_BACKING_FILES_PATH = "/localstorage/snapshot/prefixrebasebackingfiles"
+    ENCRYPT_VOLUME_BITS_PATH = "/localstorage/volume/encryptinplace"
+    CONVERT_VOLUME_ENCRYPTION_PATH = "/localstorage/volume/convertencryption"
 
     _metadata_handler = FileBasedMetadataHandler()
 
@@ -339,6 +344,8 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
         http_server.register_async_uri(self.SCAN_VM_METADATA_PATH, self.scan_vm_metadata)
         http_server.register_async_uri(self.CLEANUP_VM_METADATA_PATH, self.cleanup_vm_metadata)
         http_server.register_async_uri(self.PREFIX_REBASE_BACKING_FILES_PATH, self.prefix_rebase_backing_files)
+        http_server.register_async_uri(self.ENCRYPT_VOLUME_BITS_PATH, self.encrypt_volume_bits)
+        http_server.register_async_uri(self.CONVERT_VOLUME_ENCRYPTION_PATH, self.convert_volume_encryption)
 
         self.imagestore_client = ImageStoreClient()
 
@@ -420,8 +427,13 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
 
         install_path = cmd.installPath
         rsp = ResizeVolumeRsp()
-        linux.qemu_img_resize(install_path, cmd.size, 'qcow2', cmd.force)
-        ret = linux.qcow2_virtualsize(install_path)
+        secret_material_file = getattr(cmd, 'encryptLuksSecretMaterialFilePath', None)
+        if secret_material_file:
+            linux.qemu_img_resize_with_secret(install_path, cmd.size, secret_material_file, cmd.force)
+            ret = linux.qcow2_get_virtual_size(install_path)
+        else:
+            linux.qemu_img_resize(install_path, cmd.size, 'qcow2', cmd.force)
+            ret = linux.qcow2_virtualsize(install_path)
         rsp.size = ret
         return jsonobject.dumps(rsp)
 
@@ -720,9 +732,14 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
     @kvmagent.replyerror
     def rebase_backing_files(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
         for sp in cmd.snapshots:
             if sp.parentPath:
-                linux.qcow2_rebase_no_check(sp.parentPath, sp.path)
+                if encrypted_dek:
+                    with volume_secret.luks_secret_channel(encrypted_dek) as secret_file:
+                        linux.qcow2_rebase_no_check_with_secret(sp.parentPath, sp.path, secret_file)
+                else:
+                    linux.qcow2_rebase_no_check(sp.parentPath, sp.path)
 
         return jsonobject.dumps(AgentResponse())
 
@@ -748,7 +765,13 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
         _0()
 
         t_shell = traceable_shell.get_shell(cmd)
-        linux.create_template(cmd.volumePath, cmd.installPath, shell=t_shell)
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
+        if encrypted_dek:
+            with volume_secret.luks_secret_channel(encrypted_dek) as secret_file:
+                linux.create_encrypted_template_with_secret(
+                    cmd.volumePath, cmd.installPath, secret_file, shell=t_shell)
+        else:
+            linux.create_template(cmd.volumePath, cmd.installPath, shell=t_shell)
 
         logger.debug('successfully created template[%s] from volume[%s]' % (cmd.installPath, cmd.volumePath))
 
@@ -802,7 +825,12 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
             os.makedirs(workspace_dir)
 
         t_shell = traceable_shell.get_shell(cmd)
-        linux.create_template(cmd.snapshotInstallPath, cmd.workspaceInstallPath, shell=t_shell)
+        if getattr(cmd, 'encryptLuksSecretMaterialFilePath', None):
+            linux.create_encrypted_template_with_secret(
+                cmd.snapshotInstallPath, cmd.workspaceInstallPath,
+                cmd.encryptLuksSecretMaterialFilePath, shell=t_shell)
+        else:
+            linux.create_template(cmd.snapshotInstallPath, cmd.workspaceInstallPath, shell=t_shell)
         rsp.size, rsp.actualSize = linux.qcow2_size_and_actual_size(cmd.workspaceInstallPath)
 
         rsp.totalCapacity, rsp.availableCapacity = self._get_disk_capacity(cmd.storagePath)
@@ -836,17 +864,27 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = OfflineMergeSnapshotRsp()
 
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
         src_path = cmd.srcPath if not cmd.fullRebase else ""
-        if linux.qcow2_get_backing_file(cmd.destPath) == src_path:
+        raw_backing = linux.qcow2_get_backing_file(cmd.destPath, normalize=False)
+        backing_needs_reset = encrypted_dek and raw_backing and raw_backing.startswith('json:')
+        if linux.qcow2_get_backing_file(cmd.destPath) == src_path and not backing_needs_reset:
             _, rsp.actualSize = linux.qcow2_size_and_actual_size(cmd.destPath)
             rsp.totalCapacity, rsp.availableCapacity = self._get_disk_capacity(cmd.storagePath)
             return jsonobject.dumps(rsp)
 
         if not cmd.fullRebase:
-            linux.qcow2_rebase(cmd.srcPath, cmd.destPath)
+            if encrypted_dek:
+                linux.qcow2_rebase_with_secret(cmd.srcPath, cmd.destPath,
+                                               lambda: volume_secret.luks_secret_channel(encrypted_dek))
+            else:
+                linux.qcow2_rebase(cmd.srcPath, cmd.destPath)
         else:
             tmp = os.path.join(os.path.dirname(cmd.destPath), '%s.qcow2' % uuidhelper.uuid())
-            qcow2.create_template_with_task_daemon(cmd.destPath, tmp, task_spec=cmd)
+            if encrypted_dek:
+                linux.create_encrypted_template_with_secret(cmd.destPath, tmp, volume_secret.make_luks_secret_file(encrypted_dek))
+            else:
+                qcow2.create_template_with_task_daemon(cmd.destPath, tmp, task_spec=cmd)
             shell.call("mv %s %s" % (tmp, cmd.destPath))
 
         self.imagestore_client.clean_meta(cmd.destPath)
@@ -860,13 +898,20 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = OfflineCommitSnapshotRsp()
 
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
         if linux.qcow2_get_backing_file(cmd.top) != linux.qcow2_get_backing_file(cmd.base):
-            linux.qcow2_commit(cmd.top, cmd.base)
+            if encrypted_dek:
+                linux.qcow2_commit_with_secret(cmd.top, cmd.base, volume_secret.make_luks_secret_file(encrypted_dek))
+            else:
+                linux.qcow2_commit(cmd.top, cmd.base)
 
         if cmd.topChildrenInstallPathInDb:
             for children in cmd.topChildrenInstallPathInDb:
                 if linux.qcow2_get_backing_file(children) != cmd.base:
-                    linux.qcow2_rebase_no_check(cmd.base, children)
+                    if encrypted_dek:
+                        linux.qcow2_rebase_no_check_with_secret(cmd.base, children, volume_secret.make_luks_secret_file(encrypted_dek))
+                    else:
+                        linux.qcow2_rebase_no_check(cmd.base, children)
 
         self.imagestore_client.clean_meta(cmd.base)
 
@@ -925,6 +970,7 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
     def create_empty_volume(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = CreateEmptyVolumeRsp()
+
         try:
             self.do_create_empty_volume(cmd)
         except Exception as e:
@@ -945,11 +991,112 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
 
         if cmd.volumeFormat == "raw":
             linux.raw_create(cmd.installUrl, cmd.size)
-        else:  # default: cmd.volumeFormat == "qcow2"
-            if cmd.backingFile:
+            return
+
+        # default: cmd.volumeFormat == "qcow2".
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
+        if cmd.backingFile:
+            if encrypted_dek:
+                opt = ""
+                if getattr(cmd, 'kvmHostAddons', None) is not None and cmd.kvmHostAddons.qcow2Options is not None:
+                    opt = cmd.kvmHostAddons.qcow2Options
+                with volume_secret.luks_secret_channel(encrypted_dek) as secret_file:
+                    linux.qcow2_clone_encrypted(cmd.backingFile, cmd.installUrl, secret_file, size=cmd.size, opt=opt)
+            else:
                 linux.qcow2_create_with_backing_file_and_cmd(cmd.backingFile, cmd.installUrl, cmd, cmd.size)
+        else:
+            if encrypted_dek:
+                opt = None
+                if getattr(cmd, 'kvmHostAddons', None) is not None and cmd.kvmHostAddons.qcow2Options is not None:
+                    opt = cmd.kvmHostAddons.qcow2Options
+                with volume_secret.luks_secret_channel(encrypted_dek) as secret_file:
+                    if opt:
+                        linux.qcow2_create_encrypted(cmd.installUrl, cmd.size, secret_file, opt=opt)
+                    else:
+                        linux.qcow2_create_encrypted(cmd.installUrl, cmd.size, secret_file)
             else:
                 linux.qcow2_create_with_cmd(cmd.installUrl, cmd.size, cmd)
+
+    @kvmagent.replyerror
+    def encrypt_volume_bits(self, req):
+        """
+        In-place LUKS encryption of a plain volume file on local storage.
+        Used by the data-volume-from-template path: after the plain template bits
+        have been downloaded into the volume's install path, this handler converts
+        them into a self-contained LUKS-encrypted qcow2 at the same path.
+        """
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = AgentResponse()
+        try:
+            encrypted_dek = getattr(cmd, 'encryptedDek', None)
+            secret_material_file = volume_secret.make_luks_secret_file(encrypted_dek)
+            linux.encrypt_plain_volume_in_place(cmd.installPath, secret_material_file)
+            logger.debug('successfully LUKS-encrypted volume bits at %s' % cmd.installPath)
+        except Exception as e:
+            logger.warn(linux.get_exception_stacktrace())
+            rsp.success = False
+            rsp.error = 'failed to LUKS-encrypt volume bits at %s: %s' % (cmd.installPath, str(e))
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def convert_volume_encryption(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = AgentResponse()
+        actual_sizes = {}
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
+        converted_items = []
+        converted_target_paths = {}
+        renamed_sources = []
+        finalized_targets = []
+
+        def rebase_secret_file(reason):
+            return volume_secret.luks_secret_channel(encrypted_dek)
+
+        try:
+            if cmd.targetEncrypted and not encrypted_dek:
+                raise Exception("target encrypted conversion requires encryptedDek")
+
+            for index, item in enumerate(cmd.items):
+                effective_target_path = "%s.converted.%s" % (item.targetInstallPath, uuidhelper.uuid())
+                target_backing_path = getattr(item, 'targetBackingInstallPath', None)
+                effective_backing_path = converted_target_paths.get(target_backing_path, target_backing_path)
+                secret_file_provider = (lambda: volume_secret.luks_secret_channel(encrypted_dek)) if encrypted_dek else None
+                actual_size = linux.convert_qcow2_volume_encryption(
+                    item.sourceInstallPath, effective_target_path, cmd.targetEncrypted,
+                    secret_file_provider, effective_backing_path)
+                actual_sizes[item.resourceUuid] = long(actual_size)
+                converted_items.append((item, effective_target_path, effective_backing_path, target_backing_path))
+                converted_target_paths[item.targetInstallPath] = effective_target_path
+
+            for item, _, _, _ in converted_items:
+                source_trash_path = getattr(item, 'sourceTrashInstallPath', None)
+                if source_trash_path:
+                    linux.move_file_no_overwrite(item.sourceInstallPath, source_trash_path)
+                    renamed_sources.append((source_trash_path, item.sourceInstallPath))
+
+            for item, effective_target_path, effective_backing_path, target_backing_path in converted_items:
+                if target_backing_path and effective_backing_path != target_backing_path:
+                    if cmd.targetEncrypted:
+                        with rebase_secret_file("final encrypted backing rebase") as reset_secret_file:
+                            linux.qcow2_rebase_no_check_with_secret(target_backing_path, effective_target_path, reset_secret_file)
+                    else:
+                        linux.qcow2_rebase_no_check(target_backing_path, effective_target_path)
+                if effective_target_path != item.targetInstallPath:
+                    linux.move_file_no_overwrite(effective_target_path, item.targetInstallPath)
+                    finalized_targets.append(item.targetInstallPath)
+            rsp.actualSizes = actual_sizes
+        except Exception as e:
+            logger.warn(linux.get_exception_stacktrace())
+            for target_path in finalized_targets:
+                linux.rm_file_force(target_path)
+            for item, effective_target_path, _, _ in converted_items:
+                linux.rm_file_force(effective_target_path)
+            for source_trash_path, source_path in reversed(renamed_sources):
+                if os.path.exists(source_trash_path) and not os.path.exists(source_path):
+                    linux.move_file_no_overwrite(source_trash_path, source_path)
+            rsp.success = False
+            rsp.error = 'failed to convert volume[%s] encryption: %s' % (cmd.volumeUuid, str(e))
+        return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror
     def create_volume_with_backing(self, req):
@@ -983,6 +1130,15 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
         dirname = os.path.dirname(vol_path)
         if not os.path.exists(dirname):
             os.makedirs(dirname, 0775)
+
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
+        if encrypted_dek:
+            with volume_secret.luks_secret_channel(encrypted_dek) as secret_file:
+                linux.qcow2_clone_with_secret(
+                    backing_path, vol_path, secret_file,
+                    size=getattr(cmd, 'virtualSize', 0) or "",
+                    kvm_host_addons=getattr(cmd, 'kvmHostAddons', None))
+            return
 
         linux.qcow2_clone_with_cmd(backing_path, vol_path, cmd)
 

--- a/kvmagent/kvmagent/plugins/nfs_primarystorage_plugin.py
+++ b/kvmagent/kvmagent/plugins/nfs_primarystorage_plugin.py
@@ -10,6 +10,7 @@ import traceback
 
 import zstacklib.utils.uuidhelper as uuidhelper
 from kvmagent import kvmagent
+from kvmagent.plugins import volume_secret
 from kvmagent.plugins.imagestore import ImageStoreClient
 from zstacklib.utils import jsonobject
 from zstacklib.utils import lock
@@ -289,6 +290,8 @@ class NfsPrimaryStoragePlugin(kvmagent.KvmAgent):
     CANCEL_DOWNLOAD_BITS_FROM_KVM_HOST_PATH = "/nfsprimarystorage/kvmhost/download/cancel"
     GET_DOWNLOAD_BITS_FROM_KVM_HOST_PROGRESS_PATH = "/nfsprimarystorage/kvmhost/download/progress"
     GET_QCOW2_HASH_VALUE_PATH = "/nfsprimarystorage/getqcow2hash"
+    ENCRYPT_VOLUME_BITS_PATH = "/nfsprimarystorage/volume/encryptinplace"
+    CONVERT_VOLUME_ENCRYPTION_PATH = "/nfsprimarystorage/volume/convertencryption"
     WRITE_VM_METADATA_PATH = "/nfsprimarystorage/vm/metadata/write"
     GET_VM_INSTANCE_METADATA_PATH = "/nfsprimarystorage/vm/metadata/get"
     SCAN_VM_METADATA_PATH = "/nfsprimarystorage/vm/metadata/scan"
@@ -341,6 +344,8 @@ class NfsPrimaryStoragePlugin(kvmagent.KvmAgent):
         http_server.register_async_uri(self.CANCEL_DOWNLOAD_BITS_FROM_KVM_HOST_PATH, self.cancel_download_from_kvmhost)
         http_server.register_async_uri(self.GET_DOWNLOAD_BITS_FROM_KVM_HOST_PROGRESS_PATH, self.get_download_bits_from_kvmhost_progress)
         http_server.register_async_uri(self.GET_QCOW2_HASH_VALUE_PATH, self.get_qcow2_hashvalue)
+        http_server.register_async_uri(self.ENCRYPT_VOLUME_BITS_PATH, self.encrypt_volume_bits)
+        http_server.register_async_uri(self.CONVERT_VOLUME_ENCRYPTION_PATH, self.convert_volume_encryption)
         http_server.register_async_uri(self.WRITE_VM_METADATA_PATH, self.write_vm_metadata)
         http_server.register_async_uri(self.GET_VM_INSTANCE_METADATA_PATH, self.get_vm_instance_metadata)
         http_server.register_async_uri(self.SCAN_VM_METADATA_PATH, self.scan_vm_metadata)
@@ -481,8 +486,13 @@ class NfsPrimaryStoragePlugin(kvmagent.KvmAgent):
 
         install_path = cmd.installPath
         rsp = ResizeVolumeRsp()
-        linux.qemu_img_resize(install_path, cmd.size, 'qcow2', cmd.force)
-        ret = linux.qcow2_virtualsize(install_path)
+        secret_material_file = getattr(cmd, 'encryptLuksSecretMaterialFilePath', None)
+        if secret_material_file:
+            linux.qemu_img_resize_with_secret(install_path, cmd.size, secret_material_file, cmd.force)
+            ret = linux.qcow2_get_virtual_size(install_path)
+        else:
+            linux.qemu_img_resize(install_path, cmd.size, 'qcow2', cmd.force)
+            ret = linux.qcow2_virtualsize(install_path)
         rsp.size = ret
         return jsonobject.dumps(rsp)
 
@@ -602,17 +612,27 @@ class NfsPrimaryStoragePlugin(kvmagent.KvmAgent):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = OfflineMergeSnapshotRsp()
 
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
         src_path = cmd.srcPath if not cmd.fullRebase else ""
-        if linux.qcow2_get_backing_file(cmd.destPath) == src_path:
+        raw_backing = linux.qcow2_get_backing_file(cmd.destPath, normalize=False)
+        backing_needs_reset = encrypted_dek and raw_backing and raw_backing.startswith('json:')
+        if linux.qcow2_get_backing_file(cmd.destPath) == src_path and not backing_needs_reset:
             _, rsp.actualSize = linux.qcow2_size_and_actual_size(cmd.destPath)
             self._set_capacity_to_response(cmd.uuid, rsp)
             return jsonobject.dumps(rsp)
 
         if not cmd.fullRebase:
-            linux.qcow2_rebase(cmd.srcPath, cmd.destPath)
+            if encrypted_dek:
+                linux.qcow2_rebase_with_secret(cmd.srcPath, cmd.destPath,
+                                               lambda: volume_secret.luks_secret_channel(encrypted_dek))
+            else:
+                linux.qcow2_rebase(cmd.srcPath, cmd.destPath)
         else:
             tmp = os.path.join(os.path.dirname(cmd.destPath), '%s.qcow2' % uuidhelper.uuid())
-            qcow2.create_template_with_task_daemon(cmd.destPath, tmp, task_spec=cmd)
+            if encrypted_dek:
+                linux.create_encrypted_template_with_secret(cmd.destPath, tmp, volume_secret.make_luks_secret_file(encrypted_dek))
+            else:
+                qcow2.create_template_with_task_daemon(cmd.destPath, tmp, task_spec=cmd)
             shell.call("mv %s %s" % (tmp, cmd.destPath))
 
         self.imagestore_client.clean_meta(cmd.destPath)
@@ -626,13 +646,20 @@ class NfsPrimaryStoragePlugin(kvmagent.KvmAgent):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = OfflineCommitSnapshotRsp()
 
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
         if linux.qcow2_get_backing_file(cmd.top) != linux.qcow2_get_backing_file(cmd.base):
-            linux.qcow2_commit(cmd.top, cmd.base)
+            if encrypted_dek:
+                linux.qcow2_commit_with_secret(cmd.top, cmd.base, volume_secret.make_luks_secret_file(encrypted_dek))
+            else:
+                linux.qcow2_commit(cmd.top, cmd.base)
 
         if cmd.topChildrenInstallPathInDb:
             for children in cmd.topChildrenInstallPathInDb:
                 if linux.qcow2_get_backing_file(children) != cmd.base:
-                    linux.qcow2_rebase_no_check(cmd.base, children)
+                    if encrypted_dek:
+                        linux.qcow2_rebase_no_check_with_secret(cmd.base, children, volume_secret.make_luks_secret_file(encrypted_dek))
+                    else:
+                        linux.qcow2_rebase_no_check(cmd.base, children)
 
         self.imagestore_client.clean_meta(cmd.base)
 
@@ -697,10 +724,15 @@ class NfsPrimaryStoragePlugin(kvmagent.KvmAgent):
 
         try:
             if cmd.incremental:
-                return linux.qcow2_create_with_backing_file_and_option(cmd.snapshotInstallPath, cmd.workspaceInstallPath)
+                linux.qcow2_create_with_backing_file_and_cmd(cmd.snapshotInstallPath, cmd.workspaceInstallPath, cmd)
             else:
                 t_shell = traceable_shell.get_shell(cmd)
-                linux.create_template(cmd.snapshotInstallPath, cmd.workspaceInstallPath, shell=t_shell)
+                if getattr(cmd, 'encryptLuksSecretMaterialFilePath', None):
+                    linux.create_encrypted_template_with_secret(
+                        cmd.snapshotInstallPath, cmd.workspaceInstallPath,
+                        cmd.encryptLuksSecretMaterialFilePath, shell=t_shell)
+                else:
+                    linux.create_template(cmd.snapshotInstallPath, cmd.workspaceInstallPath, shell=t_shell)
             rsp.size, rsp.actualSize = linux.qcow2_size_and_actual_size(cmd.workspaceInstallPath)
             self._set_capacity_to_response(cmd.uuid, rsp)
         except linux.LinuxError as e:
@@ -918,10 +950,28 @@ class NfsPrimaryStoragePlugin(kvmagent.KvmAgent):
             if cmd.volumeFormat == "raw":
                 linux.raw_create(cmd.installUrl, cmd.size)
             else:  # default: cmd.volumeFormat == "qcow2"
+                encrypted_dek = getattr(cmd, 'encryptedDek', None)
                 if cmd.backingFile:
-                    linux.qcow2_create_with_backing_file_and_cmd(cmd.backingFile, cmd.installUrl, cmd)
+                    if encrypted_dek:
+                        opt = ""
+                        if getattr(cmd, 'kvmHostAddons', None) is not None and cmd.kvmHostAddons.qcow2Options is not None:
+                            opt = cmd.kvmHostAddons.qcow2Options
+                        with volume_secret.luks_secret_channel(encrypted_dek) as secret_file:
+                            linux.qcow2_clone_encrypted(cmd.backingFile, cmd.installUrl, secret_file, opt=opt)
+                    else:
+                        linux.qcow2_create_with_backing_file_and_cmd(cmd.backingFile, cmd.installUrl, cmd)
                 else:
-                    linux.qcow2_create_with_cmd(cmd.installUrl, cmd.size, cmd)
+                    if encrypted_dek:
+                        opt = None
+                        if getattr(cmd, 'kvmHostAddons', None) is not None and cmd.kvmHostAddons.qcow2Options is not None:
+                            opt = cmd.kvmHostAddons.qcow2Options
+                        with volume_secret.luks_secret_channel(encrypted_dek) as secret_file:
+                            if opt:
+                                linux.qcow2_create_encrypted(cmd.installUrl, cmd.size, secret_file, opt=opt)
+                            else:
+                                linux.qcow2_create_encrypted(cmd.installUrl, cmd.size, secret_file)
+                    else:
+                        linux.qcow2_create_with_cmd(cmd.installUrl, cmd.size, cmd)
         try:
             _create_dir_and_file()
         except Exception as e:
@@ -938,6 +988,87 @@ class NfsPrimaryStoragePlugin(kvmagent.KvmAgent):
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror
+    def encrypt_volume_bits(self, req):
+        """
+        In-place LUKS encryption of a plain volume file on NFS primary storage.
+        Used by the data-volume-from-template path: after the plain template bits
+        have been downloaded into the volume's install path, this handler converts
+        them into a self-contained LUKS-encrypted qcow2 at the same path.
+        """
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = kvmagent.AgentResponse()
+        try:
+            encrypted_dek = getattr(cmd, 'encryptedDek', None)
+            secret_material_file = volume_secret.make_luks_secret_file(encrypted_dek)
+            linux.encrypt_plain_volume_in_place(cmd.installPath, secret_material_file)
+            logger.debug('successfully LUKS-encrypted volume bits at %s' % cmd.installPath)
+        except Exception as e:
+            logger.warn(linux.get_exception_stacktrace())
+            rsp.success = False
+            rsp.error = 'failed to LUKS-encrypt volume bits at %s: %s' % (cmd.installPath, str(e))
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def convert_volume_encryption(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = kvmagent.AgentResponse()
+        actual_sizes = {}
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
+        converted_items = []
+        converted_target_paths = {}
+        renamed_sources = []
+        finalized_targets = []
+
+        def rebase_secret_file(reason):
+            return volume_secret.luks_secret_channel(encrypted_dek)
+
+        try:
+            if cmd.targetEncrypted and not encrypted_dek:
+                raise Exception("target encrypted conversion requires encryptedDek")
+
+            for index, item in enumerate(cmd.items):
+                effective_target_path = "%s.converted.%s" % (item.targetInstallPath, uuidhelper.uuid())
+                target_backing_path = getattr(item, 'targetBackingInstallPath', None)
+                effective_backing_path = converted_target_paths.get(target_backing_path, target_backing_path)
+                secret_file_provider = (lambda: volume_secret.luks_secret_channel(encrypted_dek)) if encrypted_dek else None
+                actual_size = linux.convert_qcow2_volume_encryption(
+                    item.sourceInstallPath, effective_target_path, cmd.targetEncrypted,
+                    secret_file_provider, effective_backing_path)
+                actual_sizes[item.resourceUuid] = long(actual_size)
+                converted_items.append((item, effective_target_path, effective_backing_path, target_backing_path))
+                converted_target_paths[item.targetInstallPath] = effective_target_path
+
+            for item, _, _, _ in converted_items:
+                source_trash_path = getattr(item, 'sourceTrashInstallPath', None)
+                if source_trash_path:
+                    linux.move_file_no_overwrite(item.sourceInstallPath, source_trash_path)
+                    renamed_sources.append((source_trash_path, item.sourceInstallPath))
+
+            for item, effective_target_path, effective_backing_path, target_backing_path in converted_items:
+                if target_backing_path and effective_backing_path != target_backing_path:
+                    if cmd.targetEncrypted:
+                        with rebase_secret_file("final encrypted backing rebase") as reset_secret_file:
+                            linux.qcow2_rebase_no_check_with_secret(target_backing_path, effective_target_path, reset_secret_file)
+                    else:
+                        linux.qcow2_rebase_no_check(target_backing_path, effective_target_path)
+                if effective_target_path != item.targetInstallPath:
+                    linux.move_file_no_overwrite(effective_target_path, item.targetInstallPath)
+                    finalized_targets.append(item.targetInstallPath)
+            rsp.actualSizes = actual_sizes
+        except Exception as e:
+            logger.warn(linux.get_exception_stacktrace())
+            for target_path in finalized_targets:
+                linux.rm_file_force(target_path)
+            for item, effective_target_path, _, _ in converted_items:
+                linux.rm_file_force(effective_target_path)
+            for source_trash_path, source_path in reversed(renamed_sources):
+                if os.path.exists(source_trash_path) and not os.path.exists(source_path):
+                    linux.move_file_no_overwrite(source_trash_path, source_path)
+            rsp.success = False
+            rsp.error = 'failed to convert volume[%s] encryption: %s' % (cmd.volumeUuid, str(e))
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
     def create_template_from_root_volume(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = CreateTemplateFromRootVolumeRsp()
@@ -947,7 +1078,13 @@ class NfsPrimaryStoragePlugin(kvmagent.KvmAgent):
                 os.makedirs(dirname, 0755)
 
             t_shell = traceable_shell.get_shell(cmd)
-            linux.create_template(cmd.rootVolumePath, cmd.installPath, shell=t_shell)
+            encrypted_dek = getattr(cmd, 'encryptedDek', None)
+            if encrypted_dek:
+                with volume_secret.luks_secret_channel(encrypted_dek) as secret_file:
+                    linux.create_encrypted_template_with_secret(
+                        cmd.rootVolumePath, cmd.installPath, secret_file, shell=t_shell)
+            else:
+                linux.create_template(cmd.rootVolumePath, cmd.installPath, shell=t_shell)
             rsp.size, rsp.actualSize = linux.qcow2_size_and_actual_size(cmd.installPath)
         except linux.LinuxError as e:
             linux.rm_file_force(cmd.installPath)
@@ -1023,6 +1160,7 @@ class NfsPrimaryStoragePlugin(kvmagent.KvmAgent):
             err = 'unable to clone qcow2 template[%s] to %s' % (cmd.templatePathInCache, cmd.installUrl)
             rsp.error = err
             rsp.success = False
+            return jsonobject.dumps(rsp)
 
         rsp.size, rsp.actualSize = linux.qcow2_size_and_actual_size(cmd.installUrl)
         return jsonobject.dumps(rsp)
@@ -1032,6 +1170,17 @@ class NfsPrimaryStoragePlugin(kvmagent.KvmAgent):
         dirname = os.path.dirname(vol_path)
         if not os.path.exists(dirname):
             os.makedirs(dirname, 0775)
+
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
+        if encrypted_dek:
+            opt = ""
+            if getattr(cmd, 'kvmHostAddons', None) is not None and cmd.kvmHostAddons.qcow2Options is not None:
+                opt = cmd.kvmHostAddons.qcow2Options
+            with volume_secret.luks_secret_channel(encrypted_dek) as secret_file:
+                linux.qcow2_clone_encrypted(
+                    backing_path, vol_path, secret_file,
+                    size=getattr(cmd, 'virtualSize', 0) or "", opt=opt)
+            return
 
         linux.qcow2_clone_with_cmd(backing_path, vol_path, cmd)
 

--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -5,6 +5,7 @@ import random
 import traceback
 
 from kvmagent import kvmagent
+from kvmagent.plugins import volume_secret
 from kvmagent.plugins.imagestore import ImageStoreClient
 from zstacklib.utils import jsonobject
 from zstacklib.utils import shell
@@ -31,6 +32,7 @@ DEFAULT_VG_METADATA_SIZE = "2g"
 DEFAULT_SANLOCK_LV_SIZE = "1024"
 QMP_SOCKET_PATH = "/var/lib/libvirt/qemu/zstack"
 MAX_ACTUAL_SIZE_FACTOR = 3
+LUKS_HEADER_OVERHEAD = 8 * 1024 * 1024
 
 
 class AgentRsp(object):
@@ -135,6 +137,12 @@ class ConvertVolumeFormatRsp(AgentRsp):
     def __init__(self):
         super(ConvertVolumeFormatRsp, self).__init__()
         self.size = None
+
+
+class ConvertVolumeEncryptionRsp(AgentRsp):
+    def __init__(self):
+        super(ConvertVolumeEncryptionRsp, self).__init__()
+        self.actualSizes = {}
 
 
 class RetryException(Exception):
@@ -421,6 +429,8 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
     SCAN_VM_METADATA_PATH = "/sharedblock/vm/metadata/scan"
     CLEANUP_VM_METADATA_PATH = "/sharedblock/vm/metadata/cleanup"
     PREFIX_REBASE_BACKING_FILES_PATH = "/sharedblock/snapshot/prefixrebasebackingfiles"
+    ENCRYPT_VOLUME_BITS_PATH = "/sharedblock/volume/encryptinplace"
+    CONVERT_VOLUME_ENCRYPTION_PATH = "/sharedblock/volume/convertencryption"
 
     _metadata_handler = SblkMetadataHandler(lvm, bash)
 
@@ -483,6 +493,8 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         http_server.register_async_uri(self.CLEANUP_VM_METADATA_PATH, self.cleanup_vm_metadata)
         http_server.register_async_uri(self.GET_VM_INSTANCE_METADATA_PATH, self.get_vm_instance_metadata)
         http_server.register_async_uri(self.PREFIX_REBASE_BACKING_FILES_PATH, self.prefix_rebase_backing_files)
+        http_server.register_async_uri(self.ENCRYPT_VOLUME_BITS_PATH, self.encrypt_volume_bits)
+        http_server.register_async_uri(self.CONVERT_VOLUME_ENCRYPTION_PATH, self.convert_volume_encryption)
 
         self.imagestore_client = ImageStoreClient()
 
@@ -890,16 +902,26 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
     def resize_volume(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         install_abs_path = translate_absolute_path_from_install_path(cmd.installPath)
+        secret_material_file = getattr(cmd, 'encryptLuksSecretMaterialFilePath', None)
+        encrypted = bool(getattr(cmd, 'encrypted', False) or secret_material_file)
+        lv_size = int(cmd.size) + LUKS_HEADER_OVERHEAD if encrypted else cmd.size
 
         with lvm.RecursiveOperateLv(install_abs_path, shared=False):
             if cmd.force:
-                lvm.resize_lv(install_abs_path, cmd.size, True)
+                lvm.resize_lv(install_abs_path, lv_size, True)
             else:
-                lvm.extend_lv_from_cmd(install_abs_path, cmd.size, cmd)
+                lvm.extend_lv_from_cmd(install_abs_path, lv_size, cmd)
             fmt = linux.get_img_fmt(install_abs_path)
             if not cmd.live and fmt == 'qcow2':
-                linux.qemu_img_resize(install_abs_path, cmd.size, 'qcow2', cmd.force, skip_if_sufficient=True)
-            ret = linux.qcow2_virtualsize(install_abs_path)
+                if secret_material_file:
+                    linux.qemu_img_resize_with_secret(install_abs_path, cmd.size, secret_material_file,
+                                                      cmd.force, skip_if_sufficient=True)
+                elif encrypted:
+                    raise Exception("encrypted shared block volume resize requires LUKS secret material file")
+                else:
+                    linux.qemu_img_resize(install_abs_path, cmd.size, 'qcow2', cmd.force, skip_if_sufficient=True)
+            ret = cmd.size if cmd.live and encrypted else (
+                linux.qcow2_get_virtual_size(install_abs_path) if encrypted else linux.qcow2_virtualsize(install_abs_path))
 
         rsp = ResizeVolumeRsp()
         rsp.size = ret
@@ -926,6 +948,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         template_abs_path_cache = translate_absolute_path_from_install_path(cmd.templatePathInCache)
         install_abs_path = translate_absolute_path_from_install_path(cmd.installPath)
         qcow2_options = self.calc_qcow2_option(self, cmd.kvmHostAddons, True, cmd.provisioning)
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
 
         with lvm.RecursiveOperateLv(template_abs_path_cache, shared=True, skip_deactivate_tags=[IMAGE_TAG]):
             if cmd.virtualSize:
@@ -934,8 +957,15 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
                 virtual_size = linux.qcow2_virtualsize(template_abs_path_cache)
             lvm.create_lv_from_cmd(install_abs_path, virtual_size, cmd,
                                    "%s::%s::%s" % (VOLUME_TAG, cmd.hostUuid, time.time()), lvmlock=False)
-            size = cmd.virtualSize if cmd.virtualSize else ""
-            linux.qcow2_clone_with_option(template_abs_path_cache, install_abs_path, qcow2_options, size)
+            size = cmd.virtualSize if cmd.virtualSize else virtual_size
+            if encrypted_dek:
+                with volume_secret.luks_secret_channel(encrypted_dek) as secret_material_file:
+                    lvm.extend_lv(install_abs_path, int(virtual_size) + LUKS_HEADER_OVERHEAD,
+                                  skip_if_sufficient=True)
+                    linux.qcow2_clone_encrypted(template_abs_path_cache, install_abs_path,
+                                                secret_material_file, size=size, opt=qcow2_options)
+            else:
+                linux.qcow2_clone_with_option(template_abs_path_cache, install_abs_path, qcow2_options, size)
 
         virtual_size = linux.qcow2_get_virtual_size(install_abs_path)
         lvm.deactive_lv(install_abs_path)
@@ -991,6 +1021,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         rsp = CreateTemplateFromVolumeRsp()
         volume_abs_path = translate_absolute_path_from_install_path(cmd.volumePath)
         install_abs_path = translate_absolute_path_from_install_path(cmd.installPath)
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
 
         if cmd.sharedVolume:
             lvm.do_active_lv(volume_abs_path, lvm.LvmlockdLockType.SHARE, True)
@@ -998,12 +1029,19 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         with lvm.RecursiveOperateLv(volume_abs_path, shared=cmd.sharedVolume, skip_deactivate_tags=[IMAGE_TAG]):
             if not lvm.lv_exists(install_abs_path):
                 total_size = self.get_total_required_size(volume_abs_path)
+                if encrypted_dek:
+                    total_size += LUKS_HEADER_OVERHEAD
                 lvm.update_pv_allocate_strategy(cmd)
                 lvm.create_lv_from_absolute_path(install_abs_path, total_size,
                                                  "%s::%s::%s" % (VOLUME_TAG, cmd.hostUuid, time.time()))
             with lvm.OperateLv(install_abs_path, shared=False, delete_when_exception=True):
                 t_shell = traceable_shell.get_shell(cmd)
-                linux.create_template(volume_abs_path, install_abs_path, shell=t_shell)
+                if encrypted_dek:
+                    with volume_secret.luks_secret_channel(encrypted_dek) as secret_file:
+                        linux.create_encrypted_template_with_secret(
+                            volume_abs_path, install_abs_path, secret_file, shell=t_shell)
+                else:
+                    linux.create_template(volume_abs_path, install_abs_path, shell=t_shell)
                 logger.debug('successfully created template[%s] from volume[%s]' % (cmd.installPath, cmd.volumePath))
 
                 if cmd.compareQcow2:
@@ -1032,15 +1070,23 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         rsp = CreateTemplateFromVolumeRsp()
         volume_abs_path = translate_absolute_path_from_install_path(cmd.volumePath)
         install_abs_path = translate_absolute_path_from_install_path(cmd.installPath)
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
 
         with lvm.RecursiveOperateLv(volume_abs_path, shared=True, skip_deactivate_tags=[IMAGE_TAG]):
             if not lvm.lv_exists(install_abs_path):
                 total_size = self.get_total_required_size(volume_abs_path)
+                if encrypted_dek:
+                    total_size += LUKS_HEADER_OVERHEAD
                 lvm.update_pv_allocate_strategy(cmd)
                 lvm.create_lv_from_absolute_path(install_abs_path, total_size, IMAGE_TAG)
             with lvm.OperateLv(install_abs_path, shared=False, delete_when_exception=True):
                 t_shell = traceable_shell.get_shell(cmd)
-                linux.create_template(volume_abs_path, install_abs_path, shell=t_shell)
+                if encrypted_dek:
+                    with volume_secret.luks_secret_channel(encrypted_dek) as secret_file:
+                        linux.create_encrypted_template_with_secret(
+                            volume_abs_path, install_abs_path, secret_file, shell=t_shell)
+                else:
+                    linux.create_template(volume_abs_path, install_abs_path, shell=t_shell)
                 logger.debug('successfully created template cache [%s] from volume[%s]' % (cmd.installPath, cmd.volumePath))
 
                 if cmd.compareQcow2:
@@ -1170,6 +1216,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         rsp = RevertVolumeFromSnapshotRsp()
         snapshot_abs_path = translate_absolute_path_from_install_path(cmd.snapshotInstallPath)
         qcow2_options = self.calc_qcow2_option(self, cmd.kvmHostAddons, True, cmd.provisioning)
+        secret_material_file = getattr(cmd, 'encryptLuksSecretMaterialFilePath', None)
         new_volume_path = cmd.installPath
         if new_volume_path is None or new_volume_path == "":
             new_volume_path = "/dev/%s/%s" % (cmd.vgUuid, uuidhelper.uuid())
@@ -1178,12 +1225,17 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
 
         with lvm.RecursiveOperateLv(snapshot_abs_path, shared=True):
             size = linux.qcow2_virtualsize(snapshot_abs_path)
+            lv_size = int(size) + LUKS_HEADER_OVERHEAD if secret_material_file else size
             pe_ranges = lvm.get_lv_affinity_sorted_pvs(snapshot_abs_path, cmd)
-            lvm.create_lv_from_cmd(new_volume_path, size, cmd,
+            lvm.create_lv_from_cmd(new_volume_path, lv_size, cmd,
                                              "%s::%s::%s" % (VOLUME_TAG, cmd.hostUuid, time.time()), pe_ranges=pe_ranges)
             with lvm.OperateLv(new_volume_path, shared=False, delete_when_exception=True):
-                linux.qcow2_clone_with_option(snapshot_abs_path, new_volume_path, qcow2_options)
-                size = linux.qcow2_virtualsize(new_volume_path)
+                if secret_material_file:
+                    linux.qcow2_clone_encrypted(snapshot_abs_path, new_volume_path,
+                                                secret_material_file, size=size, opt=qcow2_options)
+                else:
+                    linux.qcow2_clone_with_option(snapshot_abs_path, new_volume_path, qcow2_options)
+                    size = linux.qcow2_virtualsize(new_volume_path)
 
         rsp.newVolumeInstallPath = new_volume_path
         rsp.size = size
@@ -1195,11 +1247,14 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         rsp = MergeSnapshotRsp()
         snapshot_abs_path = translate_absolute_path_from_install_path(cmd.snapshotInstallPath)
         workspace_abs_path = translate_absolute_path_from_install_path(cmd.workspaceInstallPath)
+        secret_material_file = getattr(cmd, 'encryptLuksSecretMaterialFilePath', None)
 
         lvm.update_pv_allocate_strategy(cmd)
         with lvm.RecursiveOperateLv(snapshot_abs_path, shared=True):
             virtual_size = linux.qcow2_virtualsize(snapshot_abs_path)
             lv_size = max(self.get_total_required_size(snapshot_abs_path), int(lvm.get_lv_size(snapshot_abs_path)))
+            if secret_material_file:
+                lv_size += LUKS_HEADER_OVERHEAD
             if not lvm.lv_exists(workspace_abs_path):
                 pe_ranges = lvm.get_lv_affinity_sorted_pvs(snapshot_abs_path, cmd)
                 lvm.create_lv_from_absolute_path(workspace_abs_path, lv_size,
@@ -1208,7 +1263,11 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
                                                  exact_size=True)
             with lvm.OperateLv(workspace_abs_path, shared=False, delete_when_exception=True):
                 t_shell = traceable_shell.get_shell(cmd)
-                linux.create_template(snapshot_abs_path, workspace_abs_path, shell=t_shell)
+                if secret_material_file:
+                    linux.create_encrypted_template_with_secret(
+                        snapshot_abs_path, workspace_abs_path, secret_material_file, shell=t_shell)
+                else:
+                    linux.create_template(snapshot_abs_path, workspace_abs_path, shell=t_shell)
                 rsp.size = virtual_size
                 rsp.actualSize = int(lvm.get_lv_size(workspace_abs_path))
 
@@ -1249,36 +1308,50 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         rsp = OfflineMergeSnapshotRsp()
         src_abs_path = translate_absolute_path_from_install_path(cmd.srcPath) if not cmd.fullRebase else ""
         dst_abs_path = translate_absolute_path_from_install_path(cmd.destPath)
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
 
-        with lvm.RecursiveOperateLv(dst_abs_path, shared=False, skip_deactivate_tags=[IMAGE_TAG]):
-            if linux.qcow2_get_backing_file(dst_abs_path) == src_abs_path:
+        try:
+            with lvm.RecursiveOperateLv(dst_abs_path, shared=False, skip_deactivate_tags=[IMAGE_TAG]):
+                raw_backing = linux.qcow2_get_backing_file(dst_abs_path, normalize=False)
+                backing_needs_reset = encrypted_dek and raw_backing and raw_backing.startswith('json:')
+                if linux.qcow2_get_backing_file(dst_abs_path) == src_abs_path and not backing_needs_reset:
+                    rsp.actualSize = lvm.get_lv_size(dst_abs_path)
+                    rsp.totalCapacity, rsp.availableCapacity = lvm.get_vg_size(cmd.vgUuid)
+                    return jsonobject.dumps(rsp)
+
+                total_required_size = self.get_total_required_size(dst_abs_path)
+                current_size = int(lvm.get_lv_size(dst_abs_path))
+                if not cmd.fullRebase:
+                    if current_size < total_required_size:
+                        lvm.extend_lv_from_cmd(dst_abs_path, total_required_size, cmd, extend_thin_by_specified_size=True)
+
+                    with lvm.RecursiveOperateLv(src_abs_path, shared=True):
+                        if encrypted_dek:
+                            linux.qcow2_rebase_with_secret(src_abs_path, dst_abs_path,
+                                                           lambda: volume_secret.luks_secret_channel(encrypted_dek))
+                        else:
+                            linux.qcow2_rebase(src_abs_path, dst_abs_path)
+                else:
+                    tmp_abs_path = os.path.join(os.path.dirname(dst_abs_path), 'tmp_%s' % uuidhelper.uuid())
+                    logger.debug("creating temp lv %s" % tmp_abs_path)
+                    lv_size = max(total_required_size, current_size)
+                    if encrypted_dek:
+                        lv_size += LUKS_HEADER_OVERHEAD
+                    pe_ranges = lvm.get_lv_affinity_sorted_pvs(dst_abs_path, cmd)
+                    lvm.create_lv_from_absolute_path(tmp_abs_path, lv_size,
+                                                     "%s::%s::%s" % (VOLUME_TAG, cmd.hostUuid, time.time()),
+                                                     pe_ranges=pe_ranges,
+                                                     exact_size=True)
+                    with lvm.OperateLv(tmp_abs_path, shared=False, delete_when_exception=True):
+                        if encrypted_dek:
+                            linux.create_encrypted_template_with_secret(dst_abs_path, tmp_abs_path, volume_secret.make_luks_secret_file(encrypted_dek))
+                        else:
+                            qcow2.create_template_with_task_daemon(dst_abs_path, tmp_abs_path, task_spec=cmd)
+                        lvm.lv_rename(tmp_abs_path, dst_abs_path, overwrite=True)
+                lvm.delete_lv_meta(dst_abs_path)
                 rsp.actualSize = lvm.get_lv_size(dst_abs_path)
-                rsp.totalCapacity, rsp.availableCapacity = lvm.get_vg_size(cmd.vgUuid)
-                return jsonobject.dumps(rsp)
-
-            total_required_size = self.get_total_required_size(dst_abs_path)
-            current_size = int(lvm.get_lv_size(dst_abs_path))
-            if not cmd.fullRebase:
-                if current_size < total_required_size:
-                    lvm.extend_lv_from_cmd(dst_abs_path, total_required_size, cmd, extend_thin_by_specified_size=True)
-
-                with lvm.RecursiveOperateLv(src_abs_path, shared=True):
-                    linux.qcow2_rebase(src_abs_path, dst_abs_path)
-            else:
-                tmp_abs_path = os.path.join(os.path.dirname(dst_abs_path), 'tmp_%s' % uuidhelper.uuid())
-                logger.debug("creating temp lv %s" % tmp_abs_path)
-                lv_size = max(total_required_size, current_size)
-                pe_ranges = lvm.get_lv_affinity_sorted_pvs(dst_abs_path, cmd)
-                lvm.create_lv_from_absolute_path(tmp_abs_path, lv_size,
-                                                 "%s::%s::%s" % (VOLUME_TAG, cmd.hostUuid, time.time()),
-                                                 pe_ranges=pe_ranges,
-                                                 exact_size=True)
-                with lvm.OperateLv(tmp_abs_path, shared=False, delete_when_exception=True):
-                    qcow2.create_template_with_task_daemon(dst_abs_path, tmp_abs_path, task_spec=cmd)
-                    lvm.lv_rename(tmp_abs_path, dst_abs_path, overwrite=True)
-            lvm.delete_lv_meta(dst_abs_path)
-            rsp.actualSize = lvm.get_lv_size(dst_abs_path)
-        rsp.totalCapacity, rsp.availableCapacity = lvm.get_vg_size(cmd.vgUuid)
+        finally:
+            rsp.totalCapacity, rsp.availableCapacity = lvm.get_vg_size(cmd.vgUuid)
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror
@@ -1287,16 +1360,22 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         rsp = OfflineCommitSnapshotRsp()
         top = translate_absolute_path_from_install_path(cmd.top)
         base = translate_absolute_path_from_install_path(cmd.base)
-
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
         with lvm.RecursiveOperateLv(top, shared=True):
-            if linux.qcow2_get_backing_file(cmd.top) != linux.qcow2_get_backing_file(cmd.base):
-                linux.qcow2_commit(cmd.top, cmd.base)
+            if linux.qcow2_get_backing_file(top) != linux.qcow2_get_backing_file(base):
+                if encrypted_dek:
+                    linux.qcow2_commit_with_secret(top, base, volume_secret.make_luks_secret_file(encrypted_dek))
+                else:
+                    linux.qcow2_commit(top, base)
 
             if cmd.topChildrenInstallPathInDb:
                 for childrenInstallPath in cmd.topChildrenInstallPathInDb:
                     with lvm.RecursiveOperateLv(childrenInstallPath, shared=True):
                         if linux.qcow2_get_backing_file(childrenInstallPath) != base:
-                            linux.qcow2_rebase_no_check(base, childrenInstallPath)
+                            if encrypted_dek:
+                                linux.qcow2_rebase_no_check_with_secret(base, childrenInstallPath, volume_secret.make_luks_secret_file(encrypted_dek))
+                            else:
+                                linux.qcow2_rebase_no_check(base, childrenInstallPath)
 
             lvm.delete_lv_meta(base)
 
@@ -1311,6 +1390,13 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         rsp = CreateEmptyVolumeRsp()
 
         install_abs_path = translate_absolute_path_from_install_path(cmd.installPath)
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
+
+        def make_secret():
+            if encrypted_dek:
+                return volume_secret.make_luks_secret_file(encrypted_dek)
+
+        is_encrypted = bool(encrypted_dek)
 
         if cmd.backingFile:
             qcow2_options = self.calc_qcow2_option(self, cmd.kvmHostAddons, True, cmd.provisioning)
@@ -1322,7 +1408,13 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
                     lvm.create_lv_from_cmd(install_abs_path, virtual_size, cmd,
                                                      "%s::%s::%s" % (VOLUME_TAG, cmd.hostUuid, time.time()))
                 with lvm.OperateLv(install_abs_path, shared=False, delete_when_exception=True):
-                    linux.qcow2_create_with_backing_file_and_option(backing_abs_path, install_abs_path, qcow2_options)
+                    if is_encrypted:
+                        lvm.extend_lv(install_abs_path, int(virtual_size) + LUKS_HEADER_OVERHEAD,
+                                      skip_if_sufficient=True)
+                        linux.qcow2_clone_encrypted(backing_abs_path, install_abs_path,
+                                                    make_secret(), size=virtual_size, opt=qcow2_options)
+                    else:
+                        linux.qcow2_create_with_backing_file_and_option(backing_abs_path, install_abs_path, qcow2_options)
                     rsp.size = linux.qcow2_virtualsize(install_abs_path)
         elif not lvm.lv_exists(install_abs_path):
             lvm.create_lv_from_cmd(install_abs_path, cmd.size, cmd,
@@ -1330,8 +1422,17 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             if cmd.volumeFormat != 'raw':
                 qcow2_options = self.calc_qcow2_option(self, cmd.kvmHostAddons, False, cmd.provisioning)
                 with lvm.OperateLv(install_abs_path, shared=False, delete_when_exception=True):
-                    linux.qcow2_create_with_option(install_abs_path, cmd.size, qcow2_options, discard_on_metadata=False)
-                    if cmd.zeroFilled:
+                    if is_encrypted:
+                        lvm.extend_lv(install_abs_path, int(cmd.size) + LUKS_HEADER_OVERHEAD,
+                                      skip_if_sufficient=True)
+                        linux.qcow2_create_encrypted(install_abs_path, cmd.size,
+                                                     make_secret(), opt=qcow2_options)
+                    else:
+                        linux.qcow2_create_with_option(install_abs_path, cmd.size, qcow2_options, discard_on_metadata=False)
+                    if cmd.zeroFilled and not is_encrypted:
+                        # Skip zero-fill on LUKS volumes: qcow2 LUKS clusters are
+                        # always cipher-noise so a deliberate-zero pre-pass adds
+                        # nothing and just wastes IO.
                         linux.qcow2_fill(0, 1048576, install_abs_path)
                     rsp.size = linux.qcow2_virtualsize(install_abs_path)
 
@@ -1352,6 +1453,175 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             lvm.add_lv_tag(install_abs_path, "%s::%s::%s" % (VOLUME_TAG, cmd.hostUuid, time.time()))
 
         lvm.delete_lv_meta(install_abs_path)
+
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    @lock.file_lock(LOCK_FILE)
+    def encrypt_volume_bits(self, req):
+        """
+        In-place LUKS encryption of a plain volume on a SharedBlock LV.
+
+        Strategy (block-device path; cannot mv-overwrite like LocalStorage):
+          1. lvcreate a sibling tmp LV in the same VG, sized = src + LUKS header
+             overhead so qemu-img convert has room for the LUKS header.
+          2. qemu-img convert  -f <auto>  -O luks  (or -O qcow2 + encrypt.format=luks)
+             src  ->  tmp_lv.  Source format dispatches per
+             linux.encrypt_plain_volume_block_to_block:
+                 raw   -> -O luks         (standalone LUKS, guest sees raw)
+                 qcow2 -> -O qcow2 +encrypt.format=luks (LUKS-in-qcow2)
+          3. Replace src with tmp_lv via lvrename (atomic, O(1), no data copy):
+                 lvrename src     -> <src>.old.<ts>
+                lvrename tmp_lv  -> src           tmp now lives at the install path
+                 lvremove <src>.old.<ts>
+             lvm.lv_rename(..., overwrite=True) implements exactly this dance.
+          4. On any failure, lvremove the tmp LV best-effort.
+        """
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = AgentRsp()
+        tmp_lv_path = None
+        try:
+            install_abs_path = translate_absolute_path_from_install_path(cmd.installPath)
+            encrypted_dek = getattr(cmd, 'encryptedDek', None)
+            sec_file = volume_secret.make_luks_secret_file(encrypted_dek)
+
+            with lvm.OperateLv(install_abs_path, shared=False):
+                # qemu-img convert -O luks needs dst >= src virtual size + LUKS
+                # header (~2MB). On a raw LV, virtual size = block device size.
+                # We make dst strictly larger by LUKS_HEADER_OVERHEAD;
+                # `create_lv_from_cmd` internally re-pads via calcLvReservedSize
+                # so dst ends up larger than src by the LUKS and LVM margins.
+                # We deliberately do NOT touch src -- growing src would only
+                # enlarge what qemu-img has to write into LUKS payload.
+                src_size = int(lvm.get_lv_size(install_abs_path))
+                dst_request_size = src_size + LUKS_HEADER_OVERHEAD
+
+                vg_uuid = cmd.vgUuid
+                tmp_lv_name = "%s-encrypting-%s" % (
+                    os.path.basename(install_abs_path), uuidhelper.uuid()[:8])
+                tmp_lv_path = "/dev/%s/%s" % (vg_uuid, tmp_lv_name)
+                lvm.create_lv_from_cmd(tmp_lv_path, dst_request_size, cmd,
+                                       "%s::%s::%s" % (VOLUME_TAG, cmd.hostUuid, time.time()))
+
+                with lvm.OperateLv(tmp_lv_path, shared=False, delete_when_exception=True):
+                    # Run the LUKS convert: tmp_lv now holds [LUKS header | encrypted payload].
+                    linux.encrypt_plain_volume_block_to_block(install_abs_path, tmp_lv_path, sec_file)
+
+                # Atomic swap: tmp_lv takes over the install path, original src
+                # LV is renamed aside and then removed. lvm.lv_rename(overwrite=True)
+                # does the 3-step dance internally; if the second rename fails it
+                # rolls back. After success, tmp_lv_path no longer exists -- the
+                # encrypted bits live at install_abs_path under the original name.
+                lvm.lv_rename(tmp_lv_path, install_abs_path, overwrite=True)
+                tmp_lv_path = None     # ownership transferred; nothing to clean
+
+            logger.debug('successfully LUKS-encrypted volume bits at %s' % install_abs_path)
+        except Exception as e:
+            logger.warn(linux.get_exception_stacktrace())
+            rsp.success = False
+            rsp.error = 'failed to LUKS-encrypt volume bits at %s: %s' % (cmd.installPath, str(e))
+        finally:
+            # Reap leftover tmp LV when the convert / rename never completed.
+            # On the happy path tmp_lv_path was set to None right after lv_rename,
+            # so this is a no-op then.
+            if tmp_lv_path is not None and lvm.lv_exists(tmp_lv_path):
+                try:
+                    lvm.delete_lv(tmp_lv_path, raise_exception=False)
+                except Exception as cleanup_ex:
+                    logger.warn("failed to lvremove tmp encrypt LV %s: %s" %
+                                (tmp_lv_path, cleanup_ex))
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    @lock.file_lock(LOCK_FILE)
+    def convert_volume_encryption(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = ConvertVolumeEncryptionRsp()
+        encrypted_dek = getattr(cmd, 'encryptedDek', None)
+        converted_items = []
+        converted_target_paths = {}
+        renamed_sources = []
+        finalized_targets = []
+
+        def rebase_secret_file(reason):
+            return volume_secret.luks_secret_channel(encrypted_dek)
+
+        try:
+            if cmd.targetEncrypted and not encrypted_dek:
+                raise Exception("target encrypted conversion requires encryptedDek")
+
+            lvm.update_pv_allocate_strategy(cmd)
+            for index, item in enumerate(cmd.items):
+                source_abs_path = translate_absolute_path_from_install_path(item.sourceInstallPath)
+                target_abs_path = translate_absolute_path_from_install_path(item.targetInstallPath)
+                temp_abs_path = "%s_converted_%s" % (target_abs_path, uuidhelper.uuid())
+
+                target_backing_abs_path = None
+                if getattr(item, 'targetBackingInstallPath', None):
+                    target_backing_abs_path = translate_absolute_path_from_install_path(item.targetBackingInstallPath)
+                effective_backing_abs_path = converted_target_paths.get(target_backing_abs_path, target_backing_abs_path)
+
+                if lvm.lv_exists(temp_abs_path):
+                    lvm.delete_lv(temp_abs_path)
+
+                secret_file_provider = (lambda: volume_secret.luks_secret_channel(encrypted_dek)) if encrypted_dek else None
+                with lvm.RecursiveOperateLv(source_abs_path, shared=True):
+                    lv_size = int(lvm.get_lv_size(source_abs_path))
+                    if cmd.targetEncrypted:
+                        lv_size += LUKS_HEADER_OVERHEAD
+                    lvm.create_lv_from_absolute_path(temp_abs_path, lv_size, exact_size=True)
+
+                    if effective_backing_abs_path:
+                        with lvm.RecursiveOperateLv(effective_backing_abs_path, shared=True):
+                            with lvm.OperateLv(temp_abs_path, shared=False, delete_when_exception=True):
+                                actual_size = linux.convert_qcow2_volume_encryption(
+                                    source_abs_path, temp_abs_path, cmd.targetEncrypted,
+                                    secret_file_provider, effective_backing_abs_path)
+                    else:
+                        with lvm.OperateLv(temp_abs_path, shared=False, delete_when_exception=True):
+                            actual_size = linux.convert_qcow2_volume_encryption(
+                                source_abs_path, temp_abs_path, cmd.targetEncrypted,
+                                secret_file_provider, effective_backing_abs_path)
+
+                rsp.actualSizes[item.resourceUuid] = long(lvm.get_lv_size(temp_abs_path) or actual_size)
+                converted_items.append((item, source_abs_path, temp_abs_path, target_abs_path,
+                                        effective_backing_abs_path, target_backing_abs_path))
+                converted_target_paths[target_abs_path] = temp_abs_path
+
+            for item, source_abs_path, _, _, _, _ in converted_items:
+                source_trash_path = getattr(item, 'sourceTrashInstallPath', None)
+                if source_trash_path:
+                    source_trash_abs_path = translate_absolute_path_from_install_path(source_trash_path)
+                    r, o, e = lvm.lv_rename(source_abs_path, source_trash_abs_path, False)
+                    if r != 0:
+                        raise Exception("rename lv %s to trash %s failed: stdout: %s, stderr: %s" %
+                                        (source_abs_path, source_trash_abs_path, o, e))
+                    renamed_sources.append((source_trash_abs_path, source_abs_path))
+
+            for _, _, temp_abs_path, target_abs_path, effective_backing_abs_path, target_backing_abs_path in converted_items:
+                if target_backing_abs_path and effective_backing_abs_path != target_backing_abs_path:
+                    with lvm.RecursiveOperateLv(target_backing_abs_path, shared=True):
+                        with lvm.OperateLv(temp_abs_path, shared=False):
+                            if cmd.targetEncrypted:
+                                with rebase_secret_file("final encrypted backing rebase") as reset_secret_file:
+                                    linux.qcow2_rebase_no_check_with_secret(target_backing_abs_path, temp_abs_path, reset_secret_file)
+                            else:
+                                linux.qcow2_rebase_no_check(target_backing_abs_path, temp_abs_path)
+                lvm.lv_rename(temp_abs_path, target_abs_path, False)
+                finalized_targets.append(target_abs_path)
+
+            rsp.totalCapacity, rsp.availableCapacity = lvm.get_vg_size(cmd.vgUuid)
+        except Exception as e:
+            logger.warn(linux.get_exception_stacktrace())
+            for target_abs_path in finalized_targets:
+                lvm.delete_lv(target_abs_path, False)
+            for _, _, temp_abs_path, _, _, _ in converted_items:
+                lvm.delete_lv(temp_abs_path, False)
+            for source_trash_abs_path, source_abs_path in reversed(renamed_sources):
+                if lvm.lv_exists(source_trash_abs_path) and not lvm.lv_exists(source_abs_path):
+                    lvm.lv_rename(source_trash_abs_path, source_abs_path, False)
+            rsp.success = False
+            rsp.error = 'failed to convert volume[%s] encryption: %s' % (cmd.volumeUuid, str(e))
 
         return jsonobject.dumps(rsp)
 

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -48,6 +48,7 @@ from kvmagent.plugins.baremetal_v2_gateway_agent import \
 from kvmagent.plugins.bmv2_gateway_agent import utils as bm_utils
 from kvmagent.plugins.imagestore import ImageStoreClient
 from kvmagent.plugins.nvram import nvram
+from kvmagent.plugins import volume_secret
 from kvmagent.plugins.vms import vm_host_file, vm_host_file_monitor, tpm
 from zstacklib.utils import bash, plugin, iscsi, qemu_nbd
 from zstacklib.utils.bash import in_bash
@@ -614,6 +615,12 @@ class VolumeSyncResponse(kvmagent.AgentResponse):
     def __init__(self):
         super(VolumeSyncResponse, self).__init__()
         self.inactiveVolumePaths = {}  # type: dict[str, list[str]]
+
+
+class GetActiveVolumeSizeResponse(kvmagent.AgentResponse):
+    def __init__(self):
+        super(GetActiveVolumeSizeResponse, self).__init__()
+        self.volumeSizes = {}
 
 
 class AttachDataVolumeCmd(kvmagent.AgentCommand):
@@ -1871,6 +1878,49 @@ class IsoCeph(object):
         return disk
 
 
+def _add_luks_encryption(disk, volume, allow_legacy_secret=True):
+    secret_uuid = getattr(volume, 'luksSecretUuid', None)
+    if not secret_uuid and allow_legacy_secret and getattr(volume, 'deviceType', None) != 'ceph':
+        secret_uuid = getattr(volume, 'secretUuid', None)
+    if secret_uuid:
+        enc = e(disk, 'encryption', None, {'format': 'luks'})
+        e(enc, 'secret', None, {'type': 'passphrase', 'uuid': secret_uuid})
+
+
+def _add_luks_encryption_to_source(source, volume, allow_legacy_secret=True):
+    secret_uuid = getattr(volume, 'luksSecretUuid', None)
+    if not secret_uuid and allow_legacy_secret and getattr(volume, 'deviceType', None) != 'ceph':
+        secret_uuid = getattr(volume, 'secretUuid', None)
+    if secret_uuid:
+        enc = e(source, 'encryption', None, {'format': 'luks'})
+        e(enc, 'secret', None, {'type': 'passphrase', 'uuid': secret_uuid})
+
+
+def _add_luks_backing_chain_if_needed(disk, volume, disk_type):
+    if not getattr(volume, 'luksSecretUuid', None):
+        return False
+
+    backing_chain = Vm._get_backfile_chain(volume.installPath)
+    if not backing_chain:
+        return False
+
+    encrypted_backing_paths = set([p for p in backing_chain if linux.is_luks_encrypted_image(p)])
+    if not encrypted_backing_paths:
+        return False
+
+    source_attr = Vm.disk_source_attrname.get(disk_type)
+    backing = disk
+    for backing_path in backing_chain:
+        backing = e(backing, 'backingStore', None, {'type': disk_type})
+        e(backing, 'format', None, {'type': linux.get_img_fmt(backing_path)})
+        source = e(backing, 'source', None, {source_attr: backing_path})
+        if backing_path in encrypted_backing_paths:
+            _add_luks_encryption_to_source(source, volume)
+
+    e(backing, 'backingStore')
+    return True
+
+
 class BlkCeph(object):
     def __init__(self):
         self.volume = None
@@ -1887,6 +1937,7 @@ class BlkCeph(object):
             e(auth, 'secret', attrib={'type': 'ceph', 'uuid': self.volume.secretUuid})
         for minfo in self.volume.monInfo:
             e(source, 'host', None, {'name': minfo.hostname, 'port': str(minfo.port)})
+        _add_luks_encryption(disk, self.volume, allow_legacy_secret=False)
 
         dev_format = Vm._get_disk_target_dev_format(self.bus_type)
         e(disk, 'target', None, {'dev': dev_format % self.dev_letter, 'bus': self.bus_type})
@@ -1916,6 +1967,7 @@ class VirtioCeph(object):
             e(auth, 'secret', attrib={'type': 'ceph', 'uuid': self.volume.secretUuid})
         for minfo in self.volume.monInfo:
             e(source, 'host', None, {'name': minfo.hostname, 'port': str(minfo.port)})
+        _add_luks_encryption(disk, self.volume, allow_legacy_secret=False)
         e(disk, 'target', None, {'dev': 'vd%s' % self.dev_letter, 'bus': 'virtio'})
         if self.volume.physicalBlockSize:
             e(disk, 'blockio', None, {'physical_block_size': str(self.volume.physicalBlockSize)})
@@ -1937,6 +1989,7 @@ class SCSICeph(object):
             e(auth, 'secret', attrib={'type': 'ceph', 'uuid': self.volume.secretUuid})
         for minfo in self.volume.monInfo:
             e(source, 'host', None, {'name': minfo.hostname, 'port': str(minfo.port)})
+        _add_luks_encryption(disk, self.volume, allow_legacy_secret=False)
         e(disk, 'target', None, {'dev': 'sd%s' % self.dev_letter, 'bus': 'scsi'})
         e(disk, 'wwn', self.volume.wwn)
         if self.volume.shareable:
@@ -3190,7 +3243,14 @@ class Vm(object):
             if (not volume.useVirtioSCSI) and volume.useVirtio and volume.hasattr("ioThreadId") and volume.ioThreadId:
                 driver_elements["iothread"] = str(volume.ioThreadId)
             e(disk, 'driver', None, driver_elements)
-            e(disk, 'source', None, {'file': volume.installPath})
+            source = e(disk, 'source', None, {'file': volume.installPath})
+
+            # qcow2 with LUKS header needs <encryption> + secret ref, else
+            # qemu aborts: "Parameter 'encrypt.key-secret' is required for cipher".
+            if _add_luks_backing_chain_if_needed(disk, volume, 'file'):
+                _add_luks_encryption_to_source(source, volume)
+            else:
+                _add_luks_encryption(disk, volume)
 
             if volume.shareable:
                 e(disk, 'shareable')
@@ -3285,7 +3345,12 @@ class Vm(object):
                 if (not volume.useVirtioSCSI) and volume.useVirtio and volume.hasattr("ioThreadId") and volume.ioThreadId:
                     driver_elements["iothread"] = str(volume.ioThreadId)
                 e(disk, 'driver', None, driver_elements)
-                e(disk, 'source', None, {'dev': volume.installPath})
+                source = e(disk, 'source', None, {'dev': volume.installPath})
+
+                if _add_luks_backing_chain_if_needed(disk, volume, 'block'):
+                    _add_luks_encryption_to_source(source, volume)
+                else:
+                    _add_luks_encryption(disk, volume)
 
                 if volume.shareable:
                     e(disk, 'shareable')
@@ -3806,6 +3871,7 @@ class Vm(object):
 
         logger.debug(vs_structs)
         memory_snapshot_required = False
+        reuse_ext = any(getattr(s, 'encryptedDek', None) for s in vs_structs)
         for vs_struct in vs_structs:
             if vs_struct.live is False or vs_struct.full is True:
                 raise kvmagent.KvmError("volume %s is not live or full snapshot specified, "
@@ -3845,8 +3911,17 @@ class Vm(object):
 
             disk_names.append(disk_name)
             source_file = VmPlugin.get_source_file_by_disk(target_disk)
+            encrypted_dek = getattr(vs_struct, 'encryptedDek', None)
+            if encrypted_dek:
+                with volume_secret.luks_secret_channel(encrypted_dek) as secret_file:
+                    linux.qcow2_clone_encrypted(
+                        source_file, vs_struct.installPath, secret_file,
+                        size=linux.qcow2_virtualsize(source_file))
+            elif reuse_ext:
+                linux.qcow2_clone(source_file, vs_struct.installPath)
             d = e(disks, 'disk', None, attrib={'name': disk_name, 'snapshot': 'external', 'type': target_disk.type_})
-            e(d, 'source', None, attrib={'file' if target_disk.type_ == 'file' else 'dev': vs_struct.installPath})
+            source = e(d, 'source', None, attrib={'file' if target_disk.type_ == 'file' else 'dev': vs_struct.installPath})
+            _add_luks_encryption_to_source(source, vs_struct.volume)
             e(d, 'driver', None, attrib={'type': 'qcow2'})
             return_structs.append(VolumeSnapshotResultStruct(
                 vs_struct.volumeUuid,
@@ -3866,6 +3941,8 @@ class Vm(object):
         snap_flags = libvirt.VIR_DOMAIN_SNAPSHOT_CREATE_NO_METADATA | libvirt.VIR_DOMAIN_SNAPSHOT_CREATE_ATOMIC
         if not memory_snapshot_required:
             snap_flags |= libvirt.VIR_DOMAIN_SNAPSHOT_CREATE_DISK_ONLY
+        if reuse_ext:
+            snap_flags |= libvirt.VIR_DOMAIN_SNAPSHOT_CREATE_REUSE_EXT
 
         try:
             self.domain.snapshotCreateXML(xml, snap_flags)
@@ -4004,7 +4081,8 @@ class Vm(object):
             snapshot = etree.Element('domainsnapshot')
             disks = e(snapshot, 'disks')
             d = e(disks, 'disk', None, attrib={'name': disk_name, 'snapshot': 'external', 'type': backing_store_type})
-            e(d, 'source', None, attrib={source_type: install_path})
+            source = e(d, 'source', None, attrib={source_type: install_path})
+            _add_luks_encryption_to_source(source, volume)
             e(d, 'driver', None, attrib={'type': 'qcow2'})
 
             # QEMU 2.3 default create snapshots on all devices
@@ -5912,7 +5990,14 @@ class Vm(object):
                 #     e(disk, 'driver', None, {'name': 'qemu', 'type': linux.get_img_fmt(_v.installPath), 'cache': _v.cacheMode, 'queues':'1', 'dataplane': 'on'})
                 # else:
                 #     e(disk, 'driver', None, {'name': 'qemu', 'type': linux.get_img_fmt(_v.installPath), 'cache': _v.cacheMode})
-                e(disk, 'source', None, {'file': _v.installPath})
+                source = e(disk, 'source', None, {'file': _v.installPath})
+
+                # qcow2 with LUKS header needs <encryption> + secret ref, else
+                # qemu aborts: "Parameter 'encrypt.key-secret' is required for cipher".
+                if _add_luks_backing_chain_if_needed(disk, _v, 'file'):
+                    _add_luks_encryption_to_source(source, _v)
+                else:
+                    _add_luks_encryption(disk, _v)
 
                 if _v.shareable:
                     e(disk, 'shareable')
@@ -6055,8 +6140,13 @@ class Vm(object):
                 if (not _v.useVirtioSCSI) and _v.useVirtio and _v.hasattr("ioThreadId") and _v.ioThreadId:
                     driver_elements["iothread"] = str(_v.ioThreadId)
                 e(disk, 'driver', None, driver_elements)
-                e(disk, 'source', None, {'dev': _v.installPath})
-                
+                source = e(disk, 'source', None, {'dev': _v.installPath})
+
+                if _add_luks_backing_chain_if_needed(disk, _v, 'block'):
+                    _add_luks_encryption_to_source(source, _v)
+                else:
+                    _add_luks_encryption(disk, _v)
+
                 if _v.shareable:
                     e(disk, 'shareable')
 
@@ -7090,6 +7180,65 @@ def get_vm_blocks(domain_id):
     return blocks
 
 
+def _collect_qmp_file_references(obj, refs):
+    if obj is None:
+        return
+
+    if isinstance(obj, basestring):
+        refs.add(obj)
+        if obj.startswith("ceph://"):
+            refs.add(obj[len("ceph://"):])
+        if obj.startswith("json:"):
+            try:
+                _collect_qmp_file_references(simplejson.loads(obj[5:]), refs)
+            except Exception:
+                pass
+        return
+
+    if isinstance(obj, list):
+        for item in obj:
+            _collect_qmp_file_references(item, refs)
+        return
+
+    if not isinstance(obj, dict):
+        return
+
+    driver = obj.get("driver")
+    if driver == "rbd":
+        pool = obj.get("pool")
+        image_name = obj.get("image")
+        snapshot = obj.get("snapshot")
+        if pool and image_name:
+            rbd_path = "%s/%s" % (pool, image_name)
+            refs.add(rbd_path)
+            refs.add("ceph://%s" % rbd_path)
+            if snapshot:
+                refs.add("%s@%s" % (rbd_path, snapshot))
+                refs.add("ceph://%s@%s" % (rbd_path, snapshot))
+
+    if driver == "file" and obj.get("filename"):
+        refs.add(obj.get("filename"))
+
+    filename = obj.get("filename")
+    if filename:
+        _collect_qmp_file_references(filename, refs)
+
+    for key in ("file", "backing", "backing-image", "children"):
+        _collect_qmp_file_references(obj.get(key), refs)
+
+
+def _qmp_image_matches_install_path(image, install_path):
+    refs = set()
+    _collect_qmp_file_references(image, refs)
+    candidates = set([install_path])
+    if install_path.startswith("ceph://"):
+        candidates.add(install_path[len("ceph://"):])
+    if install_path.startswith("sharedblock://"):
+        candidates.add("/dev/%s" % install_path[len("sharedblock://"):])
+
+    return bool(refs & candidates)
+
+
 # Deprecation, use get_disk_device_name instead.
 def get_block_node_name_by_disk_name(domain_id, disk_name):
     all_blocks = get_vm_blocks(domain_id)
@@ -7199,6 +7348,7 @@ class VmPlugin(kvmagent.KvmAgent):
     KVM_GET_CONSOLE_PORT_PATH = "/vm/getvncport"
     KVM_VM_SYNC_PATH = "/vm/vmsync"
     KVM_VOLUME_SYNC_PATH = "/vm/volumesync"
+    KVM_GET_ACTIVE_VOLUME_SIZE_PATH = "/vm/getactivevolumesize"
     KVM_ATTACH_VOLUME = "/vm/attachdatavolume"
     KVM_DETACH_VOLUME = "/vm/detachdatavolume"
     KVM_MIGRATE_VM_PATH = "/vm/migrate"
@@ -7290,6 +7440,7 @@ class VmPlugin(kvmagent.KvmAgent):
     WRITE_VM_HOST_FILE_PATH = "/vm/hostfile/write"
     BACKUP_VM_HOST_FILE_PATH = "/vm/hostfile/backup"
     VTPM_RESOLVE_LIBVIRT_SECRET_UUID_PATH = '/vm/vtpm/resolveLibvirtSecretUuid'
+    VOLUME_RESOLVE_LIBVIRT_SECRET_UUID_PATH = '/vm/volume/resolveLibvirtSecretUuid'
 
     VM_CONSOLE_LOGROTATE_PATH = "/etc/logrotate.d/vm-console-log"
 
@@ -8044,6 +8195,30 @@ class VmPlugin(kvmagent.KvmAgent):
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror
+    def get_active_volume_size(self, req):
+        rsp = GetActiveVolumeSizeResponse()
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+
+        install_paths = getattr(cmd, "installPaths", None) or []
+        blocks = get_vm_blocks(cmd.vmUuid)
+        for install_path in install_paths:
+            for block in blocks:
+                inserted = block.get("inserted")
+                if not inserted:
+                    continue
+
+                image = inserted.get("image")
+                if not image or not _qmp_image_matches_install_path(image, install_path):
+                    continue
+
+                virtual_size = image.get("virtual-size")
+                if virtual_size is not None:
+                    rsp.volumeSizes[install_path] = long(virtual_size)
+                break
+
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
     def online_increase_mem(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = IncreaseMemoryResponse()
@@ -8712,6 +8887,8 @@ class VmPlugin(kvmagent.KvmAgent):
         if block_backing_store is not None:
             ele.append(block_backing_store)
 
+        _add_luks_encryption(ele, volume)
+
         logger.info("updated disk XML: " + etree.tostring(ele))
         return ele
 
@@ -8977,25 +9154,38 @@ class VmPlugin(kvmagent.KvmAgent):
             """
             return VmPlugin._get_snapshot_size(install_path)
 
-        def take_full_snapshot_by_qemu_img_convert(previous_install_path, install_path, new_volume_install_path):
+        def qcow2_clone_with_encrypted_dek(src, dst, encrypted_dek, size=""):
+            if encrypted_dek:
+                with volume_secret.luks_secret_channel(encrypted_dek) as secret_file:
+                    linux.qcow2_clone_with_secret(
+                        src, dst, secret_file, size=size, kvm_host_addons=getattr(cmd, 'kvmHostAddons', None))
+            else:
+                linux.qcow2_clone_with_cmd(src, dst, cmd)
+
+        def take_full_snapshot_by_qemu_img_convert(previous_install_path, install_path, new_volume_install_path, encrypted_dek=None):
             """
             :rtype: (str, str, long)
             """
             makedir_if_need(install_path)
-            linux.create_template(previous_install_path, install_path)
+            if encrypted_dek:
+                linux.create_encrypted_template_with_secret(
+                    previous_install_path, install_path, volume_secret.make_luks_secret_file(encrypted_dek))
+            else:
+                linux.create_template(previous_install_path, install_path)
             new_volume_path = new_volume_install_path if new_volume_install_path is not None else os.path.join(os.path.dirname(install_path), '{0}.qcow2'.format(uuidhelper.uuid()))
             makedir_if_need(new_volume_path)
-            linux.qcow2_clone_with_cmd(install_path, new_volume_path, cmd)
+            qcow2_clone_with_encrypted_dek(
+                install_path, new_volume_path, encrypted_dek, size=linux.qcow2_virtualsize(install_path) if encrypted_dek else "")
 
             return install_path, new_volume_path, get_size(install_path)
 
-        def take_delta_snapshot_by_qemu_img_convert(previous_install_path, install_path, new_volume_install_path):
+        def take_delta_snapshot_by_qemu_img_convert(previous_install_path, install_path, new_volume_install_path, encrypted_dek=None):
             """
             :rtype: (str, str, long)
             """
             new_volume_path = new_volume_install_path if new_volume_install_path is not None else os.path.join(os.path.dirname(install_path), '{0}.qcow2'.format(uuidhelper.uuid()))
             makedir_if_need(new_volume_path)
-            linux.qcow2_clone_with_cmd(previous_install_path, new_volume_path, cmd)
+            qcow2_clone_with_encrypted_dek(previous_install_path, new_volume_path, encrypted_dek)
 
             return previous_install_path, new_volume_path, get_size(install_path)
 
@@ -9025,11 +9215,13 @@ class VmPlugin(kvmagent.KvmAgent):
                     if snapshot_job.full:
                         rsp.snapshots.append(VolumeSnapshotResultStruct(
                             snapshot_job.volumeUuid, *take_full_snapshot_by_qemu_img_convert(
-                                snapshot_job.previousInstallPath, snapshot_job.installPath, snapshot_job.newVolumeInstallPath)))
+                                snapshot_job.previousInstallPath, snapshot_job.installPath, snapshot_job.newVolumeInstallPath,
+                                getattr(snapshot_job, 'encryptedDek', None))))
                     else:
                         rsp.snapshots.append(VolumeSnapshotResultStruct(
                             snapshot_job.volumeUuid, *take_delta_snapshot_by_qemu_img_convert(
-                                snapshot_job.previousInstallPath, snapshot_job.installPath, snapshot_job.newVolumeInstallPath)))
+                                snapshot_job.previousInstallPath, snapshot_job.installPath, snapshot_job.newVolumeInstallPath,
+                                getattr(snapshot_job, 'encryptedDek', None))))
 
         except kvmagent.KvmError as error:
             logger.warn(linux.get_exception_stacktrace())
@@ -9135,20 +9327,35 @@ host side snapshot files chian:
             if not os.path.exists(dirname):
                 os.makedirs(dirname, 0755)
 
+        def qcow2_clone_with_encrypted_dek(src, dst, encrypted_dek, size=""):
+            if encrypted_dek:
+                with volume_secret.luks_secret_channel(encrypted_dek) as secret_file:
+                    linux.qcow2_clone_with_secret(
+                        src, dst, secret_file, size=size, kvm_host_addons=getattr(cmd, 'kvmHostAddons', None))
+            else:
+                linux.qcow2_clone_with_cmd(src, dst, cmd)
+
         def take_full_snapshot_by_qemu_img_convert(previous_install_path, install_path):
             makedir_if_need(install_path)
-            linux.create_template(previous_install_path, install_path)
+            # FIXME: this an untested code path
+            if getattr(cmd, 'encryptedDek', None):
+                linux.create_encrypted_template_with_secret(
+                    previous_install_path, install_path, volume_secret.make_luks_secret_file(cmd.encryptedDek))
+            else:
+                linux.create_template(previous_install_path, install_path)
             new_volume_path = cmd.newVolumeInstallPath if cmd.newVolumeInstallPath is not None else os.path.join(os.path.dirname(install_path), '{0}.qcow2'.format(uuidhelper.uuid()))
             makedir_if_need(new_volume_path)
             self.active_volume_if_need(new_volume_path)
-            linux.qcow2_clone_with_cmd(install_path, new_volume_path, cmd)
+            qcow2_clone_with_encrypted_dek(
+                install_path, new_volume_path, getattr(cmd, 'encryptedDek', None),
+                size=linux.qcow2_virtualsize(install_path) if getattr(cmd, 'encryptedDek', None) else "")
             return install_path, new_volume_path
 
         def take_delta_snapshot_by_qemu_img_convert(previous_install_path, install_path):
             Vm.ensure_delta_snapshot_not_exceed(previous_install_path)
             new_volume_path = cmd.newVolumeInstallPath if cmd.newVolumeInstallPath is not None else os.path.join(os.path.dirname(install_path), '{0}.qcow2'.format(uuidhelper.uuid()))
             makedir_if_need(new_volume_path)
-            linux.qcow2_clone_with_cmd(previous_install_path, new_volume_path, cmd)
+            qcow2_clone_with_encrypted_dek(previous_install_path, new_volume_path, getattr(cmd, 'encryptedDek', None))
             return previous_install_path, new_volume_path
 
         try:
@@ -11678,6 +11885,63 @@ host side snapshot files chian:
             rsp.error = err or 'failed to resolve vTPM libvirt secret uuid'
         return jsonobject.dumps(rsp)
 
+    @staticmethod
+    def _get_volume_luks_secret_uuid_from_domain_xml(domain_xml, volume_uuid):
+        if not volume_uuid:
+            return None, 'volumeUuid is empty'
+        try:
+            tree = etree.fromstring(domain_xml)
+        except Exception as e:
+            return None, 'failed to parse domain XML: %s' % e
+
+        for disk in tree.findall('devices/disk'):
+            serial = disk.find('serial')
+            if serial is None or serial.text != volume_uuid:
+                continue
+
+            for enc_path in ('encryption', 'source/encryption'):
+                enc = disk.find(enc_path)
+                if enc is None:
+                    continue
+                secret = enc.find('secret')
+                if secret is not None and secret.get('uuid'):
+                    return secret.get('uuid'), None
+            return None, 'volume[%s] disk has no LUKS secret in domain XML' % volume_uuid
+
+        return None, 'volume[%s] disk not found in domain XML' % volume_uuid
+
+    @kvmagent.replyerror
+    def resolve_volume_libvirt_secret_uuid(self, req):
+        rsp = kvmagent.AgentResponse()
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        vm_uuid = getattr(cmd, 'vmUuid', None)
+        volume_uuid = getattr(cmd, 'volumeUuid', None)
+        vm = get_vm_by_uuid(str(vm_uuid), False)
+        if vm is None:
+            rsp.success = False
+            rsp.error = 'vm not found on this host'
+            return jsonobject.dumps(rsp)
+        domain_xml = vm.domain_xml
+        if not domain_xml and vm.domain is not None:
+            try:
+                domain_xml = vm.domain.XMLDesc(0)
+            except Exception as e:
+                rsp.success = False
+                rsp.error = 'failed to get domain XML from libvirt: %s' % e
+                return jsonobject.dumps(rsp)
+        if not domain_xml:
+            rsp.success = False
+            rsp.error = 'empty domain xml for vm'
+            return jsonobject.dumps(rsp)
+        suuid, err = self._get_volume_luks_secret_uuid_from_domain_xml(domain_xml, str(volume_uuid))
+        if suuid:
+            rsp.success = True
+            rsp.secretUuid = suuid
+        else:
+            rsp.success = False
+            rsp.error = err or 'failed to resolve volume LUKS libvirt secret uuid'
+        return jsonobject.dumps(rsp)
+
     @kvmagent.replyerror
     def read_hostfile(self, req):
         # type: (dict) -> object
@@ -11746,6 +12010,7 @@ host side snapshot files chian:
         http_server.register_async_uri(self.KVM_ONLINE_INCREASE_MEMORY_PATH, self.online_increase_mem)
         http_server.register_async_uri(self.KVM_VM_SYNC_PATH, self.vm_sync)
         http_server.register_async_uri(self.KVM_VOLUME_SYNC_PATH, self.volume_sync)
+        http_server.register_sync_uri(self.KVM_GET_ACTIVE_VOLUME_SIZE_PATH, self.get_active_volume_size)
         http_server.register_async_uri(self.KVM_ATTACH_VOLUME, self.attach_data_volume)
         http_server.register_async_uri(self.KVM_DETACH_VOLUME, self.detach_data_volume)
         http_server.register_async_uri(self.KVM_ATTACH_ISO_PATH, self.attach_iso)
@@ -11845,6 +12110,7 @@ host side snapshot files chian:
         http_server.register_async_uri(self.WRITE_VM_HOST_FILE_PATH, self.write_hostfile, cmd=WriteVmHostFileContentCmd())
         http_server.register_async_uri(self.BACKUP_VM_HOST_FILE_PATH, self.backup_hostfile, cmd=BackupVmHostFileCmd())
         http_server.register_async_uri(self.VTPM_RESOLVE_LIBVIRT_SECRET_UUID_PATH, self.resolve_vtpm_libvirt_secret_uuid)
+        http_server.register_async_uri(self.VOLUME_RESOLVE_LIBVIRT_SECRET_UUID_PATH, self.resolve_volume_libvirt_secret_uuid)
         self.clean_old_sshfs_mount_points()
         self.register_libvirt_event()
         self.register_qemu_log_cleaner()

--- a/kvmagent/kvmagent/plugins/volume_secret.py
+++ b/kvmagent/kvmagent/plugins/volume_secret.py
@@ -1,0 +1,82 @@
+import base64
+import contextlib
+import os
+import re
+
+from zstacklib.utils import linux
+from zstacklib.utils import log
+
+logger = log.get_logger(__name__)
+
+KEY_AGENT_UNIX_SOCKET = 'unix:///var/run/key-agent/key-agent.sock'
+KEY_AGENT_SOCKET_PATH = '/var/run/key-agent/key-agent.sock'
+
+try:
+    import grpc
+    from kvmagent.keyagent import key_agent_pb2
+    from kvmagent.keyagent import key_agent_pb2_grpc
+    KEY_AGENT_GRPC_AVAILABLE = True
+except Exception:
+    KEY_AGENT_GRPC_AVAILABLE = False
+
+
+def _decode_encrypted_dek(encrypted_dek_b64):
+    if not encrypted_dek_b64:
+        raise Exception('encryptedDek is required')
+
+    normalized = str(encrypted_dek_b64).strip()
+    if not re.match(r'^[A-Za-z0-9+/]+={0,2}$', normalized) or len(normalized) % 4 != 0:
+        raise Exception('encryptedDek must be valid base64')
+
+    encrypted_dek = base64.b64decode(normalized)
+    encoded = base64.b64encode(encrypted_dek)
+    if not isinstance(encoded, str):
+        encoded = encoded.decode('ascii')
+    if encoded.rstrip('=') != normalized.rstrip('='):
+        raise Exception('encryptedDek must be canonical base64')
+    return encrypted_dek
+
+
+def prepare_luks_secret_material_channel(encrypted_dek_b64):
+    if not KEY_AGENT_GRPC_AVAILABLE:
+        raise Exception('key_agent grpc not available')
+    if not os.path.exists(KEY_AGENT_SOCKET_PATH):
+        raise Exception('key-agent socket not found')
+
+    encrypted_dek = _decode_encrypted_dek(encrypted_dek_b64)
+    channel = grpc.insecure_channel(KEY_AGENT_UNIX_SOCKET)
+    try:
+        stub = key_agent_pb2_grpc.KeyAgentServiceStub(channel)
+        req = key_agent_pb2.PrepareLuksSecretMaterialChannelRequest(encrypted_dek=encrypted_dek)
+        resp = stub.PrepareLuksSecretMaterialChannel(req, timeout=60)
+        path = getattr(resp, 'channel_path', None) if resp else None
+        path = str(path).strip() if path else ''
+        if not path:
+            raise Exception('key-agent PrepareLuksSecretMaterialChannel returned empty channel_path')
+        return path
+    except grpc.RpcError as e:
+        details = e.details() if hasattr(e, 'details') and callable(getattr(e, 'details')) else str(e)
+        logger.debug('key-agent PrepareLuksSecretMaterialChannel gRPC error: %s' % details)
+        raise Exception(details or str(e))
+    finally:
+        channel.close()
+
+
+def make_luks_secret_file(encrypted_dek_b64):
+    """Create a one-shot FIFO for a single qemu-img operation.
+    The caller passes the returned path to a *_with_secret function,
+    which deletes it in its own finally block."""
+    return prepare_luks_secret_material_channel(encrypted_dek_b64)
+
+
+@contextlib.contextmanager
+def luks_secret_channel(encrypted_dek_b64):
+    if not encrypted_dek_b64:
+        yield None
+        return
+
+    channel_path = prepare_luks_secret_material_channel(encrypted_dek_b64)
+    try:
+        yield channel_path
+    finally:
+        linux.rm_file_force(channel_path)

--- a/zstackcli/zstackcli/cli.py
+++ b/zstackcli/zstackcli/cli.py
@@ -371,8 +371,12 @@ Parse command parameters error:
                     all_params[params[0]] = eval(params[1])
                 elif apiname == 'APICreateTicketMsg' and params[0] == 'accountSystemContext':
                     all_params[params[0]] = eval(params[1])
-                elif apiname == 'APICreateVmInstanceMsg' and params[0] == 'diskAOs':
+                elif apiname in ['APICreateVmInstanceMsg',
+                                 'APICreateVmInstanceFromTemplatedVmInstanceMsg',
+                                 'APICloneVmInstanceMsg'] and params[0] == 'diskAOs':
                     all_params[params[0]] = eval(params[1])
+                elif apiname == 'APICreateVmInstanceFromVolumeSnapshotGroupMsg' and params[0] == 'volumeSnapshotEncryptions':
+                    all_params[params[0]] = eval_string(params[0], params[1])
                 elif apiname in ['APICreateVmInstanceFromTemplatedVmInstanceMsg',
                                  'APICloneVmInstanceMsg'] and params[0] == 'vmCustomSpecification':
                     all_params[params[0]] = eval_string(params[0], params[1])

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -19,11 +19,13 @@ import re
 import resource
 import shutil
 import socket
+import stat
 import struct
 import tempfile
 import threading
 import time
 import traceback
+import uuid
 from inspect import stack
 
 import netaddr
@@ -47,6 +49,8 @@ except NameError:
     long = int
 
 logger = log.get_logger(__name__)
+
+QCOW2_BACKING_ARG_COMPACT_THRESHOLD = 900
 
 RPM_BASED_OS = ['redhat', 'centos', 'alibaba', 'kylin10', 'rocky']
 DEB_BASED_OS = ['uos', 'kylin4.0.2', 'debian', 'ubuntu', 'uniontech']
@@ -308,6 +312,19 @@ def rm_file_force(fpath):
         os.remove(fpath)
     except:
         pass
+
+def move_file_no_overwrite(src, dst):
+    if src == dst:
+        return
+    if not os.path.exists(src):
+        raise Exception("source file %s does not exist" % src)
+    if os.path.exists(dst):
+        raise Exception("target file %s already exists" % dst)
+
+    dst_dir = os.path.dirname(dst)
+    if dst_dir and not os.path.exists(dst_dir):
+        os.makedirs(dst_dir)
+    os.rename(src, dst)
 
 black_dpath_list = ["", "/", "*", "/root", "/var", "/bin", "/lib", "/sys"]
 
@@ -1249,6 +1266,18 @@ def get_img_file_fmt(src):
     return fmt
 
 
+def _is_block_device(path):
+    """True if `path` exists and points to a block device. False on missing path
+    (caller is expected to fail loudly elsewhere) or on a regular file. Used to
+    decide whether tmp+rename is feasible (regular files) versus writing in
+    place (block devices, e.g. SharedBlock LVs).
+    """
+    try:
+        return stat.S_ISBLK(os.stat(path).st_mode)
+    except OSError:
+        return False
+
+
 def get_img_fmt(src):
     if os.path.exists(src):
         with open(src, 'rb') as f:
@@ -1277,13 +1306,6 @@ def qcow2_clone(src, dst, size=""):
     shell.check_run('/usr/bin/qemu-img create -F %s -b %s -f qcow2 %s %s' % (fmt, src, dst, size))
     os.chmod(dst, 0o660)
 
-def qcow2_clone_with_cmd(src, dst, cmd=None):
-    size = cmd.virtualSize if cmd.virtualSize else ""
-    if cmd is None or cmd.kvmHostAddons is None or cmd.kvmHostAddons.qcow2Options is None:
-        qcow2_clone(src, dst, size)
-    else:
-        qcow2_clone_with_option(src, dst, cmd.kvmHostAddons.qcow2Options, size)
-
 def qcow2_clone_with_option(src, dst, opt="", size=""):
     # NOTE(weiw): qcow2 doesn't support specify backing file and preallocation at same time
     pattern = re.compile("\-o\ preallocation\=\w+ ")
@@ -1293,15 +1315,76 @@ def qcow2_clone_with_option(src, dst, opt="", size=""):
     shell.check_run('/usr/bin/qemu-img create -F %s %s -b %s -f qcow2 %s %s' % (fmt, opt, src, dst, size))
     os.chmod(dst, 0o660)
 
+def qcow2_clone_encrypted(src, dst, secret_material_file, size="", opt=""):
+    """
+    Clone a qcow2 overlay backed by `src`, with LUKS encryption applied only to the
+    overlay layer. `src` is left untouched: qemu reads unallocated clusters from `src`
+    using `src`'s own format, while writes to the new overlay are encrypted with the
+    LUKS master key sealed by the passphrase read from `secret_material_file`.
+
+    `secret_material_file` is a one-shot channel (typically a FIFO produced by
+    key-agent) and is rm'd after the qemu-img invocation.
+
+    For file-based dst we go through a tmp+rename so a half-written file never
+    appears at the target path. For block-device dst (SharedBlock LV) tmp+rename
+    is impossible: we write directly to `dst` and rely on the caller to gc the
+    LV if the qemu-img invocation fails.
+    """
+    if not secret_material_file:
+        raise Exception("qcow2_clone_encrypted requires a non-empty secret material file path")
+    if not os.path.exists(src):
+        raise Exception("backing file %s does not exist" % src)
+
+    fmt = get_img_fmt(src)
+    # qcow2 doesn't allow backing_file together with preallocation
+    opt = re.sub(r"-o\s+preallocation=\w+\s*", " ", opt or "")
+    if not size:
+        size = qcow2_virtualsize(src)
+    dst_is_block = _is_block_device(dst)
+    target_path = dst if dst_is_block else ("%s.creating.%s" % (dst, uuid.uuid4().hex))
+    try:
+        cmd = ("/usr/bin/qemu-img create -u "
+               "--object secret,id=luks_sec,format=raw,file=%s "
+               "-F %s -b %s -f qcow2 %s "
+               "-o encrypt.format=luks,encrypt.key-secret=luks_sec "
+               "%s %s") % (
+            secret_material_file, fmt, src, opt, target_path, size)
+        shell.check_run(cmd)
+        if not dst_is_block:
+            shell.check_run("mv %s %s" % (target_path, dst))
+            os.chmod(dst, 0o660)
+    finally:
+        rm_file_force(secret_material_file)
+        # tmp_path cleanup only meaningful for the file-based dst path
+        if not dst_is_block and os.path.exists(target_path):
+            rm_file_force(target_path)
+
+def qcow2_clone_with_cmd(src, dst, cmd=None):
+    secret_material_file = getattr(cmd, 'encryptLuksSecretMaterialFilePath', None) if cmd else None
+
+    size = cmd.virtualSize if cmd.virtualSize else ""
+    if cmd is None or cmd.kvmHostAddons is None or cmd.kvmHostAddons.qcow2Options is None:
+        if secret_material_file:
+            qcow2_clone_encrypted(src, dst, secret_material_file, size=size)
+        else:
+            qcow2_clone(src, dst, size)
+    else:
+        if secret_material_file:
+            qcow2_clone_encrypted(src, dst, secret_material_file, size=size,
+                                  opt=cmd.kvmHostAddons.qcow2Options)
+        else:
+            qcow2_clone_with_option(src, dst, cmd.kvmHostAddons.qcow2Options, size)
+
+def qcow2_clone_with_secret(src, dst, secret_material_file, size="", kvm_host_addons=None):
+    if kvm_host_addons is None or kvm_host_addons.qcow2Options is None:
+        qcow2_clone_encrypted(src, dst, secret_material_file, size=size)
+    else:
+        qcow2_clone_encrypted(src, dst, secret_material_file, size=size,
+                              opt=kvm_host_addons.qcow2Options)
+
 def raw_clone(src, dst):
     shell.check_run('/usr/bin/qemu-img create -b %s -f raw %s' % (src, dst))
     os.chmod(dst, 0o660)
-
-
-def qcow2_create(dst, size, chmod=True):
-    shell.check_run('/usr/bin/qemu-img create -f qcow2 %s %s' % (dst, size))
-    if (chmod):
-        os.chmod(dst, 0o660)
 
 def qemu_img_resize(target, size, fmt='qcow2', force=False, skip_if_sufficient=False):
     if skip_if_sufficient:
@@ -1314,11 +1397,28 @@ def qemu_img_resize(target, size, fmt='qcow2', force=False, skip_if_sufficient=F
     force_option = '--shrink' if force else ''
     shell.check_run('/usr/bin/qemu-img resize %s %s %s %s' % (fmt_option, force_option, target, size))
 
-def qcow2_create_with_cmd(dst, size, cmd=None, discard_on_metadata=True):
-    if cmd is None or cmd.kvmHostAddons is None or cmd.kvmHostAddons.qcow2Options is None:
-        qcow2_create(dst, size)
-    else:
-        qcow2_create_with_option(dst, size, cmd.kvmHostAddons.qcow2Options, discard_on_metadata)
+def qemu_img_resize_with_secret(target, size, secret_material_file, force=False, skip_if_sufficient=False):
+    if not secret_material_file:
+        raise Exception("qemu_img_resize_with_secret requires a non-empty secret material file path")
+    try:
+        if skip_if_sufficient:
+            virtual_size = qcow2_get_virtual_size(target)
+            if virtual_size >= size:
+                logger.debug('skip resize the encrypted image[%s] as the virtual size[%s] '
+                             'is already larger than the required size[%s]' % (target, virtual_size, size))
+                return
+
+        force_option = '--shrink' if force else ''
+        with _qcow2_image_opts_with_secret_context(target) as target_arg:
+            shell.check_run('%s --object secret,id=luks_sec,format=raw,file=%s %s %s %s' %
+                            (qemu_img.subcmd('resize'), secret_material_file, force_option, target_arg, size))
+    finally:
+        rm_file_force(secret_material_file)
+
+def qcow2_create(dst, size, chmod=True):
+    shell.check_run('/usr/bin/qemu-img create -f qcow2 %s %s' % (dst, size))
+    if (chmod):
+        os.chmod(dst, 0o660)
 
 def qcow2_create_with_option(dst, size, opt="", discard_on_metadata=True):
     shell.check_run('/usr/bin/qemu-img create -f qcow2 %s %s %s' % (opt, dst, size))
@@ -1326,12 +1426,567 @@ def qcow2_create_with_option(dst, size, opt="", discard_on_metadata=True):
         qcow2_discard(dst)
     os.chmod(dst, 0o660)
 
+def qcow2_create_encrypted(dst, size, secret_material_file, opt=""):
+    """
+    Create a standalone LUKS-encrypted qcow2 (no backing). One-shot via `qemu-img create`
+    so the file lands in its final encrypted form; `secret_material_file` is rm'd after.
+
+    File-based dst: tmp+rename to keep the install path atomic.
+    Block-device dst (SharedBlock LV): write directly to `dst` (rename across
+    block devices is meaningless).
+    """
+    if not secret_material_file:
+        raise Exception("qcow2_create_encrypted requires a non-empty secret material file path")
+
+    dst_is_block = _is_block_device(dst)
+    target_path = dst if dst_is_block else ("%s.creating.%s" % (dst, uuid.uuid4().hex))
+    try:
+        cmd = ("/usr/bin/qemu-img create "
+               "--object secret,id=luks_sec,format=raw,file=%s "
+               "-f qcow2 %s "
+               "-o encrypt.format=luks,encrypt.key-secret=luks_sec "
+               "%s %s") % (
+            secret_material_file, opt or "", target_path, size)
+        shell.check_run(cmd)
+        if not dst_is_block:
+            shell.check_run("mv %s %s" % (target_path, dst))
+            os.chmod(dst, 0o660)
+    finally:
+        rm_file_force(secret_material_file)
+        if not dst_is_block and os.path.exists(target_path):
+            rm_file_force(target_path)
+
+def encrypt_plain_volume_in_place(src, secret_material_file, opt=""):
+    """
+    In-place LUKS encryption of the plain volume file at `src`. Dispatches by the
+    source's detected format so each source format lands in its idiomatic encrypted
+    form (no surprise format flips for the user):
+
+      raw   -> `-O luks`         (standalone LUKS container; guest sees raw payload,
+                                  file size ~= original raw + a few MB of LUKS header)
+      qcow2 -> `-O qcow2 -o encrypt.format=luks`   (LUKS embedded in qcow2 header)
+      vmdk  -> never reaches here on real ZStack flows: the imagestore BS rewrites
+               vmdk to qcow2 at addImage time, so the downloaded bits are already
+               qcow2. We still treat any non-raw source as the qcow2 branch as a
+               defensive default.
+
+    Runs the conversion into a tmp file and atomically renames it over `src`. The
+    original plain bits are removed on successful rename. `secret_material_file`
+    is rm'd at the end (single-use).
+
+    Used by the data-volume-from-template encryption path on file-based primary
+    storages: the agent first downloads the plain template into the volume's
+    install path, then invokes this helper to turn it into a self-contained
+    encrypted volume (no backing file). The output keeps the same install path
+    so downstream consumers see no diff; libvirt-side <driver type=...> is
+    resolved at start_vm time by linux.get_img_fmt on the actual file magic.
+    """
+    if not secret_material_file:
+        raise Exception("encrypt_plain_volume_in_place requires a non-empty secret material file path")
+    if not os.path.exists(src):
+        raise Exception("source file %s does not exist" % src)
+
+    fmt = get_img_fmt(src)
+    if fmt == 'raw':
+        # standalone LUKS: -O luks emits a self-contained luks container
+        # (LUKS header + encrypted raw payload). Guest virtual size matches
+        # the original raw; only the few-MB header is overhead.
+        out_format = 'luks'
+        out_opts = "-o key-secret=luks_sec"
+    else:
+        # qcow2-and-friends: keep LUKS-in-qcow2 layout so backing chains, sparse
+        # allocation and qcow2 snapshot semantics survive.
+        out_format = 'qcow2'
+        out_opts = "-o encrypt.format=luks,encrypt.key-secret=luks_sec"
+
+    if _is_block_device(src):
+        raise Exception(
+            "encrypt_plain_volume_in_place does not support block-device source[%s]; "
+            "callers backed by LVM (e.g. SharedBlock) must use "
+            "encrypt_plain_volume_block_to_block which lets the caller manage the "
+            "destination LV lifecycle (lvcreate + lvextend for LUKS header overhead, "
+            "dd back, lvremove)." % src)
+
+    tmp_path = "%s.encrypting.%s" % (src, uuid.uuid4().hex)
+    try:
+        cmd = ("/usr/bin/qemu-img convert "
+               "--object secret,id=luks_sec,format=raw,file=%s "
+               "-f %s -O %s "
+               "%s "
+               "%s %s %s") % (
+            secret_material_file, fmt, out_format, out_opts, opt or "", src, tmp_path)
+        shell.check_run(cmd)
+        shell.check_run("mv -f %s %s" % (tmp_path, src))
+        os.chmod(src, 0o660)
+    finally:
+        rm_file_force(secret_material_file)
+        if os.path.exists(tmp_path):
+            rm_file_force(tmp_path)
+
+
+def encrypt_plain_volume_block_to_block(src_block, dst_block, secret_material_file, opt=""):
+    """
+    Convert plain bits at `src_block` (a block device) into LUKS-encrypted bits
+    at `dst_block` (another block device), one-shot via `qemu-img convert`.
+    Source format is autodetected; output format follows the same rule as
+    `encrypt_plain_volume_in_place`: `raw` -> `-O luks`, anything else -> `-O qcow2`
+    with `encrypt.format=luks`. NOT in-place: the caller owns dst_block's
+    lifecycle (typically lvcreate it, run this helper, then lvrename to swap).
+
+    Block-device callers (SharedBlock LV) own the destination LV lifecycle:
+      1. `lvcreate` a destination LV in the same VG, sized = source size +
+         LUKS header overhead (~16MB safe margin). qemu-img will fail with
+         "Cannot grow device files" if the destination cannot hold the
+         encrypted payload + header.
+      2. Invoke this helper.
+      3. (Optional) `dd if=dst of=src` then `lvremove dst` if the caller wants
+         the encrypted bits to end up under `src`'s LV name -- this helper
+         does not perform that copy; it just runs the qemu-img convert.
+
+    `secret_material_file` is rm'd after the qemu-img invocation, win or lose.
+    """
+    if not secret_material_file:
+        raise Exception("encrypt_plain_volume_block_to_block requires a non-empty secret material file path")
+    if not _is_block_device(src_block):
+        raise Exception("src[%s] is not a block device" % src_block)
+    if not _is_block_device(dst_block):
+        raise Exception("dst[%s] is not a block device" % dst_block)
+
+    fmt = get_img_fmt(src_block)
+    if fmt == 'raw':
+        out_format = 'luks'
+        out_opts = "-o key-secret=luks_sec"
+    else:
+        out_format = 'qcow2'
+        out_opts = "-o encrypt.format=luks,encrypt.key-secret=luks_sec"
+
+    try:
+        cmd = ("/usr/bin/qemu-img convert "
+               "--object secret,id=luks_sec,format=raw,file=%s "
+               "-f %s -O %s "
+               "%s "
+               "%s %s %s") % (
+            secret_material_file, fmt, out_format, out_opts, opt or "", src_block, dst_block)
+        shell.check_run(cmd)
+    finally:
+        rm_file_force(secret_material_file)
+
+def qcow2_create_with_cmd(dst, size, cmd=None, discard_on_metadata=True):
+    secret_material_file = getattr(cmd, 'encryptLuksSecretMaterialFilePath', None) if cmd else None
+
+    if cmd is None or cmd.kvmHostAddons is None or cmd.kvmHostAddons.qcow2Options is None:
+        if secret_material_file:
+            qcow2_create_encrypted(dst, size, secret_material_file)
+        else:
+            qcow2_create(dst, size)
+    else:
+        if secret_material_file:
+            qcow2_create_encrypted(dst, size, secret_material_file,
+                                   opt=cmd.kvmHostAddons.qcow2Options)
+        else:
+            qcow2_create_with_option(dst, size, cmd.kvmHostAddons.qcow2Options, discard_on_metadata)
+
+def is_luks_encrypted_image(src):
+    try:
+        info = simplejson.loads(shell.call('%s --output=json %s' % (qemu_img.subcmd('info'), src)))
+    except Exception:
+        return False
+
+    if info.get('encrypted') is True:
+        return True
+    fmt_data = info.get('format-specific', {}).get('data', {})
+    encrypt = fmt_data.get('encrypt')
+    if isinstance(encrypt, dict):
+        return bool(encrypt.get('format') or encrypt.get('key-secret'))
+    return False
+
+def create_encrypted_template_with_secret(src, dst, secret_material_file,
+                                          dst_format='qcow2', compress=False,
+                                          shell=shell, progress_output=None, opts=None):
+    if not secret_material_file:
+        raise Exception("create_encrypted_template_with_secret requires a non-empty secret material file path")
+    redirect, ext_opts = "", []
+    if progress_output:
+        redirect = " > " + progress_output
+        ext_opts.append("-p")
+    if compress:
+        ext_opts.append("-c")
+    if opts:
+        ext_opts.append(opts)
+
+    dst_is_block = _is_block_device(dst)
+    target_path = dst if dst_is_block else ("%s.creating.%s" % (dst, uuid.uuid4().hex))
+    try:
+        out_format = dst_format
+        if dst_format == 'raw':
+            out_format = 'luks'
+            out_opts = "-o key-secret=luks_sec"
+        else:
+            out_opts = "-o encrypt.format=luks,encrypt.key-secret=luks_sec"
+
+        with _qcow2_image_opts_with_secret_context(src) as src_arg:
+            cmdline = ("%s --object secret,id=luks_sec,format=raw,file=%s "
+                       "%s -O %s %s %s %s %s") % (
+                qemu_img.subcmd('convert'), secret_material_file,
+                " ".join(ext_opts), out_format, out_opts, src_arg, target_path, redirect)
+            shell.call(cmdline)
+        if not dst_is_block:
+            shell.call("mv -f %s %s" % (target_path, dst))
+            os.chmod(dst, 0o660)
+    finally:
+        rm_file_force(secret_material_file)
+        if not dst_is_block and os.path.exists(target_path):
+            rm_file_force(target_path)
+
+def _qcow2_image_opts_with_secret(path, secret_id='luks_sec', include_backing=True, path_aliases=None):
+    image_opts = []
+    current = path
+    prefix = ""
+    path_aliases = path_aliases or {}
+    while current:
+        image_opts.append("%sdriver=%s" % (prefix, get_img_fmt(current)))
+        image_opts.append("%sfile.filename=%s" % (prefix, path_aliases.get(current, current)))
+        if is_luks_encrypted_image(current):
+            image_opts.append("%sencrypt.key-secret=%s" % (prefix, secret_id))
+        if not include_backing:
+            break
+        current = qcow2_get_backing_file(current)
+        prefix += "backing."
+    return "--image-opts %s" % shellquote(",".join(image_opts))
+
+@contextlib.contextmanager
+def _qcow2_path_aliases_context(path, include_backing=True):
+    tmpdir = tempfile.mkdtemp(prefix='zstack-qcow2-backing-', dir='/tmp')
+    try:
+        path_aliases = {}
+        current = path
+        index = 0
+        while current:
+            alias = os.path.join(tmpdir, "b%d" % index)
+            os.symlink(current, alias)
+            path_aliases[current] = alias
+            if not include_backing:
+                break
+            current = qcow2_get_backing_file(current)
+            index += 1
+
+        yield path_aliases
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+@contextlib.contextmanager
+def _qcow2_image_opts_with_secret_context(path, secret_id='luks_sec', include_backing=True):
+    image_opts = _qcow2_image_opts_with_secret(path, secret_id, include_backing)
+    if len(image_opts) <= QCOW2_BACKING_ARG_COMPACT_THRESHOLD:
+        yield image_opts
+        return
+
+    with _qcow2_path_aliases_context(path, include_backing) as path_aliases:
+        yield _qcow2_image_opts_with_secret(path, secret_id, include_backing, path_aliases)
+
+def _qcow2_chain_has_luks_encrypted_image(path):
+    current = path
+    while current:
+        if is_luks_encrypted_image(current):
+            return True
+        current = qcow2_get_backing_file(current)
+    return False
+
+def _qcow2_image_opts_json_with_secret(path, secret_id='luks_sec', include_backing=True):
+    return _qcow2_image_opts_json_with_secret_aliases(path, secret_id, include_backing, {})
+
+def _qcow2_image_opts_json_with_secret_aliases(path, secret_id, include_backing, path_aliases):
+    opts = {
+        "driver": get_img_fmt(path),
+        "file": {
+            "driver": "host_device" if _is_block_device(path) else "file",
+            "filename": path_aliases.get(path, path),
+        },
+    }
+
+    if is_luks_encrypted_image(path):
+        opts["encrypt"] = {
+            "key-secret": secret_id,
+        }
+
+    if include_backing:
+        backing_file = qcow2_get_backing_file(path)
+        if backing_file:
+            opts["backing"] = _qcow2_image_opts_json_with_secret_aliases(backing_file, secret_id, include_backing, path_aliases)
+
+    return opts
+
+def _qcow2_backing_arg_with_secret(path, secret_id='luks_sec', include_backing=True):
+    if not path or not _qcow2_chain_has_luks_encrypted_image(path):
+        return path
+
+    opts = _qcow2_image_opts_json_with_secret(path, secret_id, include_backing)
+    return "json:%s" % json.dumps(opts, separators=(',', ':'))
+
+@contextlib.contextmanager
+def _qcow2_backing_arg_with_secret_context(path, secret_id='luks_sec', include_backing=True):
+    backing_arg = _qcow2_backing_arg_with_secret(path, secret_id, include_backing)
+    if not backing_arg.startswith("json:") or len(backing_arg) <= QCOW2_BACKING_ARG_COMPACT_THRESHOLD:
+        yield backing_arg
+        return
+
+    with _qcow2_path_aliases_context(path, include_backing) as path_aliases:
+        opts = _qcow2_image_opts_json_with_secret_aliases(path, secret_id, include_backing, path_aliases)
+        yield "json:%s" % json.dumps(opts, separators=(',', ':'))
+
+def read_luks_secret_material_file(secret_material_file):
+    if not secret_material_file:
+        return None
+
+    try:
+        with open(secret_material_file, 'rb') as fd:
+            return fd.read()
+    finally:
+        rm_file_force(secret_material_file)
+
+def _write_all(fd, data):
+    written = 0
+    while written < len(data):
+        written += os.write(fd, data[written:])
+
+@contextlib.contextmanager
+def existing_luks_secret_file(secret_material_file):
+    yield secret_material_file
+
+@contextlib.contextmanager
+def temporary_luks_secret_file(secret_material):
+    if secret_material is None:
+        yield None
+        return
+
+    fd, path = tempfile.mkstemp(prefix='zstack-luks-sec-', dir='/tmp')
+    try:
+        os.fchmod(fd, 0o600)
+        _write_all(fd, secret_material)
+        os.close(fd)
+        fd = None
+        yield path
+    finally:
+        if fd is not None:
+            os.close(fd)
+        rm_file_force(path)
+
+@contextlib.contextmanager
+def temporary_luks_secret_fifo(secret_material):
+    if secret_material is None:
+        yield None
+        return
+
+    path = os.path.join('/tmp', 'zstack-luks-fifo-%s' % uuid.uuid4().hex)
+    os.mkfifo(path, 0o600)
+    stop = [False]
+    errors = []
+
+    def write_secret():
+        fd = None
+        try:
+            while not stop[0]:
+                try:
+                    fd = os.open(path, os.O_WRONLY | os.O_NONBLOCK)
+                    break
+                except OSError as e:
+                    if e.errno == errno.ENXIO:
+                        time.sleep(0.05)
+                        continue
+                    raise
+            if fd is None:
+                return
+            _write_all(fd, secret_material)
+        except Exception as e:
+            errors.append(e)
+        finally:
+            if fd is not None:
+                os.close(fd)
+
+    writer = threading.Thread(target=write_secret)
+    writer.daemon = True
+    writer.start()
+    try:
+        yield path
+    finally:
+        stop[0] = True
+        writer.join(10)
+        rm_file_force(path)
+        if errors:
+            logger.warn('failed to write temporary LUKS secret FIFO %s: %s' % (path, errors[0]))
+
+def qcow2_commit_with_secret(top, base, secret_material_file):
+    if not secret_material_file:
+        raise Exception("qcow2_commit_with_secret requires a non-empty secret material file path")
+    try:
+        with _qcow2_image_opts_with_secret_context(top) as top_arg:
+            base_option = '' if qcow2_get_backing_file(top) == base else '-b %s' % shellquote(base)
+            shell.call('%s --object secret,id=luks_sec,format=raw,file=%s %s %s' %
+                       (qemu_img.subcmd('commit'), secret_material_file, base_option, top_arg))
+    finally:
+        rm_file_force(secret_material_file)
+
+def qcow2_rebase_with_secret(backing_file, target, secret_file_provider):
+    if not secret_file_provider or not callable(secret_file_provider):
+        raise Exception("qcow2_rebase_with_secret requires a non-empty LUKS secret file provider")
+
+    top_virtual_size = int(qcow2_get_virtual_size(target))
+    backing_chain = qcow2_get_backing_chain(target)
+    for idx, bf in enumerate(backing_chain):
+        if idx == len(backing_chain)-1 and get_img_fmt(bf) != 'qcow2':
+            break
+        bf_virtual_size = int(qcow2_get_virtual_size(bf))
+        if bf_virtual_size < top_virtual_size:
+            if is_luks_encrypted_image(bf):
+                with secret_file_provider() as resize_secret:
+                    with _qcow2_image_opts_with_secret_context(bf) as target_arg:
+                        shell.check_run('%s --object secret,id=luks_sec,format=raw,file=%s %s %s' %
+                                        (qemu_img.subcmd('resize'), resize_secret, target_arg, top_virtual_size))
+            else:
+                qemu_img_resize(bf, top_virtual_size)
+        if bf == backing_file:
+            break
+
+    if backing_file:
+        fmt = get_img_fmt(backing_file)
+        backing_arg = _qcow2_backing_arg_with_secret(backing_file)
+        backing_needs_reset = backing_arg != backing_file
+
+        def do_rebase(effective_backing_arg):
+            backing_option = '-F %s -b %s' % (fmt, shellquote(effective_backing_arg))
+            with _qcow2_image_opts_with_secret_context(target) as target_arg:
+                with secret_file_provider() as rebase_secret:
+                    shell.call('%s --object secret,id=luks_sec,format=raw,file=%s %s %s' %
+                               (qemu_img.subcmd('rebase'), rebase_secret, backing_option, target_arg))
+
+        if backing_needs_reset:
+            with _qcow2_backing_arg_with_secret_context(backing_file) as effective_backing_arg:
+                do_rebase(effective_backing_arg)
+        else:
+            do_rebase(backing_arg)
+    else:
+        backing_needs_reset = False
+        with _qcow2_image_opts_with_secret_context(target) as target_arg:
+            with secret_file_provider() as rebase_secret:
+                shell.call('%s --object secret,id=luks_sec,format=raw,file=%s -b "" %s' %
+                           (qemu_img.subcmd('rebase'), rebase_secret, target_arg))
+
+    if backing_file and backing_needs_reset:
+        with _qcow2_image_opts_with_secret_context(target, include_backing=False) as target_arg:
+            with secret_file_provider() as reset_secret:
+                shell.call('%s --object secret,id=luks_sec,format=raw,file=%s -F %s -u -b "%s" %s' %
+                           (qemu_img.subcmd('rebase'), reset_secret, fmt, backing_file, target_arg))
+
+def qcow2_rebase_no_check_with_secret(backing_file, target, secret_material_file, backing_fmt=None):
+    if not secret_material_file:
+        raise Exception("qcow2_rebase_no_check_with_secret requires a non-empty secret material file path")
+    try:
+        fmt = backing_fmt if backing_fmt else get_img_fmt(backing_file)
+        with _qcow2_image_opts_with_secret_context(target, include_backing=False) as target_arg:
+            shell.call('%s --object secret,id=luks_sec,format=raw,file=%s -F %s -u -b "%s" %s' %
+                       (qemu_img.subcmd('rebase'), secret_material_file, fmt, backing_file, target_arg))
+    finally:
+        rm_file_force(secret_material_file)
+
+def convert_qcow2_volume_encryption(src, dst, target_encrypted, secret_file_provider=None,
+                                    target_backing_file=None):
+    if not os.path.exists(src):
+        raise Exception("source image %s does not exist" % src)
+    if target_encrypted and not secret_file_provider:
+        raise Exception("target encrypted conversion requires a non-empty LUKS secret file provider")
+    if _qcow2_chain_has_luks_encrypted_image(src) and not secret_file_provider:
+        raise Exception("source image chain %s contains encrypted image but secret file provider is not provided" % src)
+
+    dst_dir = os.path.dirname(dst)
+    if dst_dir and not os.path.exists(dst_dir):
+        os.makedirs(dst_dir)
+
+    dst_is_block = _is_block_device(dst)
+    target_path = dst if dst_is_block else ("%s.creating.%s" % (dst, uuid.uuid4().hex))
+    backing_arg = target_backing_file
+    backing_fmt = None
+    backing_needs_reset = False
+    try:
+        if target_backing_file:
+            if not os.path.exists(target_backing_file):
+                raise Exception("target backing image %s does not exist" % target_backing_file)
+            backing_fmt = get_img_fmt(target_backing_file)
+            if _qcow2_chain_has_luks_encrypted_image(target_backing_file):
+                if not secret_file_provider:
+                    raise Exception("target backing image chain %s contains encrypted image but secret file provider is not provided" %
+                                    target_backing_file)
+                backing_arg = _qcow2_backing_arg_with_secret(target_backing_file)
+                backing_needs_reset = backing_arg != target_backing_file
+
+        out_opts = []
+        if target_encrypted:
+            out_opts.extend(["encrypt.format=luks", "encrypt.key-secret=luks_sec"])
+        out_opt = "-o %s" % ",".join(out_opts) if out_opts else ""
+
+        @contextlib.contextmanager
+        def src_arg_context():
+            if _qcow2_chain_has_luks_encrypted_image(src):
+                with _qcow2_image_opts_with_secret_context(src) as src_arg:
+                    yield src_arg
+            else:
+                yield "-f %s %s" % (get_img_fmt(src), shellquote(src))
+
+        def run_convert(effective_backing_arg):
+            backing_opt = ""
+            if target_backing_file:
+                backing_opt = "-F %s -B %s" % (backing_fmt, shellquote(effective_backing_arg))
+
+            if secret_file_provider:
+                with secret_file_provider() as secret_file:
+                    secret_opt = "--object secret,id=luks_sec,format=raw,file=%s" % shellquote(secret_file)
+                    shell.check_run("%s %s %s -O qcow2 %s %s %s" % (
+                        qemu_img.subcmd('convert'), secret_opt, src_arg, out_opt, backing_opt, shellquote(target_path)))
+            else:
+                shell.check_run("%s %s -O qcow2 %s %s %s" % (
+                    qemu_img.subcmd('convert'), src_arg, out_opt, backing_opt, shellquote(target_path)))
+
+        with src_arg_context() as src_arg:
+            if backing_needs_reset:
+                with _qcow2_backing_arg_with_secret_context(target_backing_file) as effective_backing_arg:
+                    run_convert(effective_backing_arg)
+            else:
+                run_convert(backing_arg)
+
+        if backing_needs_reset:
+            if target_encrypted:
+                with secret_file_provider() as reset_secret_file:
+                    reset_secret_opt = "--object secret,id=luks_sec,format=raw,file=%s" % shellquote(reset_secret_file)
+                    with _qcow2_image_opts_with_secret_context(target_path, include_backing=False) as target_arg:
+                        shell.check_run("%s %s -F %s -u -b %s %s" % (
+                            qemu_img.subcmd('rebase'), reset_secret_opt, backing_fmt,
+                            shellquote(target_backing_file), target_arg))
+            else:
+                reset_secret_opt = ""
+                target_arg = shellquote(target_path)
+                shell.check_run("%s %s -F %s -u -b %s %s" % (
+                    qemu_img.subcmd('rebase'), reset_secret_opt, backing_fmt,
+                    shellquote(target_backing_file), target_arg))
+
+        if not dst_is_block:
+            shell.check_run("mv -f %s %s" % (shellquote(target_path), shellquote(dst)))
+            os.chmod(dst, 0o660)
+        return os.path.getsize(dst)
+    finally:
+        if not dst_is_block and os.path.exists(target_path):
+            rm_file_force(target_path)
+
 def qcow2_create_with_backing_file(backing_file, dst, size=""):
     fmt = get_img_fmt(backing_file)
     shell.call('/usr/bin/qemu-img create -F %s -f qcow2 -b %s %s %s' % (fmt, backing_file, dst, size))
     os.chmod(dst, 0o660)
 
 def qcow2_create_with_backing_file_and_cmd(backing_file, dst, cmd=None, size=""):
+    secret_material_file = getattr(cmd, 'encryptLuksSecretMaterialFilePath', None) if cmd else None
+    if secret_material_file:
+        opt = ""
+        if cmd is not None and cmd.kvmHostAddons is not None and cmd.kvmHostAddons.qcow2Options is not None:
+            opt = cmd.kvmHostAddons.qcow2Options
+        return qcow2_clone_encrypted(backing_file, dst, secret_material_file, size=size, opt=opt)
     if cmd is None or cmd.kvmHostAddons is None or cmd.kvmHostAddons.qcow2Options is None:
         qcow2_create_with_backing_file(backing_file, dst, size)
     else:
@@ -1428,13 +2083,47 @@ def qcow2_virtualsize(file_path):
     out = cmd.stdout.strip(' \t\r\n')
     return long(out)
 
-def qcow2_get_backing_file(path):
+def qcow2_get_backing_file(path, normalize=True):
+    def json_image_opts_from_arg(arg):
+        if not arg or not arg.startswith('json:'):
+            return None
+        try:
+            return json.loads(arg[len('json:'):])
+        except Exception:
+            return None
+
+    def json_image_opts_file(opts):
+        if not isinstance(opts, dict):
+            return None
+        file_opts = opts.get('file')
+        if isinstance(file_opts, dict):
+            return file_opts.get('filename')
+        return None
+
+    def json_image_opts_backing_file(opts):
+        if not isinstance(opts, dict):
+            return None
+        return json_image_opts_file(opts.get('backing'))
+
+    def normalize_backing_arg(backing):
+        opts = json_image_opts_from_arg(backing)
+        if opts:
+            filename = json_image_opts_file(opts)
+            if filename:
+                return filename
+        return backing
+
+    json_opts = json_image_opts_from_arg(path)
+    if json_opts:
+        return json_image_opts_backing_file(json_opts) or ""
+
     if not os.path.exists(path) and ":" in path:
         # find through protocol
         out = shell.call("%s %s" %(qemu_img.subcmd('info'), path))
         for line in out.splitlines():
             if "backing file:" in line:
-                return line.replace("backing file:", "", 1).strip()
+                backing = line.replace("backing file:", "", 1).strip()
+                return normalize_backing_arg(backing) if normalize else backing
         return ""
 
     with open(path, 'r') as resp:
@@ -1451,7 +2140,8 @@ def qcow2_get_backing_file(path):
 
         backing_file_size = struct.unpack('>L', backing_file_info[8:])[0]
         resp.seek(backing_file_offset)
-        return resp.read(backing_file_size)
+        backing = resp.read(backing_file_size)
+        return normalize_backing_arg(backing) if normalize else backing
 
 def qcow2_get_virtual_size(path):
     # type: (str) -> int


### PR DESCRIPTION
Source: filtered from enc-test branch (commit "enc test"), excluding
cross_ps_copy_capability endpoints (migration). Includes:

- zstacklib utils: qcow2_luks helpers, volume_encryption_env switches
- kvmagent localstorage / shared_block create-path LUKS option plumbing
- kvmagent vm_plugin: disk XML <encryption> generation,
  ensure_volume_luks_secrets endpoint, online resize for LUKS RBD views
- ceph primarystorage agent + driver create-path LUKS option plumbing

sync from gitlab !7024