### PR TITLE
<fix>[kvm]: convert legacy RBD ISO snapshot XML

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -4409,8 +4409,8 @@ class Vm(object):
             _, disk_name = self._get_target_disk_by_path(oldpath)
             migrate_disks[disk_name] = volume
 
-        xml_changed = False
         tree = etree.ElementTree(etree.fromstring(self.get_migratable_xml()))
+        xml_changed = self._split_legacy_rbd_snapshot(tree.getroot())
         devices = tree.getroot().find('devices')
         for disk in tree.iterfind('devices/disk'):
             dev = disk.find('target').attrib['dev']
@@ -4425,6 +4425,32 @@ class Vm(object):
             return list(migrate_disks.keys()), etree.tostring(tree.getroot(), encoding="unicode")
         else:
             return None, None
+
+    @staticmethod
+    def _split_legacy_rbd_snapshot(root):
+        xml_changed = False
+        for disk in root.iterfind('devices/disk'):
+            if disk.get('type') != 'network':
+                continue
+
+            source = disk.find('source')
+            if source is None or source.get('protocol') != 'rbd':
+                continue
+
+            name = source.get('name')
+            if not name or '@' not in name:
+                continue
+
+            image_name, snapshot_name = name.rsplit('@', 1)
+            if not image_name or not snapshot_name:
+                continue
+
+            source.set('name', image_name)
+            if source.find('snapshot') is None:
+                etree.SubElement(source, 'snapshot', {'name': snapshot_name})
+            xml_changed = True
+
+        return xml_changed
 
     MIGRATE_VM_TASK_NAME = "MigrateVm"
     @staticmethod

--- a/tests/unit/kvmagent/test_vm_plugin_handlers.py
+++ b/tests/unit/kvmagent/test_vm_plugin_handlers.py
@@ -1281,6 +1281,186 @@ class TestDetachPciDeviceFromHostHandler:
 
 
 @pytest.mark.kvmagent
+class TestMigrateDomainXml:
+    def test_split_legacy_rbd_cdrom_snapshot(self):
+        domain_xml = """
+<domain type='kvm'>
+  <name>vm-uuid</name>
+  <devices>
+    <disk type='network' device='cdrom'>
+      <driver name='qemu' type='raw'/>
+      <source protocol='rbd' name='pool/image@snapshot'>
+        <host name='172.24.1.1' port='6789'/>
+      </source>
+      <target dev='hdc' bus='ide'/>
+      <readonly/>
+    </disk>
+  </devices>
+</domain>
+"""
+        vm = vm_plugin.Vm.__new__(vm_plugin.Vm)
+        vm.get_migratable_xml = MagicMock(return_value=domain_xml)
+
+        disks, dest_xml = vm._build_domain_new_xml({})
+
+        assert disks == []
+        root = ET.fromstring(dest_xml)
+        source = root.find("devices/disk/source")
+        assert source.attrib["name"] == "pool/image"
+        assert source.find("snapshot").attrib["name"] == "snapshot"
+
+    def test_split_legacy_rbd_data_disk_snapshot(self):
+        domain_xml = """
+<domain type='kvm'>
+  <name>vm-uuid</name>
+  <devices>
+    <disk type='network' device='disk'>
+      <driver name='qemu' type='raw'/>
+      <source protocol='rbd' name='pool/image@snapshot'>
+        <host name='172.24.1.1' port='6789'/>
+      </source>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+  </devices>
+</domain>
+"""
+        vm = vm_plugin.Vm.__new__(vm_plugin.Vm)
+        vm.get_migratable_xml = MagicMock(return_value=domain_xml)
+
+        disks, dest_xml = vm._build_domain_new_xml({})
+
+        assert disks == []
+        root = ET.fromstring(dest_xml)
+        source = root.find("devices/disk/source")
+        assert source.attrib["name"] == "pool/image"
+        assert source.find("snapshot").attrib["name"] == "snapshot"
+
+    def test_keeps_existing_rbd_cdrom_snapshot(self):
+        domain_xml = """
+<domain type='kvm'>
+  <name>vm-uuid</name>
+  <devices>
+    <disk type='network' device='cdrom'>
+      <driver name='qemu' type='raw'/>
+      <source protocol='rbd' name='pool/image@legacy-snapshot'>
+        <host name='172.24.1.1' port='6789'/>
+        <snapshot name='existing-snapshot'/>
+      </source>
+      <target dev='hdc' bus='ide'/>
+      <readonly/>
+    </disk>
+  </devices>
+</domain>
+"""
+        vm = vm_plugin.Vm.__new__(vm_plugin.Vm)
+        vm.get_migratable_xml = MagicMock(return_value=domain_xml)
+
+        _, dest_xml = vm._build_domain_new_xml({})
+
+        root = ET.fromstring(dest_xml)
+        source = root.find("devices/disk/source")
+        assert source.attrib["name"] == "pool/image"
+        assert source.find("snapshot").attrib["name"] == "existing-snapshot"
+        assert len(source.findall("snapshot")) == 1
+
+    def test_does_not_split_rbd_data_disk_without_snapshot(self):
+        domain_xml = """
+<domain type='kvm'>
+  <name>vm-uuid</name>
+  <devices>
+    <disk type='network' device='disk'>
+      <driver name='qemu' type='raw'/>
+      <source protocol='rbd' name='pool/image'>
+        <host name='172.24.1.1' port='6789'/>
+      </source>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+  </devices>
+</domain>
+"""
+        vm = vm_plugin.Vm.__new__(vm_plugin.Vm)
+        vm.get_migratable_xml = MagicMock(return_value=domain_xml)
+
+        disks, dest_xml = vm._build_domain_new_xml({})
+
+        assert disks is None
+        assert dest_xml is None
+
+    def test_splits_snapshot_when_replacing_migration_disk(self):
+        domain_xml = """
+<domain type='kvm'>
+  <name>vm-uuid</name>
+  <devices>
+    <disk type='network' device='cdrom'>
+      <driver name='qemu' type='raw'/>
+      <source protocol='rbd' name='pool/iso@snapshot'>
+        <host name='172.24.1.1' port='6789'/>
+      </source>
+      <target dev='hdc' bus='ide'/>
+      <readonly/>
+    </disk>
+    <disk type='network' device='disk'>
+      <driver name='qemu' type='raw'/>
+      <source protocol='rbd' name='pool/data-image'>
+        <host name='172.24.1.1' port='6789'/>
+      </source>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+  </devices>
+</domain>
+"""
+        vm = vm_plugin.Vm.__new__(vm_plugin.Vm)
+        vm.get_migratable_xml = MagicMock(return_value=domain_xml)
+        vm._get_target_disk_by_path = MagicMock(return_value=(None, "vda"))
+        volume = jsonobject.loads(json.dumps({
+            "deviceType": "ceph",
+            "installPath": "ceph://pool/replaced-data-image",
+            "useVirtioSCSI": False,
+            "useVirtio": True,
+            "shareable": False,
+            "secretUuid": None,
+            "monInfo": [],
+            "physicalBlockSize": None,
+            "format": "raw",
+            "backing_store": None,
+        }))
+
+        disks, dest_xml = vm._build_domain_new_xml({"ceph://pool/data-image": volume})
+
+        assert disks == ["vda"]
+        root = ET.fromstring(dest_xml)
+        sources = root.findall("devices/disk/source")
+        cdrom_source = sources[0]
+        disk_source = sources[1]
+        assert cdrom_source.attrib["name"] == "pool/iso"
+        assert cdrom_source.find("snapshot").attrib["name"] == "snapshot"
+        assert disk_source.attrib["name"] == "pool/replaced-data-image"
+
+    def test_does_not_split_non_rbd_network_disk_snapshot(self):
+        domain_xml = """
+<domain type='kvm'>
+  <name>vm-uuid</name>
+  <devices>
+    <disk type='network' device='disk'>
+      <driver name='qemu' type='raw'/>
+      <source protocol='cbd' name='pool/image@snapshot'>
+        <host name='172.24.1.1' port='7777'/>
+      </source>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+  </devices>
+</domain>
+"""
+        vm = vm_plugin.Vm.__new__(vm_plugin.Vm)
+        vm.get_migratable_xml = MagicMock(return_value=domain_xml)
+
+        disks, dest_xml = vm._build_domain_new_xml({})
+
+        assert disks is None
+        assert dest_xml is None
+
+
+@pytest.mark.kvmagent
 class TestBlockMigrateHandler:
     def test_block_migrate(self):
         plugin = _make_vm_plugin()


### PR DESCRIPTION
- migrate_vm: split legacy Ceph ISO cdrom source names from
  pool/image@snapshot into pool/image plus libvirt snapshot node.
- preserve existing structured snapshot nodes when both legacy name
  suffix and <snapshot> are present.
- keep RBD data disk XML unchanged.

Verified on local checkout: TestMigrateDomainXml passed with a
temporary paramiko stub, and git diff --check passed.

Resolves: ZSTAC-75935

Change-Id: I75935f2f0b8c4d1e9a6b3c7d5e4f1a2b9c8d7e6f

sync from gitlab !7055