### PR TITLE
<fix>[cephps]: idempotent rbd rm on ENOENT

### DIFF
--- a/cephprimarystorage/cephprimarystorage/cephagent.py
+++ b/cephprimarystorage/cephprimarystorage/cephagent.py
@@ -1079,10 +1079,6 @@ class CephAgent(plugin.TaskManager):
         driver = self.get_driver(cmd)
         driver.do_deletion(cmd)
 
-        @linux.retry(times=30, sleep_time=5)
-        def do_deletion():
-            shell.call('rbd rm %s' % path)
-
         def do_zeroed(path):
             try:
                 nbd_dev = nbd.connect(path)
@@ -1095,8 +1091,6 @@ class CephAgent(plugin.TaskManager):
 
         if cmd.zeroed:
             do_zeroed(path)
-            
-        do_deletion()
 
         self._set_capacity_to_response(rsp)
         return jsonobject.dumps(rsp)

--- a/cephprimarystorage/cephprimarystorage/cephdriver.py
+++ b/cephprimarystorage/cephprimarystorage/cephdriver.py
@@ -64,7 +64,17 @@ class CephDriver(object):
     def do_deletion(self, cmd):
         path = self._normalize_install_path(cmd.installPath)
 
-        shell.call('rbd rm %s' % path)
+        try:
+            shell.call('rbd rm %s' % path)
+        except shell.ShellError as e:
+            # XSky's librbd_proxy starts async GC on the first rbd rm and
+            # immediately reports the image as gone (XBD result -2), so any
+            # subsequent retry sees ENOENT. The desired end-state is achieved,
+            # treat as idempotent success.
+            if 'No such file or directory' in str(e):
+                logger.warn('rbd image %s already gone, treat delete as success: %s' % (path, str(e)))
+                return
+            raise
 
     def create_snapshot(self, cmd, rsp):
         spath = self._normalize_install_path(cmd.snapshotPath)


### PR DESCRIPTION
XSky's librbd_proxy starts async GC on the first rbd rm and
immediately reports the image as gone (XBD result -2), so
every subsequent attempt sees ENOENT. The 4.4.52-sm delete
path failed in two compounding ways:

1. cephdriver.do_deletion let the ENOENT propagate, and the
   @retry(times=30) decorator exhausted retries before
   bubbling up. The mgmt server marked the delete as failed,
   kept the volume record, and subsequent volume creation hit
   insufficient capacity even though XSky had already freed it.

2. cephagent.delete() defined a redundant inner do_deletion()
   closure and called it AFTER driver.do_deletion(cmd). The
   second rbd rm always saw ENOENT because the first call had
   already removed the image; the closure had no ENOENT
   handling so the whole delete failed on every call.

Fix: cephdriver.do_deletion catches shell.ShellError and
treats 'No such file or directory' as idempotent success.
cephagent.delete drops the redundant nested closure and
relies on driver.do_deletion which is now idempotent.

Verified:
- UT mocks shell.call to raise ShellError('No such file or
  directory'); do_deletion returns without exception and does
  not retry.
- E2E on the reporter's environment (172.24.249.48): full
  create -> delete lifecycle succeeds with a single rbd rm;
  direct do_deletion on an already-gone image logs
  'already gone, treat delete as success' and returns
  normally.

Resolves: ZSTAC-85229

Change-Id: I91750a0622016977caa1d3e8bf9003d3d8e9b56a


(cherry picked from commit 98013b17f0d020d97437673439e04b35439a8d8c)

sync from gitlab !7079