### PR TITLE
<fix>[kvm]: report firstConnect and agent start time

### DIFF
--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -108,6 +108,8 @@ DISTRO_USING_DNF = ['rl84', 'h84r', 'ky10sp1', 'ky10sp2', 'ky10sp3',
 class ConnectResponse(kvmagent.AgentResponse):
     def __init__(self):
         super(ConnectResponse, self).__init__()
+        self.firstConnect = False
+        self.agentStartTimeMillis = 0
 
 
 class HostCapacityResponse(kvmagent.AgentResponse):
@@ -1166,6 +1168,8 @@ class HostPlugin(kvmagent.KvmAgent):
         self.IS_YUM = False
         self.IS_APT = False
         self.NVIDIA_SMI_INSTALLED = False
+        self._first_connect_after_boot = True
+        self._agent_start_time_millis = int(time.time() * 1000)
 
         if shell.run("which yum") == 0:
             self.IS_YUM = True
@@ -1209,6 +1213,8 @@ class HostPlugin(kvmagent.KvmAgent):
     def connect(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = ConnectResponse()
+        rsp.agentStartTimeMillis = self._agent_start_time_millis
+        rsp.firstConnect = self._first_connect_after_boot
 
         # page table extension
         if shell.run('lscpu | grep -q -w GenuineIntel') == 0:
@@ -1267,6 +1273,7 @@ class HostPlugin(kvmagent.KvmAgent):
         bash_r(get_ebtables_cmd() + ' -D FORWARD -j ZSTACK-VF-NICS')
         bash_r(get_ebtables_cmd() + ' -X ZSTACK-VF-NICS')
 
+        self._first_connect_after_boot = False
         return jsonobject.dumps(rsp)
 
     @thread.AsyncThread


### PR DESCRIPTION
## Summary
Agent-side companion for ZSTAC-58310. kvmagent now exposes `firstConnect` (true on the first `/host/connect` after process boot) and `agentStartTimeMillis` (epoch ms captured at HostPlugin init) in `ConnectResponse`, so MN can drain stale HTTP wrappers that were in flight against the previous agent process.

## Changes
- `HostPlugin.__init__` captures `_agent_start_time_millis = int(time.time() * 1000)` and sets `_first_connect_after_boot = True`.
- `def connect()` populates `rsp.firstConnect` + `rsp.agentStartTimeMillis` on the response and flips the flag to `False` after the connect handler finishes.
- `ConnectResponse` adds the two fields. `PingResponse` unchanged.

## Testing
- Companion zstack MR `fix/ZSTAC-58310@@2` carries the MN-side drain logic + a Groovy IT case `HostAgentRestartDrainCase` that exercises the helper end-to-end (3 sub-assertions, BUILD SUCCESS).

Resolves: ZSTAC-58310

sync from gitlab !7076