### PR TITLE
<fix>[kvmagent]: idempotent block_commit and merge_snapshot

### DIFF
--- a/kvmagent/kvmagent/plugins/localstorage.py
+++ b/kvmagent/kvmagent/plugins/localstorage.py
@@ -801,8 +801,11 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
         if not os.path.exists(workspace_dir):
             os.makedirs(workspace_dir)
 
-        t_shell = traceable_shell.get_shell(cmd)
-        linux.create_template(cmd.snapshotInstallPath, cmd.workspaceInstallPath, shell=t_shell)
+        # Idempotency: if a previous (possibly retried) call already produced
+        # the workspace template, skip the expensive qemu-img convert.
+        if not qcow2.already_template_of(cmd.snapshotInstallPath, cmd.workspaceInstallPath):
+            t_shell = traceable_shell.get_shell(cmd)
+            linux.create_template(cmd.snapshotInstallPath, cmd.workspaceInstallPath, shell=t_shell)
         rsp.size, rsp.actualSize = linux.qcow2_size_and_actual_size(cmd.workspaceInstallPath)
 
         rsp.totalCapacity, rsp.availableCapacity = self._get_disk_capacity(cmd.storagePath)
@@ -813,11 +816,13 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         snapshots = cmd.snapshotInstallPaths
         count = len(snapshots)
+        # Idempotency: only do the rebases that haven't already been done.
         for i in range(count):
             if i+1 < count:
                 target = snapshots[i]
                 backing_file = snapshots[i+1]
-                linux.qcow2_rebase_no_check(backing_file, target)
+                if linux.qcow2_get_backing_file(target) != backing_file:
+                    linux.qcow2_rebase_no_check(backing_file, target)
 
         latest = snapshots[0]
         rsp = RebaseAndMergeSnapshotsRsp()
@@ -825,7 +830,8 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
         if not os.path.exists(workspace_dir):
             os.makedirs(workspace_dir)
 
-        linux.create_template(latest, cmd.workspaceInstallPath)
+        if not qcow2.already_template_of(latest, cmd.workspaceInstallPath):
+            linux.create_template(latest, cmd.workspaceInstallPath)
         rsp.size, rsp.actualSize = linux.qcow2_size_and_actual_size(cmd.workspaceInstallPath)
 
         rsp.totalCapacity, rsp.availableCapacity = self._get_disk_capacity(cmd.storagePath)

--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -1199,6 +1199,18 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         lvm.update_pv_allocate_strategy(cmd)
         with lvm.RecursiveOperateLv(snapshot_abs_path, shared=True):
             virtual_size = linux.qcow2_virtualsize(snapshot_abs_path)
+            # Idempotency: if the workspace LV already exists AND already
+            # holds a self-contained template of the snapshot, skip the
+            # expensive qemu-img convert (which would otherwise re-run on
+            # every retry of this HTTP request).
+            if lvm.lv_exists(workspace_abs_path):
+                with lvm.OperateLv(workspace_abs_path, shared=False):
+                    if qcow2.already_template_of(snapshot_abs_path, workspace_abs_path):
+                        rsp.size = virtual_size
+                        rsp.actualSize = int(lvm.get_lv_size(workspace_abs_path))
+                        rsp.totalCapacity, rsp.availableCapacity = lvm.get_vg_size(cmd.vgUuid)
+                        return jsonobject.dumps(rsp)
+
             lv_size = max(self.get_total_required_size(snapshot_abs_path), int(lvm.get_lv_size(snapshot_abs_path)))
             if not lvm.lv_exists(workspace_abs_path):
                 pe_ranges = lvm.get_lv_affinity_sorted_pvs(snapshot_abs_path, cmd)

--- a/kvmagent/kvmagent/plugins/shared_mountpoint_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_mountpoint_plugin.py
@@ -472,8 +472,11 @@ class SharedMountPointPrimaryStoragePlugin(kvmagent.KvmAgent):
         if not os.path.exists(workspace_dir):
             os.makedirs(workspace_dir)
 
-        t_shell = traceable_shell.get_shell(cmd)
-        linux.create_template(cmd.snapshotInstallPath, cmd.workspaceInstallPath, shell=t_shell)
+        # Idempotency: skip the qemu-img convert if a previous (retried) call
+        # already produced the workspace template.
+        if not qcow2.already_template_of(cmd.snapshotInstallPath, cmd.workspaceInstallPath):
+            t_shell = traceable_shell.get_shell(cmd)
+            linux.create_template(cmd.snapshotInstallPath, cmd.workspaceInstallPath, shell=t_shell)
         rsp.size, rsp.actualSize = linux.qcow2_size_and_actual_size(cmd.workspaceInstallPath)
 
         rsp.totalCapacity, rsp.availableCapacity = self._get_disk_capacity(cmd.mountPoint)

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -3978,6 +3978,30 @@ class Vm(object):
         base = get_volume_actual_installpath(task_spec.base)
         install_path = VmPlugin.get_source_file_by_disk(target_disk)
         active_commit = top == install_path
+
+        # Idempotency guard: detect work already done by a previous (interrupted) call.
+        # 1) `top` no longer in chain AND `base` is in chain  ->  commit already happened.
+        # 2) A libvirt block job is still running on this disk  ->  take over instead of
+        #    re-issuing blockCommit (which libvirt would reject as duplicate).
+        try:
+            current_chain = self.get_disk_chain_by_volume(volume)
+        except Exception:
+            current_chain = []
+        if current_chain and (top not in current_chain) and (base in current_chain):
+            logger.debug('block commit skipped: top[%s] already merged into base[%s] for disk %s'
+                         % (top, base, disk_name))
+            return base
+        try:
+            inflight = bool(self.domain.blockJobInfo(disk_name, 0))
+        except Exception:
+            inflight = False
+        if inflight:
+            logger.debug('block commit detected in-flight job on %s, awaiting completion' % disk_name)
+            with BlockCommitDaemon(task_spec, self, disk_name, top=top, base=base, active_commit=active_commit) as d:
+                if not self.await_block_job(disk_name, d.get_remaining_timeout()):
+                    raise kvmagent.KvmError('block commit failed - previous block job did not finish')
+            return base
+
         with BlockCommitDaemon(task_spec, self, disk_name, top=top, base=base, active_commit=active_commit) as d:
             return do_block_commit_disk(task_spec, disk_name, task_spec.top, task_spec.base, active_commit)
 
@@ -4102,6 +4126,44 @@ class Vm(object):
                 res.append(src_file)
 
         return res
+
+    def get_disk_chain_by_volume(self, volume):
+        """Return the active->bottom chain for the disk that hosts `volume`.
+
+        First element is the active (top) source file. Empty list if not found.
+        Used by idempotent block_commit/merge_snapshot to skip work that has
+        already been done in a previous (interrupted) call.
+        """
+        try:
+            target_disk, _ = self._get_target_disk(volume, is_exception=False)
+        except Exception:
+            target_disk = None
+        if not target_disk:
+            return []
+        try:
+            install_path = VmPlugin.get_source_file_by_disk(target_disk)
+        except Exception:
+            install_path = None
+        if not install_path:
+            return []
+        chain = [install_path]
+        chain.extend(self._get_backfile_chain(install_path))
+        return chain
+
+    def await_block_job(self, disk_name, timeout):
+        """Block until libvirt reports no more block job on `disk_name`.
+
+        Returns True if the job completed within timeout (or there was no job
+        to begin with), False if it timed out.
+
+        Used to take over an in-flight block job left by a previous request,
+        without re-issuing blockCommit/blockRebase (which libvirt would reject
+        or duplicate).
+        """
+        def _poll(_):
+            return not self._wait_for_block_job(disk_name, abort_on_error=False)
+        return linux.wait_callback_success(_poll, timeout=timeout,
+                                           ignore_exception_in_callback=True)
 
     def get_all_disk_backing_chain(self):
         # type: () -> list
@@ -5055,11 +5117,48 @@ class Vm(object):
 
             logger.debug('end block rebase [active: %s, new backing: %s]' % (top, base))
 
+        # Idempotency guard: if destPath already has the desired backing
+        # (or no backing for fullRebase), the merge has already happened in a
+        # previous (possibly interrupted) call -- nothing to do.
+        try:
+            current_backing = self._get_back_file(cmd.destPath) or ""
+        except Exception:
+            current_backing = None
+        target_backing = "" if cmd.fullRebase else cmd.srcPath
+        if current_backing is not None and current_backing == target_backing:
+            logger.debug('merge_snapshot skipped: %s already has backing %r' %
+                         (cmd.destPath, target_backing))
+            # Still drain any leftover block job to keep libvirt clean.
+            try:
+                if self.domain.blockJobInfo(disk_name, 0):
+                    self.await_block_job(disk_name, 60)
+            except Exception:
+                pass
+            return
+
         self._check_snapshot_can_livemerge(cmd.srcPath, cmd.destPath,
                                            cmd.fullRebase)
         # confirm MergeSnapshotDaemon's cancel will be invoked before block job wait
         base = None if cmd.fullRebase else cmd.srcPath
         with MergeSnapshotDaemon(cmd, self, disk_name, top=cmd.destPath, base=base) as d:
+            # If a block job is already running on this disk (e.g. previous
+            # request issued blockRebase but lost the reply), take it over
+            # instead of re-issuing.
+            try:
+                inflight = bool(self.domain.blockJobInfo(disk_name, 0))
+            except Exception:
+                inflight = False
+            if inflight:
+                logger.debug('merge_snapshot detected in-flight block job on %s, awaiting completion' % disk_name)
+                if not self.await_block_job(disk_name, d.get_remaining_timeout()):
+                    raise kvmagent.KvmError('merge snapshot failed - previous block job did not finish')
+                # Verify final backing matches expectation.
+                final_backing = self._get_back_file(cmd.destPath) or ""
+                if final_backing != target_backing:
+                    raise kvmagent.KvmError(
+                        'merge snapshot inflight job finished but backing mismatch: expect %r got %r'
+                        % (target_backing, final_backing))
+                return
             do_pull(base, cmd.destPath)
 
     def take_volumes_shallow_backup(self, task_spec, volumes, dst_backup_paths):
@@ -9864,7 +9963,7 @@ host side snapshot files chian:
             rsp.success = False
             return jsonobject.dumps(rsp)
 
-        rsp.size = VmPlugin._get_snapshot_size(cmd.base)
+        rsp.size = VmPlugin._get_snapshot_size(cmd.base) if os.path.exists(cmd.base) else 0
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror

--- a/zstacklib/zstacklib/utils/qcow2.py
+++ b/zstacklib/zstacklib/utils/qcow2.py
@@ -1,4 +1,5 @@
 import log
+import os
 import plugin
 import traceable_shell
 import report
@@ -6,6 +7,48 @@ import linux
 import tempfile
 
 logger = log.get_logger(__name__)
+
+
+def already_template_of(src, dst):
+    """Return True iff `dst` already exists as a self-contained qcow2 file
+    (no backing) whose virtual size matches `src` -- i.e. an earlier
+    create_template(src, dst) call already finished. Used as an idempotency
+    guard for retried merge_snapshot HTTP requests.
+
+    Conservative: any error in inspection -> False (re-do the work).
+    """
+    try:
+        if not os.path.exists(dst):
+            return False
+        if linux.qcow2_get_backing_file(dst):
+            return False
+        if int(linux.qcow2_virtualsize(dst)) != int(linux.qcow2_virtualsize(src)):
+            return False
+        return True
+    except Exception as e:
+        logger.debug('already_template_of(%s,%s) check failed: %s' % (src, dst, e))
+        return False
+
+
+def backing_chain_already_collapsed(snapshots):
+    """For a list of snapshot file paths [s0, s1, s2, ...] where the caller
+    intends to rebase s_i to point at s_{i+1}, return True if every adjacent
+    pair already has the expected backing relationship.
+
+    Used by merge_and_rebase_snapshot to skip rebases that have all already
+    happened in a previous (interrupted) call.
+    """
+    try:
+        for i in range(len(snapshots) - 1):
+            target = snapshots[i]
+            expected_backing = snapshots[i + 1]
+            if linux.qcow2_get_backing_file(target) != expected_backing:
+                return False
+        return True
+    except Exception as e:
+        logger.debug('backing_chain check failed: %s' % e)
+        return False
+
 
 def create_template_with_task_daemon(src, dst, task_spec, dst_format='qcow2', opts=None, **daemonargs):
     t_shell = traceable_shell.get_shell(task_spec)


### PR DESCRIPTION
Add idempotency guards in vm_plugin.block_commit and merge_snapshot
so that a retried request after MN reconnect or kvmagent restart does
not duplicate or conflict with a previous in-flight libvirt block job.

block_commit:
  - if top is no longer in the disk chain AND base is, the commit
    already finished and the call returns base directly
  - if libvirt reports an in-flight block job on this disk, take it
    over via await_block_job instead of re-issuing blockCommit which
    libvirt would reject as duplicate

merge_snapshot:
  - if destPath already has the desired backing (or no backing for
    fullRebase), skip and drain any leftover block job
  - take over in-flight block job left by a previous request

Storage-side companion guards in Local, SharedBlock and SharedMount
plugins plus zstacklib qcow2 helper make the per-storage commit and
rebase paths idempotent across retries.

Resolves: ZSV-10538

Change-Id: I73e7453fa7a5fc370b627280cd7ffb4e05f92ecf

sync from gitlab !7109