### PR TITLE
<feature>[kvm]: ZSTAC-82672 report qemu-kvm package version

### DIFF
--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -129,6 +129,7 @@ class HostFactResponse(kvmagent.AgentResponse):
         self.osVersion = None
         self.osRelease = None
         self.qemuImgVersion = None
+        self.qemuKvmPackageVersion = None
         self.libvirtVersion = None
         self.hvmCpuFlag = None
         self.cpuModelName = None
@@ -1400,6 +1401,8 @@ class HostPlugin(kvmagent.KvmAgent):
                 rsp.powerSupplyMaxPowerCapacity = ''.join(re.findall(r'\d+', power_supply_max_power_capacity.strip()))
 
         rsp.qemuImgVersion = qemu_img_version
+        if self.IS_YUM:
+            rsp.qemuKvmPackageVersion = linux.get_rpm_version("qemu-kvm")
         rsp.libvirtVersion = self.libvirt_version
         rsp.libvirtPackageVersion = linux.get_libvirt_package_version()
         rsp.ipAddresses = ipV4Addrs


### PR DESCRIPTION
## Summary
Report the qemu-kvm RPM package version in KVM host facts so Cloud can derive the IOThread VQ mapping capability from package-level backports.

## Changes
- Add `qemuKvmPackageVersion` to KVM Agent `HostFactResponse`.
- Fill the field with `linux.get_rpm_version("qemu-kvm")` during host fact collection.

## Testing
- [x] `git diff --check`
- [x] `openspec validate --changes zbs-iothread-vq-mapping`
- [ ] Agent runtime test not run locally.

Resolves: ZSTAC-82672

sync from gitlab !7104