### PR TITLE
<fix>[tests]: drive empty-retry path in block-job test

### DIFF
--- a/tests/unit/kvmagent/test_vm_plugin_handlers.py
+++ b/tests/unit/kvmagent/test_vm_plugin_handlers.py
@@ -313,7 +313,10 @@ class TestGetIothreadPinHandler:
 class TestQueryBlockJobStatusHandler:
     def test_query_block_job_status(self):
         plugin = _make_vm_plugin()
-        vm_plugin.qmp.execute_qmp_command = MagicMock()
+        # return [] so the empty-result retry loop in query_block_job_status
+        # is actually exercised; bare MagicMock() returns a truthy mock which
+        # would break out of the loop on the first iteration (call_count=1).
+        vm_plugin.qmp.execute_qmp_command = MagicMock(return_value=[])
         with patch('time.sleep', return_value=None):
             req = _make_req({'vmUuid': 'vm-uuid'})
             result = plugin.query_block_job_status(req)


### PR DESCRIPTION
## Summary

`tests.unit.kvmagent.test_vm_plugin_handlers.TestQueryBlockJobStatusHandler::test_query_block_job_status` has been failing on every CI run since ZSTAC-81150 reshaped `query_block_job_status` from an unconditional 6-iteration loop to "1 initial call + up to 5 retries that break on the first truthy result". The matching test was not updated alongside that prod change.

Test setup uses bare `MagicMock()` for `qmp.execute_qmp_command`. A `MagicMock` instance is truthy, so the new prod loop breaks out after the first call, yielding `call_count == 1` while the test still asserts `6`.

## Fix

Set `MagicMock(return_value=[])` so the empty-list branch (`if block_jobs: break` evaluates to False) actually drives the retry path. `1 initial + 5 retries == 6` — matches the existing assertion and the behavior introduced by ZSTAC-81150. Assertion intentionally untouched.

Same pattern is already used in this file at line 1148 for similar retry-loop coverage; this just brings line 316 in line with that convention.

## Evidence

CI log: `http://minio.zstack.io:9001/mr.test.logs/UtilityUT/3354599/UtilityUT__3354599__x86_64__c76__pytest__tests__unit__kvmagent__test_vm_plugin_handlers__TestQueryBlockJobStatusHandler__test_query_block_job_status.log` ends with `AssertionError: assert 1 == 6`.

Local repro on this branch:
- Pre-fix (stash the diff, re-run): `AssertionError: assert 1 == 6` — bit-identical to CI.
- Post-fix: `1 passed, 12 warnings in 0.55s`.

## Testing
- [x] `pytest tests/unit/kvmagent/test_vm_plugin_handlers.py::TestQueryBlockJobStatusHandler::test_query_block_job_status` PASS locally on 5.5.22 base.
- [ ] CI pipeline

Resolves: ZSTAC-81150

sync from gitlab !7092