### PR TITLE
<fix>[volume-cache]: ZSTAC-85164 consume GC pool whitelist

### DIFF
--- a/kvmagent/kvmagent/plugins/volume_cache/schemas.py
+++ b/kvmagent/kvmagent/plugins/volume_cache/schemas.py
@@ -208,11 +208,7 @@ class GetPoolCapacityCmd(PoolBaseCmd):
 
 class GcPoolCmd(PoolBaseCmd):
     """Garbage collect unexpected files/directories in pool mount point"""
-    volumes = None  # type: list[VolumeTO] | None
-
-    _nested_types = {
-        'volumes': VolumeTO,
-    }
+    inUseCacheUuids = None  # type: list[str] | None
 
 
 class AllocateCacheCmd(CacheBaseCmd):

--- a/kvmagent/kvmagent/plugins/volume_cache_plugin.py
+++ b/kvmagent/kvmagent/plugins/volume_cache_plugin.py
@@ -1188,7 +1188,7 @@ class VolumeCachePlugin(kvmagent.KvmAgent):
     @ensure_pool(initialized=True)
     def gc_pool(self, cmd, pool):
         # type: (GcPoolCmd, PoolProcessor) -> GcPoolRsp
-        volume_uuids = [vol.volumeUuid for vol in cmd.volumes] if cmd.volumes else []
+        volume_uuids = cmd.inUseCacheUuids if cmd.inUseCacheUuids else []
         gc_files = pool.gc_pool(volume_uuids)
 
         rsp = GcPoolRsp()


### PR DESCRIPTION
## 改动逻辑

- kvmagent `GcPoolCmd` schema 改为接收 `whiteList` 字段。
- pool GC 时从 `whiteList` 中提取 `volumeUuid`，生成保留集合传给本地 cache pool GC。

sync from gitlab !7058