### PR TITLE
fix: inverted memory comparison prevented kvmagent debug dump

### DIFF
--- a/kvmagent/kvmagent/plugins/prometheus.py
+++ b/kvmagent/kvmagent/plugins/prometheus.py
@@ -2053,7 +2053,7 @@ def collect_kvmagent_memory_statistics():
     logger.warn("kvmagent used physical memory abnormal, used: %s" %
                 used_physical_memory)
     report_self_abnormal_memory_usage_if_need(used_physical_memory)
-    if used_physical_memory <= 4 * 1024**3:  # 4GB
+    if used_physical_memory >= 4 * 1024**3:  # 4GB
         dump_debug_info_if_need()
 
     return list(metrics.values())


### PR DESCRIPTION
## Summary
- Fix inverted comparison in `collect_kvmagent_memory_statistics()`: `<=` → `>=`
- When kvmagent memory exceeded 4GB, debug info was NOT dumped (opposite of intended behavior)
- This prevented effective debugging of kvmagent high memory usage issues

## Test plan
- [ ] Verify prometheus.py debug dump triggers when kvmagent memory > 4GB
- [ ] Verify no debug dump when memory < 4GB

sync from gitlab !7044