### PR TITLE
<fix>[kvmagent]: fix userdata access on alinux4

### DIFF
--- a/kvmagent/kvmagent/plugins/mevoco.py
+++ b/kvmagent/kvmagent/plugins/mevoco.py
@@ -27,6 +27,8 @@ from jinja2 import Template
 import struct
 import socket
 import platform
+import traceback
+import xml.etree.ElementTree as etree
 
 from zstacklib.utils.ovs import OvsError
 
@@ -131,10 +133,7 @@ class NamespaceInfraEnv(object):
         if ret != 0:
             bash_errorout(get_ebtables_cmd() + ' -t nat -N {{EBCHAIN_NAME}}')
 
-        if bash_r(get_ebtables_cmd() + " -t nat -L PREROUTING | grep -E -- '(--logical-in|-i) {{BR_NAME}} -j {{EBCHAIN_NAME}}'") != 0:
-            # try --logical-in first; fall back to -i for kernels (e.g. alinux4 >= 6.6.102-5.3) that reject `meta ibrname`
-            if bash_r(get_ebtables_cmd() + ' -t nat -I PREROUTING --logical-in {{BR_NAME}} -j {{EBCHAIN_NAME}}') != 0:
-                bash_errorout(get_ebtables_cmd() + ' -t nat -I PREROUTING -i {{BR_NAME}} -j {{EBCHAIN_NAME}}')
+        _ensure_userdata_prerouting_rule(BR_NAME, EBCHAIN_NAME, ETH_NAME)
 
         # ebtables has a bug that will eliminate 0 in MAC, for example, aa:bb:0c will become aa:bb:c
         macAddr = ip.removeZeroFromMacAddress(MAC)
@@ -800,6 +799,108 @@ def is_ebtables_nf_tables():
         raise Exception('Failed to get ebtables version')
     return "nf_tables" in o
 
+
+def is_userdata_vm_bridge_port(port_name, bridge_phy_dev):
+    if not port_name or port_name == bridge_phy_dev:
+        return False
+    if port_name.startswith('outer') or port_name.startswith('ud_outer'):
+        return False
+    return port_name.startswith('vnic') or port_name.startswith('tap')
+
+
+def get_userdata_prerouting_chains_for_bridge(bridge_name):
+    bridge_name = ebtables.validate_name(bridge_name, 'bridge name')
+    chains = set()
+    output = shell.call(get_ebtables_cmd() + " -t nat -L PREROUTING")
+    for line in output.splitlines():
+        line = line.strip()
+        for prefix in ("--logical-in %s -j " % bridge_name, "-i %s -j " % bridge_name):
+            if not line.startswith(prefix):
+                continue
+            chain_name = line[len(prefix):].split()[0]
+            if chain_name.startswith('UD-') or chain_name.startswith('USERDATA-'):
+                chains.add(ebtables.validate_name(chain_name, 'ebtables chain'))
+    return sorted(chains)
+
+
+def get_userdata_prerouting_vm_port_rules():
+    rules = []
+    output = shell.call(get_ebtables_cmd() + " -t nat -L PREROUTING")
+    for line in output.splitlines():
+        items = line.strip().split()
+        if len(items) < 4 or items[0] != '-i' or items[2] != '-j':
+            continue
+        port_name = items[1]
+        chain_name = items[3]
+        if not is_userdata_vm_bridge_port(port_name, None):
+            continue
+        if not chain_name.startswith('UD-') and not chain_name.startswith('USERDATA-'):
+            continue
+        rules.append((
+            ebtables.validate_name(port_name, 'bridge port'),
+            ebtables.validate_name(chain_name, 'ebtables chain')
+        ))
+    return rules
+
+
+def _delete_userdata_prerouting_rule_for_port(port_name, chain_name):
+    port_name = ebtables.validate_name(port_name, 'bridge port')
+    chain_name = ebtables.validate_name(chain_name, 'ebtables chain')
+    rule = "-i %s -j %s" % (port_name, chain_name)
+    for _ in range(20):
+        if not ebtables.has_nat_prerouting_rule(rule):
+            return
+        bash_errorout(get_ebtables_cmd() + ' -t nat -D PREROUTING -i %s -j %s' % (port_name, chain_name))
+
+
+@lock.file_lock('/run/xtables.lock')
+def delete_userdata_prerouting_rule_for_port(port_name, chain_name):
+    _delete_userdata_prerouting_rule_for_port(port_name, chain_name)
+
+
+def _cleanup_stale_userdata_prerouting_rules():
+    if not is_ebtables_nf_tables():
+        return
+    for port_name, chain_name in get_userdata_prerouting_vm_port_rules():
+        if not linux.is_network_device_existing(port_name):
+            _delete_userdata_prerouting_rule_for_port(port_name, chain_name)
+
+
+@lock.file_lock('/run/xtables.lock')
+def cleanup_stale_userdata_prerouting_rules():
+    _cleanup_stale_userdata_prerouting_rules()
+
+
+def _ensure_userdata_prerouting_rule(bridge_name, chain_name, bridge_phy_dev):
+    bridge_name = ebtables.validate_name(bridge_name, 'bridge name')
+    chain_name = ebtables.validate_name(chain_name, 'ebtables chain')
+    if bridge_phy_dev:
+        bridge_phy_dev = ebtables.validate_name(bridge_phy_dev, 'bridge physical device')
+
+    logical_rule = "--logical-in %s -j %s" % (bridge_name, chain_name)
+    iface_rule = "-i %s -j %s" % (bridge_name, chain_name)
+    if not ebtables.has_nat_prerouting_rule(logical_rule) and not ebtables.has_nat_prerouting_rule(iface_rule):
+        if bash_r(get_ebtables_cmd() + ' -t nat -I PREROUTING --logical-in %s -j %s' % (bridge_name, chain_name)) != 0:
+            bash_errorout(get_ebtables_cmd() + ' -t nat -I PREROUTING -i %s -j %s' % (bridge_name, chain_name))
+
+    if not is_ebtables_nf_tables():
+        return
+
+    for port_name in linux.get_all_bridge_interface(bridge_name):
+        if not port_name:
+            continue
+        port_name = ebtables.validate_name(port_name, 'bridge port')
+        if not is_userdata_vm_bridge_port(port_name, bridge_phy_dev):
+            continue
+        if not ebtables.has_nat_prerouting_rule("-i %s -j %s" % (port_name, chain_name)):
+            bash_errorout(get_ebtables_cmd() + ' -t nat -I PREROUTING -i %s -j %s' % (port_name, chain_name))
+
+
+@lock.file_lock('/run/xtables.lock')
+def ensure_userdata_prerouting_rule(bridge_name, chain_name, bridge_phy_dev):
+    _ensure_userdata_prerouting_rule(bridge_name, chain_name, bridge_phy_dev)
+
+
 class UserDataEnv(object):
     def __init__(self, bridge_name, namespace_name, vlan_id):
         self.bridge_name = bridge_name
@@ -1170,10 +1271,71 @@ class Mevoco(kvmagent.KvmAgent):
         http_server.register_async_uri(self.CLEANUP_USER_DATA, self.cleanup_userdata)
         http_server.register_async_uri(self.SET_DNS_FORWARD_PATH, self.setup_dns_forward)
         http_server.register_async_uri(self.REMOVE_DNS_FORWARD_PATH, self.remove_dns_forward)
+        self._register_userdata_vm_lifecycle_hook()
         self.register_dnsmasq_logRotate()
+        try:
+            cleanup_stale_userdata_prerouting_rules()
+        except Exception:
+            logger.warn("failed to cleanup stale userdata ebtables on plugin start: %s" % traceback.format_exc())
 
     def stop(self):
         pass
+
+    def _register_userdata_vm_lifecycle_hook(self):
+        from kvmagent.plugins import vm_plugin
+        import libvirt
+
+        callbacks = vm_plugin.LibvirtAutoReconnect.libvirt_event_callbacks.get(
+            libvirt.VIR_DOMAIN_EVENT_ID_LIFECYCLE, []
+        )
+        if self._on_vm_started_update_userdata_ebtables not in callbacks:
+            vm_plugin.LibvirtAutoReconnect.add_libvirt_callback(
+                libvirt.VIR_DOMAIN_EVENT_ID_LIFECYCLE,
+                self._on_vm_started_update_userdata_ebtables
+            )
+
+    def _on_vm_started_update_userdata_ebtables(self, conn, dom, event, detail, opaque):
+        try:
+            from kvmagent.plugins import vm_plugin
+
+            event = vm_plugin.LibvirtEventManager.event_to_string(event)
+            if event not in (vm_plugin.LibvirtEventManager.EVENT_STARTED, vm_plugin.LibvirtEventManager.EVENT_STOPPED):
+                return
+
+            if not is_ebtables_nf_tables():
+                return
+
+            bridge_ports = []
+            try:
+                root = etree.fromstring(dom.XMLDesc(0))
+            except Exception:
+                if event == vm_plugin.LibvirtEventManager.EVENT_STOPPED:
+                    cleanup_stale_userdata_prerouting_rules()
+                    return
+                raise
+
+            for iface in root.findall('./devices/interface'):
+                if iface.get('type') != 'bridge':
+                    continue
+                source = iface.find('source')
+                target = iface.find('target')
+                if source is None or target is None:
+                    continue
+                bridge_name = source.get('bridge')
+                port_name = target.get('dev')
+                if bridge_name and is_userdata_vm_bridge_port(port_name, None):
+                    bridge_ports.append((bridge_name, port_name))
+
+            if event == vm_plugin.LibvirtEventManager.EVENT_STARTED:
+                for bridge_name in set([bp[0] for bp in bridge_ports]):
+                    for chain_name in get_userdata_prerouting_chains_for_bridge(bridge_name):
+                        ensure_userdata_prerouting_rule(bridge_name, chain_name, None)
+            else:
+                for bridge_name, port_name in bridge_ports:
+                    for chain_name in get_userdata_prerouting_chains_for_bridge(bridge_name):
+                        delete_userdata_prerouting_rule_for_port(port_name, chain_name)
+        except Exception:
+            logger.warn("failed to update userdata ebtables on VM lifecycle event: %s" % traceback.format_exc())
 
     @lock.lock('dnsmasq')
     @kvmagent.replyerror
@@ -1498,6 +1660,7 @@ tag:{{TAG}},option:dns-server,{{DNS}}
         # this is workaround, for anti-spoofing & distributed virtual routing feature, there is no good way to proccess this reconnect-host case,
         # it's just keep the ebtables rules from libvirt & zsn and remove others when reconnect hosts
         self.restore_ebtables_chain_except_kvmagent()
+        cleanup_stale_userdata_prerouting_rules()
         return jsonobject.dumps(ConnectRsp())
 
     @kvmagent.replyerror
@@ -1689,10 +1852,7 @@ tag:{{TAG}},option:dns-server,{{DNS}}
         if ret != 0:
             bash_errorout(get_ebtables_cmd() + ' -t nat -N {{EBCHAIN_NAME}}')
 
-        if bash_r(get_ebtables_cmd() + " -t nat -L PREROUTING | grep -E -- '(--logical-in|-i) {{BR_NAME}} -j {{EBCHAIN_NAME}}'") != 0:
-            # try --logical-in first; fall back to -i for kernels (e.g. alinux4 >= 6.6.102-5.3) that reject `meta ibrname`
-            if bash_r(get_ebtables_cmd() + ' -t nat -I PREROUTING --logical-in {{BR_NAME}} -j {{EBCHAIN_NAME}}') != 0:
-                bash_errorout(get_ebtables_cmd() + ' -t nat -I PREROUTING -i {{BR_NAME}} -j {{EBCHAIN_NAME}}')
+        _ensure_userdata_prerouting_rule(BR_NAME, EBCHAIN_NAME, ETH_NAME)
 
         # ebtables has a bug that will eliminate 0 in MAC, for example, aa:bb:0c will become aa:bb:c
         cidr = ip.IpAddress(to.vmIp).toCidr(to.netmask)
@@ -2144,6 +2304,10 @@ mimetype.assign = (
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         html_folder = os.path.join(self.USERDATA_ROOT, cmd.namespaceName, 'html', cmd.vmIp)
         linux.rm_dir_force(html_folder)
+        try:
+            cleanup_stale_userdata_prerouting_rules()
+        except Exception:
+            logger.warn("failed to cleanup stale userdata ebtables on userdata release: %s" % traceback.format_exc())
         l3Uuid = get_l3_uuid(cmd.namespaceName)
         if l3Uuid in self.userData_vms and cmd.vmIp in self.userData_vms[l3Uuid]:
             self.userData_vms[l3Uuid].remove(cmd.vmIp)

--- a/tests/unit/kvmagent/test_mevoco_handlers.py
+++ b/tests/unit/kvmagent/test_mevoco_handlers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 # pyright: reportAny=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownLambdaType=false, reportMissingTypeArgument=false, reportPrivateUsage=false, reportAttributeAccessIssue=false, reportGeneralTypeIssues=false, reportReturnType=false, reportSelfClsParameterName=false, reportUnusedVariable=false, reportUnusedCallResult=false
 
 import importlib
+import importlib.util
 import json
 import os
 import pytest
@@ -69,6 +70,9 @@ class _MevocoModule(Protocol):
     in_bash: Callable[[Callable[..., object]], Callable[..., object]]
     lock: "_LockModule"
     getDhcpEbtableChainName: Callable[[str], str]
+    get_ebtables_cmd: Callable[[], str]
+    is_userdata_vm_bridge_port: Callable[[str, str], bool]
+    ensure_userdata_prerouting_rule: Callable[[str, str, str], None]
     EBTABLES_CMD: str
     ReleaseDhcpRsp: type[object]
     Mevoco: type[_MevocoPluginProto]
@@ -173,6 +177,27 @@ class _BashResult:
 
 def _ensure_http() -> None:
     setattr(mevoco, "http", importlib.import_module("zstacklib.utils.http"))
+
+
+def _load_real_ebtables_module() -> object:
+    ebtables_module = importlib.import_module("zstacklib.utils.ebtables")
+    module_path = getattr(ebtables_module, "__file__", None)
+    if module_path is None:
+        for path_entry in sys.path:
+            candidate = os.path.abspath(os.path.join(
+                path_entry, "zstacklib", "zstacklib", "utils", "ebtables.py"
+            ))
+            if os.path.exists(candidate):
+                module_path = candidate
+                break
+    if module_path is None:
+        raise ImportError("Cannot locate real ebtables module")
+    spec = importlib.util.spec_from_file_location("real_zstacklib_utils_ebtables", module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError("Cannot load real ebtables module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _snapshot_modules(*modules: object) -> list[tuple[object, dict[str, object]]]:
@@ -816,11 +841,13 @@ class TestMevocoReleaseUserdata:
         linux.rm_dir_force = MagicMock()
 
         req = _make_req({'namespaceName': 'ns_l3-uuid', 'vmIp': '10.0.0.2'})
-        result = plugin.release_userdata(req)
+        with patch.object(mevoco, "cleanup_stale_userdata_prerouting_rules") as cleanup_stale_rules:
+            result = plugin.release_userdata(req)
         rsp = _load_rsp(result)
 
         assert rsp['success'] is True
         assert plugin.userData_vms['l3-uuid'] == []
+        cleanup_stale_rules.assert_called_once_with()
 
 
 @pytest.mark.kvmagent
@@ -832,10 +859,12 @@ class TestMevocoReleaseUserdataMissingL3:
         linux.rm_dir_force = MagicMock()
 
         req = _make_req({'namespaceName': 'ns_l3-uuid', 'vmIp': '10.0.0.2'})
-        result = plugin.release_userdata(req)
+        with patch.object(mevoco, "cleanup_stale_userdata_prerouting_rules") as cleanup_stale_rules:
+            result = plugin.release_userdata(req)
         rsp = _load_rsp(result)
 
         assert rsp['success'] is True
+        cleanup_stale_rules.assert_called_once_with()
 
 
 @pytest.mark.kvmagent
@@ -990,6 +1019,205 @@ class TestMevocoDhcpEnvPrepare:
 
 @pytest.mark.kvmagent
 class TestMevocoApplyUserdataInternals:
+    def test_validate_ebtables_name_rejects_shell_meta(self):
+        ebtables_mod = _load_real_ebtables_module()
+        with pytest.raises(Exception, match="invalid bridge name"):
+            ebtables_mod.validate_name("br_eth0;touch /tmp/pwned", "bridge name")
+
+    def test_has_nat_prerouting_rule_uses_fixed_string(self):
+        ebtables_mod = _load_real_ebtables_module()
+        shell_run = MagicMock(return_value=1)
+
+        with patch.object(ebtables_mod, "get_ebtables_cmd", return_value="ebtables"), \
+                patch.object(ebtables_mod.shell, "run", shell_run):
+            assert not ebtables_mod.has_nat_prerouting_rule("-i vnic5.0 -j UD-br_eth0-326dc516")
+
+        shell_run.assert_called_once_with(
+            "ebtables -t nat -L PREROUTING | grep -F -- '-i vnic5.0 -j UD-br_eth0-326dc516' > /dev/null"
+        )
+
+    def test_is_userdata_vm_bridge_port_filters_non_vm_ports(self):
+        assert mevoco.is_userdata_vm_bridge_port("vnic5.0", "eth0")
+        assert mevoco.is_userdata_vm_bridge_port("tap123", "eth0")
+        assert not mevoco.is_userdata_vm_bridge_port("eth0", "eth0")
+        assert not mevoco.is_userdata_vm_bridge_port("outer5", "eth0")
+        assert not mevoco.is_userdata_vm_bridge_port("ud_outer5", "eth0")
+        assert not mevoco.is_userdata_vm_bridge_port("", "eth0")
+
+    def test_get_userdata_prerouting_chains_for_bridge(self):
+        ebtables_mod = _load_real_ebtables_module()
+        prerouting = "\n".join([
+            "Bridge chain: PREROUTING, entries: 4, policy: ACCEPT",
+            "-i br_eth0 -j UD-br_eth0-326dc516",
+            "--logical-in br_eth0 -j USERDATA-br_eth0-326dc516",
+            "-i br_eth1 -j UD-br_eth1-11111111",
+            "-i vnic5.0 -j UD-br_eth0-326dc516",
+        ])
+
+        with patch.object(mevoco, "ebtables", ebtables_mod), \
+                patch.object(mevoco, "get_ebtables_cmd", return_value="ebtables"), \
+                patch.object(mevoco.shell, "call", return_value=prerouting):
+            assert mevoco.get_userdata_prerouting_chains_for_bridge("br_eth0") == [
+                "UD-br_eth0-326dc516",
+                "USERDATA-br_eth0-326dc516",
+            ]
+
+    def test_get_userdata_prerouting_vm_port_rules(self):
+        ebtables_mod = _load_real_ebtables_module()
+        prerouting = "\n".join([
+            "-i vnic5.0 -j UD-br_eth0-326dc516",
+            "-i tap9 -j USERDATA-br_eth1-326dc516",
+            "-i br_eth0 -j UD-br_eth0-326dc516",
+            "-i outer5 -j UD-br_eth0-326dc516",
+            "--logical-in br_eth0 -j UD-br_eth0-326dc516",
+        ])
+
+        with patch.object(mevoco, "ebtables", ebtables_mod), \
+                patch.object(mevoco, "get_ebtables_cmd", return_value="ebtables"), \
+                patch.object(mevoco.shell, "call", return_value=prerouting):
+            assert mevoco.get_userdata_prerouting_vm_port_rules() == [
+                ("vnic5.0", "UD-br_eth0-326dc516"),
+                ("tap9", "USERDATA-br_eth1-326dc516"),
+            ]
+
+    def test_ensure_userdata_prerouting_rule_adds_vm_ports_for_nft(self):
+        def _has_nat_prerouting_rule(rule: str) -> bool:
+            if rule == "--logical-in br_eth0 -j UD-br_eth0-326dc516":
+                return True
+            if rule == "-i tap9 -j UD-br_eth0-326dc516":
+                return True
+            if rule == "-i vnic5.0 -j UD-br_eth0-326dc516":
+                return False
+            return False
+
+        ebtables_mod = _load_real_ebtables_module()
+        linux = cast(MagicMock, importlib.import_module("zstacklib.utils.linux"))
+        with patch.object(mevoco, "ebtables", ebtables_mod), \
+                patch.object(mevoco, "EBTABLES_CMD", "ebtables", create=True), \
+                patch.object(mevoco, "get_ebtables_cmd", return_value="ebtables"), \
+                patch.object(mevoco, "is_ebtables_nf_tables", return_value=True), \
+                patch.object(ebtables_mod, "has_nat_prerouting_rule",
+                             MagicMock(side_effect=_has_nat_prerouting_rule)), \
+                patch.object(linux, "get_all_bridge_interface",
+                             return_value=["eth0", "outer5", "ud_outer5", "vnic5.0", "tap9"]), \
+                patch.object(mevoco, "bash_errorout") as bash_errorout:
+            mevoco.ensure_userdata_prerouting_rule("br_eth0", "UD-br_eth0-326dc516", "eth0")
+
+        bash_errorout.assert_called_once_with("ebtables -t nat -I PREROUTING -i vnic5.0 -j UD-br_eth0-326dc516")
+
+    def test_delete_userdata_prerouting_rule_for_port_removes_duplicates(self):
+        ebtables_mod = _load_real_ebtables_module()
+
+        with patch.object(mevoco, "ebtables", ebtables_mod), \
+                patch.object(mevoco, "get_ebtables_cmd", return_value="ebtables"), \
+                patch.object(ebtables_mod, "has_nat_prerouting_rule",
+                             MagicMock(side_effect=[True, True, False])), \
+                patch.object(mevoco, "bash_errorout") as bash_errorout:
+            mevoco.delete_userdata_prerouting_rule_for_port("vnic5.0", "UD-br_eth0-326dc516")
+
+        assert bash_errorout.call_count == 2
+        bash_errorout.assert_called_with("ebtables -t nat -D PREROUTING -i vnic5.0 -j UD-br_eth0-326dc516")
+
+    def test_cleanup_stale_userdata_prerouting_rules_removes_absent_ports(self):
+        linux = cast(MagicMock, importlib.import_module("zstacklib.utils.linux"))
+
+        def _is_existing(port_name: str) -> bool:
+            return port_name == "tap9"
+
+        with patch.object(mevoco, "is_ebtables_nf_tables", return_value=True), \
+                patch.object(mevoco, "get_userdata_prerouting_vm_port_rules",
+                             return_value=[
+                                 ("vnic5.0", "UD-br_eth0-326dc516"),
+                                 ("tap9", "UD-br_eth0-326dc516"),
+                             ]), \
+                patch.object(linux, "is_network_device_existing", MagicMock(side_effect=_is_existing)), \
+                patch.object(mevoco, "_delete_userdata_prerouting_rule_for_port") as delete_rule:
+            mevoco.cleanup_stale_userdata_prerouting_rules()
+
+        delete_rule.assert_called_once_with("vnic5.0", "UD-br_eth0-326dc516")
+
+    def test_vm_started_hook_updates_userdata_rules_after_vnic_exists(self):
+        plugin = _make_plugin()
+        vm_plugin_mod = MagicMock()
+        vm_plugin_mod.LibvirtEventManager.EVENT_STARTED = "Started"
+        vm_plugin_mod.LibvirtEventManager.EVENT_STOPPED = "Stopped"
+        vm_plugin_mod.LibvirtEventManager.event_to_string = MagicMock(return_value="Started")
+
+        class _Dom(object):
+            def XMLDesc(self, _flags: int) -> str:
+                return """
+                <domain>
+                  <devices>
+                    <interface type="bridge">
+                      <source bridge="br_eth0"/>
+                      <target dev="vnic5.0"/>
+                    </interface>
+                    <interface type="bridge">
+                      <source bridge="br_eth1"/>
+                      <target dev="eth0"/>
+                    </interface>
+                  </devices>
+                </domain>
+                """
+
+        with patch.dict(sys.modules, {"kvmagent.plugins.vm_plugin": vm_plugin_mod}), \
+                patch.object(mevoco, "is_ebtables_nf_tables", return_value=True), \
+                patch.object(mevoco, "get_userdata_prerouting_chains_for_bridge",
+                             return_value=["UD-br_eth0-326dc516"]) as get_chains, \
+                patch.object(mevoco, "ensure_userdata_prerouting_rule") as ensure_rule:
+            plugin._on_vm_started_update_userdata_ebtables(None, _Dom(), object(), None, None)
+
+        get_chains.assert_called_once_with("br_eth0")
+        ensure_rule.assert_called_once_with("br_eth0", "UD-br_eth0-326dc516", None)
+
+    def test_vm_stopped_hook_cleans_userdata_rules_for_removed_vnic(self):
+        plugin = _make_plugin()
+        vm_plugin_mod = MagicMock()
+        vm_plugin_mod.LibvirtEventManager.EVENT_STARTED = "Started"
+        vm_plugin_mod.LibvirtEventManager.EVENT_STOPPED = "Stopped"
+        vm_plugin_mod.LibvirtEventManager.event_to_string = MagicMock(return_value="Stopped")
+
+        class _Dom(object):
+            def XMLDesc(self, _flags: int) -> str:
+                return """
+                <domain>
+                  <devices>
+                    <interface type="bridge">
+                      <source bridge="br_eth0"/>
+                      <target dev="vnic5.0"/>
+                    </interface>
+                  </devices>
+                </domain>
+                """
+
+        with patch.dict(sys.modules, {"kvmagent.plugins.vm_plugin": vm_plugin_mod}), \
+                patch.object(mevoco, "is_ebtables_nf_tables", return_value=True), \
+                patch.object(mevoco, "get_userdata_prerouting_chains_for_bridge",
+                             return_value=["UD-br_eth0-326dc516"]) as get_chains, \
+                patch.object(mevoco, "delete_userdata_prerouting_rule_for_port") as delete_rule:
+            plugin._on_vm_started_update_userdata_ebtables(None, _Dom(), object(), None, None)
+
+        get_chains.assert_called_once_with("br_eth0")
+        delete_rule.assert_called_once_with("vnic5.0", "UD-br_eth0-326dc516")
+
+    def test_vm_stopped_hook_falls_back_to_stale_cleanup_when_domain_xml_is_gone(self):
+        plugin = _make_plugin()
+        vm_plugin_mod = MagicMock()
+        vm_plugin_mod.LibvirtEventManager.EVENT_STARTED = "Started"
+        vm_plugin_mod.LibvirtEventManager.EVENT_STOPPED = "Stopped"
+        vm_plugin_mod.LibvirtEventManager.event_to_string = MagicMock(return_value="Stopped")
+
+        class _Dom(object):
+            def XMLDesc(self, _flags: int) -> str:
+                raise RuntimeError("domain is gone")
+
+        with patch.dict(sys.modules, {"kvmagent.plugins.vm_plugin": vm_plugin_mod}), \
+                patch.object(mevoco, "is_ebtables_nf_tables", return_value=True), \
+                patch.object(mevoco, "cleanup_stale_userdata_prerouting_rules") as cleanup_stale_rules:
+            plugin._on_vm_started_update_userdata_ebtables(None, _Dom(), object(), None, None)
+
+        cleanup_stale_rules.assert_called_once_with()
+
     def test_apply_userdata_xtables_vmdata_restart_httpd(self, tmp_path: object):
         plugin = _make_plugin()
         _ensure_http()

--- a/zstacklib/zstacklib/utils/ebtables.py
+++ b/zstacklib/zstacklib/utils/ebtables.py
@@ -1,6 +1,10 @@
+import re
+
 from zstacklib.utils import shell
 
 _ebtablesUseLock = None
+_SAFE_NAME_RE = re.compile(r'^[A-Za-z0-9_.-]+$')
+_SAFE_RULE_RE = re.compile(r'^[A-Za-z0-9_. -]+$')
 
 def get_ebtables_cmd():
 
@@ -17,3 +21,21 @@ def get_ebtables_cmd():
     if _ebtablesUseLock:
         return "ebtables --concurrent"
     return "ebtables"
+
+
+def validate_name(name, kind='ebtables name'):
+    if not name or _SAFE_NAME_RE.match(name) is None:
+        raise Exception('invalid %s[%s]' % (kind, name))
+    return name
+
+
+def has_table_chain_rule(table, chain, rule):
+    table = validate_name(table, 'ebtables table')
+    chain = validate_name(chain, 'ebtables chain')
+    if not rule or _SAFE_RULE_RE.match(rule) is None:
+        raise Exception('invalid ebtables rule[%s]' % rule)
+    return shell.run(get_ebtables_cmd() + " -t %s -L %s | grep -F -- '%s' > /dev/null" % (table, chain, rule)) == 0
+
+
+def has_nat_prerouting_rule(rule):
+    return has_table_chain_rule('nat', 'PREROUTING', rule)


### PR DESCRIPTION
Resolves: ZSTAC-85395

问题：alinux4/iproute2 6.6 环境下，DHCP/Userdata namespace 存在但 lo 可能未拉起，metadata 服务监听 169.254.169.254 时本地路由走 lo 会超时；同时 ebtables-nft 将 --logical-in br_* 显示/处理为 -i br_*，VM vnic 入方向包不会命中 userdata DNAT 链。

修改：
- 创建/准备 DHCP、Userdata namespace 时显式拉起 lo，userdata 重放路径也修复已有 namespace。
- ebtables-nft 后端保留 bridge 级规则，同时为 bridge 上的 VM vnic/tap 端口补充 PREROUTING 入口规则。
- 增加 userdata ebtables helper 单测。

验证：
- python -m py_compile kvmagent/kvmagent/plugins/mevoco.py
- PYTHONPATH=<local pytest wheels> python -m pytest -q -p no:tests.plugins.ssh_plugin -p no:tests.plugins.vm_deploy_plugin tests/unit/kvmagent/test_mevoco_handlers.py

sync from gitlab !7119