### PR TITLE
<fix>[ovn]: ZCF-3603 honor explicit iface id

### DIFF
--- a/kvmagent/kvmagent/plugins/ovn.py
+++ b/kvmagent/kvmagent/plugins/ovn.py
@@ -456,7 +456,7 @@ class OvnNetworkPlugin(kvmagent.KvmAgent):
 
         for nicName, nicUuid in cmd.nicMap.__dict__.items():
             vm_uuid = cmd.nicVmInstanceUuidMap.__dict__.get(nicName, None)
-            vsctl.addVnic(nicName, nicUuid, vm_uuid, reinstall)
+            vsctl.addVnic(nicName, nicUuid, vm_uuid, reinstall, ifaceId=self._get_iface_id(cmd, nicName))
         rsp = OvnAddPortResponse()
 
         return jsonobject.dumps(rsp)
@@ -616,9 +616,17 @@ class OvnNetworkPlugin(kvmagent.KvmAgent):
 
         for nicName, nicUuid in cmd.nicMap.__dict__.items():
             if nicName not in localVnics:
-                vsctl.addVnic(nicName, nicUuid, cmd.vmUuid, False)
+                vsctl.addVnic(nicName, nicUuid, cmd.vmUuid, False, ifaceId=self._get_iface_id(cmd, nicName))
 
         return jsonobject.dumps(rsp)
+
+    def _get_iface_id(self, cmd, nicName):
+        iface_id_map = getattr(cmd, "ifaceIdMap", None)
+        if iface_id_map is None:
+            return None
+        if isinstance(iface_id_map, dict):
+            return iface_id_map.get(nicName, None)
+        return getattr(iface_id_map, "__dict__", {}).get(nicName, None)
 
     @kvmagent.replyerror
     @bash.in_bash

--- a/zstacklib/zstacklib/test/test_ovn_iface_id.py
+++ b/zstacklib/zstacklib/test/test_ovn_iface_id.py
@@ -1,0 +1,60 @@
+import unittest
+import sys
+import types
+
+sys.modules.setdefault("simplejson", types.ModuleType("simplejson"))
+sys.modules.setdefault("yaml", types.ModuleType("yaml"))
+
+bash = types.ModuleType("zstacklib.utils.bash")
+bash.in_bash = lambda fn: fn
+sys.modules.setdefault("zstacklib.utils.bash", bash)
+
+log = types.ModuleType("zstacklib.utils.log")
+log.get_logger = lambda name: type("Logger", (), {
+    "debug": lambda self, *args, **kwargs: None,
+    "error": lambda self, *args, **kwargs: None,
+    "info": lambda self, *args, **kwargs: None,
+    "warn": lambda self, *args, **kwargs: None,
+})()
+sys.modules.setdefault("zstacklib.utils.log", log)
+sys.modules.setdefault("zstacklib.utils.iproute", types.ModuleType("zstacklib.utils.iproute"))
+sys.modules.setdefault("zstacklib.utils.linux", types.ModuleType("zstacklib.utils.linux"))
+
+from zstacklib.utils import ovn
+
+
+class TestOvnIfaceId(unittest.TestCase):
+    def setUp(self):
+        self.commands = []
+        self.original_bash_r = ovn.bash.bash_r if hasattr(ovn.bash, "bash_r") else None
+        ovn.bash.bash_r = self.commands.append
+
+    def tearDown(self):
+        if self.original_bash_r is None:
+            del ovn.bash.bash_r
+        else:
+            ovn.bash.bash_r = self.original_bash_r
+
+    def test_zcf_3603_uses_explicit_iface_id(self):
+        self.assertEqual(
+            "zns-segment-port-iface",
+            ovn.getInterfaceId("vnic1.0", "cloud-nic-uuid", "zns-segment-port-iface")
+        )
+
+    def test_zcf_3603_keeps_ovn_fallback_iface_id(self):
+        self.assertEqual(
+            "vnic1.0_cloud-nic-uuid",
+            ovn.getInterfaceId("vnic1.0", "cloud-nic-uuid")
+        )
+
+    def test_zcf_3603_quotes_explicit_iface_id_in_add_port_command(self):
+        ovn.VsCtl().addVnic(
+            "vnic1.0", "cloud-nic-uuid", "vm-uuid", ifaceId="zns iface; touch /tmp/bad"
+        )
+
+        self.assertEqual(1, len(self.commands))
+        self.assertIn("external-ids:iface-id='zns iface; touch /tmp/bad'", self.commands[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zstacklib/zstacklib/utils/ovn.py
+++ b/zstacklib/zstacklib/utils/ovn.py
@@ -7,6 +7,7 @@ import yaml
 import glob
 import uuid
 import re
+import shlex
 import simplejson
 from enum import Enum, unique
 
@@ -33,6 +34,12 @@ BONDING_MODE_TCP = "balance-tcp"
 LACP_MODE_OFF = "off"
 LACP_MODE_ACTIVE = "active"
 LACP_MODE_PASSIVE = "passive"
+
+
+def getInterfaceId(nicName, nicUuid, ifaceId=None):
+    if ifaceId is not None and str(ifaceId).strip() != "":
+        return ifaceId
+    return "{}_{}".format(nicName, nicUuid)
 
 
 class OvsError(Exception):
@@ -376,26 +383,29 @@ class VsCtl(object):
             return []
 
     @bash.in_bash
-    def addVnic(self, nicName, nicUuid, vmUuid, reinstall=False, brName="br-int", nicType="dpdkvhostuserclient"):
+    def addVnic(self, nicName, nicUuid, vmUuid, reinstall=False, brName="br-int", nicType="dpdkvhostuserclient",
+                ifaceId=None):
         try:
             if vmUuid is not None and vmUuid.strip() != "":
                 vmUuid = vmUuid.replace('-', '')
             srcPath = OVS_DPDK_SRC_PATH + nicName
+            interfaceId = getInterfaceId(nicName, nicUuid, ifaceId)
+            safeInterfaceId = shlex.quote(str(interfaceId))
             if reinstall:
                 cmd = '{cmd} del-port {brName} {nicName}; ' \
                       '{cmd} add-port {brName} {nicName} ' \
                       '-- set Interface {nicName} type={nicType} options:vhost-server-path={srcPath} ' \
-                      '-- set interface {nicName} external-ids:iface-id={nicName}_{nicUuid} ' \
+                      '-- set interface {nicName} external-ids:iface-id={interfaceId} ' \
                       '-- set interface {nicName} external-ids:vm-uuid={vmUuid}'.format(
-                    cmd=CtlBin, brName=brName, nicName=nicName, nicType=nicType, srcPath=srcPath, nicUuid=nicUuid,
-                    vmUuid=vmUuid)
+                    cmd=CtlBin, brName=brName, nicName=nicName, nicType=nicType, srcPath=srcPath,
+                    vmUuid=vmUuid, interfaceId=safeInterfaceId)
             else:
                 cmd = CtlBin + '--may-exist add-port {brName} {nicName} ' \
                                '-- set Interface {nicName} type={nicType} options:vhost-server-path={srcPath} ' \
-                               '-- set interface {nicName} external-ids:iface-id={nicName}_{nicUuid} ' \
+                               '-- set interface {nicName} external-ids:iface-id={interfaceId} ' \
                                '-- set interface {nicName} external-ids:vm-uuid={vmUuid}'.format(
-                    brName=brName, nicName=nicName, nicType=nicType, srcPath=srcPath, nicUuid=nicUuid,
-                    vmUuid=vmUuid)
+                    brName=brName, nicName=nicName, nicType=nicType, srcPath=srcPath,
+                    vmUuid=vmUuid, interfaceId=safeInterfaceId)
             bash.bash_r(cmd)
         except Exception as err:
             logger.error(


### PR DESCRIPTION
## Summary
Honor explicit ifaceIdMap values in KVM agent OVS DPDK port creation while preserving the legacy nicName_nicUuid fallback.

## Changes
- Resolve interface id from ifaceIdMap in add/sync port requests.
- Reuse a helper for explicit iface-id or fallback generation.
- Add a focused unit test for explicit and fallback behavior.

## Testing
- [x] PYTHONPATH=zstacklib python3 -m unittest zstacklib.test.test_ovn_iface_id
- [x] mvn -Dtest=TestZnsVmNicLifeCycleCase test

Resolves: ZCF-3603

sync from gitlab !7062