### PR TITLE
<fix>[tensorfusion]: match worker binary via cmdline[0] not proc.name()

### DIFF
--- a/kvmagent/kvmagent/plugins/tensorfusion/process_executor.py
+++ b/kvmagent/kvmagent/plugins/tensorfusion/process_executor.py
@@ -395,10 +395,9 @@ class ProcessExecutor(WorkerExecutor):
         binary_name = os.path.basename(self.WORKER_BINARY)
         for proc in psutil.process_iter():
             try:
-                if proc.name() != binary_name:
-                    continue
-
                 cmdline = proc.cmdline() or []
+                if not cmdline or os.path.basename(cmdline[0]) != binary_name:
+                    continue
                 try:
                     environ = proc.environ() or {}
                 except (AttributeError, psutil.AccessDenied):
@@ -536,7 +535,8 @@ class ProcessExecutor(WorkerExecutor):
             try:
                 if proc.pid in known_pids:
                     continue
-                if proc.name() != binary_name:
+                cmdline = proc.cmdline() or []
+                if not cmdline or os.path.basename(cmdline[0]) != binary_name:
                     continue
 
                 try:
@@ -548,7 +548,6 @@ class ProcessExecutor(WorkerExecutor):
                     continue
 
                 shared_memory_path = None
-                cmdline = proc.cmdline() or []
                 for i, arg in enumerate(cmdline):
                     if arg == '-m' and i + 1 < len(cmdline):
                         shared_memory_path = self.SHM_PREFIX + cmdline[i + 1].lstrip('/')


### PR DESCRIPTION
## 问题

`scan_running()` 使用 `proc.name()` 精确匹配 `tensor-fusion-worker`，但 Linux `/proc/<pid>/comm` 受 `TASK_COMM_LEN` 限制最多 15 字符，导致进程名被截断为 `tensor-fusion-w`，匹配失败。

kvmagent 重启后老 worker 无法被收编进 StateStore，管理面周期同步时将对应 dGPU 误标为 Fault。

## 修复

改用 `proc.cmdline()[0]` 读取 `/proc/<pid>/cmdline`，不受 15 字符截断限制。

## 关联

Resolves: ZSTAC-85550

sync from gitlab !7136