### PR TITLE
<fix>[zstackctl]: avoid empty mysql root password

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -3957,7 +3957,7 @@ Options:
         password for MySQL user 'zstack' that is the user ${PRODUCT_NAME} management nodes use to access database. By default, an empty password is applied.
 
   -P MYSQL_PASSWORD
-        password for MySQL root user. By default, an empty password is applied.
+        password for MySQL root user. By default, zstack.mysql.password is applied.
 
   -q    quiet installation. Installation will try to fix the system configuration issue, rather than quit installation process.
 
@@ -3997,7 +3997,7 @@ Following command will install the ${PRODUCT_NAME} management node to /usr/local
 . NFS server
 . Apache HTTP server
 
-And an empty password is set to the root user of MySQL.
+And zstack.mysql.password is set to the root user of MySQL.
 
 # ${PROGNAME} -a
 

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -3846,13 +3846,16 @@ class InstallDbCmd(Command):
         else:
             if not args.root_password:
                 args.root_password = args.login_password
-            more_cmd = ' '
+            more_cmd = "GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' IDENTIFIED BY '{root_pass}' WITH GRANT OPTION; ".format(root_pass=args.root_password)
+            more_cmd += "GRANT ALL PRIVILEGES ON *.* TO 'root'@'::1' IDENTIFIED BY '{root_pass}' WITH GRANT OPTION; ".format(root_pass=args.root_password)
+            more_cmd += "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '{root_pass}' WITH GRANT OPTION; ".format(root_pass=args.root_password)
             for ip in current_host_ips:
                 if not ip:
                     continue
                 more_cmd += "GRANT ALL PRIVILEGES ON *.* TO 'root'@'{}' IDENTIFIED BY '{}' WITH GRANT OPTION;".format(ip, args.root_password)
             grant_access_cmd = '''/usr/bin/mysql -u root -p{root_pass} -e '''\
                                '''"GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' IDENTIFIED BY '{root_pass}' WITH GRANT OPTION; '''\
+                               '''GRANT ALL PRIVILEGES ON *.* TO 'root'@'$(hostname)' IDENTIFIED BY '{root_pass}' WITH GRANT OPTION; '''\
                                '''GRANT ALL PRIVILEGES ON *.* TO 'root'@'{host}' IDENTIFIED BY '{root_pass}' WITH GRANT OPTION; '''\
                                '''{more_cmd} FLUSH PRIVILEGES;"'''.format(root_pass=args.root_password, host=args.host, more_cmd=more_cmd)
             if args.choose_database == 'GreatDB':


### PR DESCRIPTION
- install_db: reject omitted root/login passwords instead of creating
  root accounts with an empty password.
- install_db: reset MariaDB default root hosts, including hostname,
  127.0.0.1, ::1, %, target host, and current host IPs.
- install.sh: align help text with zstack.mysql.password.

Verified on local checkout: py_compile ctl.py, no IDENTIFIED BY ''
left, and git diff --check passed.

Resolves: ZSTAC-78927

Change-Id: I5f7c3a2b9d8e4f1a0b6c9d2e7f3a8b5c1d4e6f0a

sync from gitlab !7036