### PR TITLE
ZSTAC-79206 submit utility IPv6 commits

### DIFF
--- a/consoleproxy/consoleproxy/console_proxy_agent.py
+++ b/consoleproxy/consoleproxy/console_proxy_agent.py
@@ -27,6 +27,12 @@ def format_host_port_for_url(host, port):
     return SHELL_HOST_PORT_FORMAT % (network_ipv6.format_url_host(host), port)
 
 
+def format_host_port_for_websockify_target(host, port):
+    if host.startswith(network_ipv6.IPV6_BRACKET_PREFIX) and host.endswith(network_ipv6.IPV6_BRACKET_SUFFIX):
+        host = host[1:-1]
+    return SHELL_HOST_PORT_FORMAT % (host, port)
+
+
 def format_host_port_for_grep(host, port):
     return format_host_port_for_url(host, port).replace('[', GREP_OPEN_BRACKET).replace(']', GREP_CLOSE_BRACKET)
 
@@ -396,7 +402,7 @@ class ConsoleProxyAgent(object):
         log_file = os.path.join(self.PROXY_LOG_DIR, cmd.proxyHostname)
         proxy_host_port = format_host_port_for_url(cmd.proxyHostname, cmd.proxyPort)
         proxy_host_port_grep = format_host_port_for_grep(cmd.proxyHostname, cmd.proxyPort)
-        target_host_port = format_host_port_for_url(cmd.targetHostname, cmd.targetPort)
+        target_host_port = format_host_port_for_websockify_target(cmd.targetHostname, cmd.targetPort)
 
         token_file = ConsoleTokenFile(cmd.token)
         token_file.flush_write('%s: %s' % (cmd.token, target_host_port))

--- a/kvmagent/kvmagent/plugins/imagestore.py
+++ b/kvmagent/kvmagent/plugins/imagestore.py
@@ -7,6 +7,7 @@ from kvmagent import kvmagent
 from zstacklib.utils import jsonobject
 from zstacklib.utils import shell
 from zstacklib.utils import traceable_shell
+from zstacklib.utils import network_ipv6
 from zstacklib.utils.bash import bash_progress_1, in_bash, bash_r, bash_roe
 from zstacklib.utils.report import *
 
@@ -46,6 +47,9 @@ class ImageStoreClient(object):
     def _build_install_path(self, name, imgid):
         return "{0}{1}/{2}".format(self.ZSTORE_PROTOSTR, name, imgid)
 
+    def _build_registry_url(self, hostname):
+        return network_ipv6.format_host_port(hostname, self.ZSTORE_DEF_PORT)
+
     def upload_image(self, hostname, fpath, concurrency=None):
         imf = self.commit_image(fpath)
 
@@ -53,7 +57,7 @@ class ImageStoreClient(object):
         if concurrency and concurrency > 1:
             extra_param += "-concurrency=%d " % concurrency
 
-        cmdstr = '%s -url %s:%s push %s %s' % (self.ZSTORE_CLI_PATH, hostname, self.ZSTORE_DEF_PORT, extra_param, fpath)
+        cmdstr = '%s -url %s push %s %s' % (self.ZSTORE_CLI_PATH, self._build_registry_url(hostname), extra_param, fpath)
         logger.debug('pushing %s to image store' % fpath)
         shell.check_run(cmdstr)
         logger.debug('%s pushed to image store' % fpath)
@@ -284,7 +288,7 @@ class ImageStoreClient(object):
             return mode.strip()
 
     def image_already_pushed(self, hostname, imf):
-        cmdstr = '%s -url %s:%s info %s' % (self.ZSTORE_CLI_PATH, hostname, self.ZSTORE_DEF_PORT, self._build_install_path(imf.name, imf.id))
+        cmdstr = '%s -url %s info %s' % (self.ZSTORE_CLI_PATH, self._build_registry_url(hostname), self._build_install_path(imf.name, imf.id))
         if shell.run(cmdstr) != 0:
             return False
         return True
@@ -306,8 +310,8 @@ class ImageStoreClient(object):
         if cmd.concurrency and cmd.concurrency > 1:
             push_ext_param += " -concurrency %d" % cmd.concurrency
 
-        cmdstr = '%s -url %s:%s -callbackurl %s -taskid %s -imageUuid %s %s push %s %s' % (
-            self.ZSTORE_CLI_PATH, cmd.hostname, self.ZSTORE_DEF_PORT, req[http.REQUEST_HEADER].get(http.CALLBACK_URI),
+        cmdstr = '%s -url %s -callbackurl %s -taskid %s -imageUuid %s %s push %s %s' % (
+            self.ZSTORE_CLI_PATH, self._build_registry_url(cmd.hostname), req[http.REQUEST_HEADER].get(http.CALLBACK_URI),
             taskid, cmd.imageUuid, extpara, push_ext_param, cmd.primaryStorageInstallPath)
         logger.debug('pushing %s to image store' % cmd.primaryStorageInstallPath)
         shell = traceable_shell.get_shell(cmd)
@@ -354,8 +358,8 @@ class ImageStoreClient(object):
         pull_extra_param = ""
         if concurrency and concurrency > 1:
             pull_extra_param += " -concurrency=%d" % concurrency
-        cmdstr = '%s -url %s:%s %s pull %s -installpath %s %s:%s' % \
-                 (self.ZSTORE_CLI_PATH, host, self.ZSTORE_DEF_PORT, extra_param, pull_extra_param, ps_path, name, imageid)
+        cmdstr = '%s -url %s %s pull %s -installpath %s %s:%s' % \
+                 (self.ZSTORE_CLI_PATH, self._build_registry_url(host), extra_param, pull_extra_param, ps_path, name, imageid)
         logger.debug('pulling %s:%s from image store' % (name, imageid))
 
         try:
@@ -373,7 +377,7 @@ class ImageStoreClient(object):
     def image_info(self, host, install_path):
         self._check_zstore_cli()
         name, imageid = self._parse_image_reference(install_path)
-        cmd = "%s -url %s:%s -json info %s:%s" % (self.ZSTORE_CLI_PATH, host, self.ZSTORE_DEF_PORT, name, imageid)
+        cmd = "%s -url %s -json info %s:%s" % (self.ZSTORE_CLI_PATH, self._build_registry_url(host), name, imageid)
         s = shell.ShellCmd(cmd)
         s(False)
         if s.return_code == 0:

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -1318,6 +1318,10 @@ class ChangeVfNicHaStateRsp(kvmagent.AgentResponse):
 
 
 class VncPortIptableRule(object):
+    IPV4_VERSION = 4
+    IPV6_VERSION = 6
+    IPV6_REJECT_WITH = 'icmp6-adm-prohibited'
+
     def __init__(self):
         self.host_ip = None
         self.port = None
@@ -1332,21 +1336,40 @@ class VncPortIptableRule(object):
         assert self.port is not None
         assert self.vm_internal_id is not None
 
-        ipt = iptables.from_iptables_save()
         chain_name = self._make_chain_name()
         current_ip = linux.get_host_by_name(self.host_ip)
 
-        # get ipv4 subnet
-        current_ip_addr_list = [addr for addr in iproute.query_addresses_by_ip(current_ip, 4) if addr.scope == 'universe']
+        current_ip_addr_list = [
+            addr for addr in iproute.query_addresses_by_ip(current_ip, self.IPV4_VERSION)
+            if addr.scope == 'universe'
+        ]
+        if current_ip_addr_list:
+            ipt = iptables.from_iptables_save()
+            current_ip_with_netmask = '%s/%d' % (current_ip_addr_list[0].address, current_ip_addr_list[0].prefixlen)
+
+            ipt.add_rule('-A INPUT -p tcp -m tcp --dport %s -j %s' % (self.port, chain_name))
+            ipt.add_rule('-A %s -d %s -j ACCEPT' % (chain_name, current_ip_with_netmask))
+            ipt.add_rule('-A %s ! -d %s -j REJECT --reject-with icmp-host-prohibited' % (chain_name, current_ip_with_netmask))
+            ipt.iptable_restore()
+            return
+
+        current_ip_addr_list = [
+            addr for addr in iproute.query_addresses_by_ip(current_ip, self.IPV6_VERSION)
+            if addr.scope == 'universe'
+        ]
         if not current_ip_addr_list:
             err = 'cannot get host ip with netmask for %s' % self.host_ip
             logger.warn(err)
             raise kvmagent.KvmError(err)
+
+        ipt = iptables.from_ip6tables_save()
         current_ip_with_netmask = '%s/%d' % (current_ip_addr_list[0].address, current_ip_addr_list[0].prefixlen)
 
         ipt.add_rule('-A INPUT -p tcp -m tcp --dport %s -j %s' % (self.port, chain_name))
         ipt.add_rule('-A %s -d %s -j ACCEPT' % (chain_name, current_ip_with_netmask))
-        ipt.add_rule('-A %s ! -d %s -j REJECT --reject-with icmp-host-prohibited' % (chain_name, current_ip_with_netmask))
+        ipt.add_rule('-A %s ! -d %s -j REJECT --reject-with %s' % (
+            chain_name, current_ip_with_netmask, self.IPV6_REJECT_WITH
+        ))
         ipt.iptable_restore()
 
     @lock.file_lock('/run/xtables.lock')
@@ -1355,6 +1378,10 @@ class VncPortIptableRule(object):
 
         ipt = iptables.from_iptables_save()
         chain_name = self._make_chain_name()
+        ipt.delete_chain(chain_name)
+        ipt.iptable_restore()
+
+        ipt = iptables.from_ip6tables_save()
         ipt.delete_chain(chain_name)
         ipt.iptable_restore()
 
@@ -1380,25 +1407,24 @@ class VncPortIptableRule(object):
 
     @lock.file_lock('/run/xtables.lock')
     def delete_stale_chains(self):
-        ipt = iptables.from_iptables_save()
-        tbl = ipt.get_table()
-        if not tbl:
-            ipt.iptable_restore()
-            return
-
         vms = get_running_vms()
         internal_ids = self.find_vm_internal_ids(vms)
 
-        # delete all vnc chains
-        chains = tbl.children[:]
-        for chain in chains:
-            if 'vm' in chain.name and 'vnc' in chain.name:
-                vm_internal_id = chain.name.split('-')[1]
-                if vm_internal_id not in internal_ids:
-                    ipt.delete_chain(chain.name)
-                    logger.debug('deleted a stale VNC iptable chain[%s]' % chain.name)
+        for ipt in [iptables.from_iptables_save(), iptables.from_ip6tables_save()]:
+            tbl = ipt.get_table()
+            if not tbl:
+                ipt.iptable_restore()
+                continue
 
-        ipt.iptable_restore()
+            chains = tbl.children[:]
+            for chain in chains:
+                if 'vm' in chain.name and 'vnc' in chain.name:
+                    vm_internal_id = chain.name.split('-')[1]
+                    if vm_internal_id not in internal_ids:
+                        ipt.delete_chain(chain.name)
+                        logger.debug('deleted a stale VNC iptable chain[%s]' % chain.name)
+
+            ipt.iptable_restore()
 
 
 def e(parent, tag, value=None, attrib=None, usenamesapce = False):

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -134,6 +134,14 @@ CONSOLE_LISTEN_IPV4_ADDRESS = '0.0.0.0'
 CONSOLE_LISTEN_IPV6_ADDRESS = network_ipv6.DUAL_STACK_BIND_ADDRESS
 
 
+def build_libvirt_system_uri(proto, host):
+    return '%s://%s/system' % (proto, network_ipv6.format_url_host(host))
+
+
+def build_libvirt_tcp_uri(host):
+    return 'tcp://%s' % network_ipv6.format_url_host(host)
+
+
 def _check_tls_ready(dest_ip, vm_uuid):
     """Check if TLS migration is actually possible.
 
@@ -2356,7 +2364,7 @@ class VmVolumesRecoveryTask(plugin.TaskDaemon):
 @linux.retry(times=3, sleep_time=1)
 def get_connect(src_host_ip, use_tls=False):
     proto = 'qemu+tls' if use_tls else 'qemu+tcp'
-    uri = '{0}://{1}/system'.format(proto, src_host_ip)
+    uri = build_libvirt_system_uri(proto, src_host_ip)
     conn = libvirt.open(uri)
     if conn is None:
         logger.warn('unable to connect qemu on host {0} via {1}'.format(src_host_ip, proto))
@@ -4437,11 +4445,11 @@ class Vm(object):
         if use_tls:
             use_tls = _check_tls_ready(dest_ctrl_ip, cmd.vmUuid)
         migrate_proto = 'qemu+tls' if use_tls else 'qemu+tcp'
-        destUrl = "{0}://{1}/system".format(migrate_proto, dest_ctrl_ip)
+        destUrl = build_libvirt_system_uri(migrate_proto, dest_ctrl_ip)
         # Data channel URI must always use tcp:// scheme.
         # When TLS is enabled, encryption is activated via VIR_MIGRATE_TLS flag,
         # not by changing the URI scheme.
-        tcpUri = "tcp://{0}".format(cmd.destHostIp)
+        tcpUri = build_libvirt_tcp_uri(cmd.destHostIp)
         bandwidth = cmd.bandwidth if cmd.bandwidth > 0 else 0
 
         storage_migration_required = cmd.disks and len(cmd.disks.__dict__) != 0
@@ -9402,10 +9410,10 @@ class VmPlugin(kvmagent.KvmAgent):
         # TLS control-plane URI must use management IP (cert SAN matches
         # management address); data-plane uses tls:// when TLS is enabled.
         dst_ctrl_ip = dstHostManagementIp or dstHostIp
-        dst = '{0}://{1}/system'.format(migrate_proto, dst_ctrl_ip)
+        dst = build_libvirt_system_uri(migrate_proto, dst_ctrl_ip)
         # Data channel URI must always use tcp:// scheme.
         # When TLS is enabled, virsh --tls flag handles encryption.
-        migurl = 'tcp://{0}'.format(dstHostIp)
+        migurl = build_libvirt_tcp_uri(dstHostIp)
         diskstr = ','.join(disks)
 
         flags = "--live --p2p --copy-storage-all --persistent"

--- a/tests/unit/consoleproxy/test_console_proxy_handlers.py
+++ b/tests/unit/consoleproxy/test_console_proxy_handlers.py
@@ -73,6 +73,11 @@ class TestIpv6HostPortFormatting:
         assert module.format_host_port_for_url("console-proxy.example.com", 5900) == "console-proxy.example.com:5900"
         assert module.format_host_port_for_url("2001:db8::10", 5900) == "[2001:db8::10]:5900"
 
+    def test_format_host_port_for_websockify_target_uses_socket_host(self):
+        assert module.format_host_port_for_websockify_target("192.168.10.10", 5900) == "192.168.10.10:5900"
+        assert module.format_host_port_for_websockify_target("2001:db8::10", 5900) == "2001:db8::10:5900"
+        assert module.format_host_port_for_websockify_target("[2001:db8::10]", 5900) == "2001:db8::10:5900"
+
     def test_format_host_port_for_grep_escapes_ipv6_brackets(self):
         assert module.format_host_port_for_grep("2001:db8::10", 5900) == r"\[2001:db8::10\]:5900"
 
@@ -357,7 +362,7 @@ class TestEstablishNewVncProxy:
         agent.db.set.assert_called_once()
 
     @patch.object(module, "bash_roe", return_value=(0, "", ""))
-    def test_establish_vnc_proxy_uses_bracketed_ipv6_endpoint(self, mock_bash):
+    def test_establish_vnc_proxy_uses_socket_ipv6_token_target(self, mock_bash):
         agent = _make_agent()
         token_file_mock = MagicMock()
         token_file_mock.get_absolute_path.return_value = "/var/lib/zstack/consoleProxy/vm_ipv6_123"
@@ -379,7 +384,7 @@ class TestEstablishNewVncProxy:
 
         rsp = _load_rsp(result)
         assert rsp["success"] is True
-        token_file_mock.flush_write.assert_called_once_with("vm_ipv6_123: [2001:db8::11]:5900")
+        token_file_mock.flush_write.assert_called_once_with("vm_ipv6_123: 2001:db8::11:5900")
         assert any(r"\[2001:db8::10\]:6800" in call_args[0][0] for call_args in mock_bash.call_args_list)
 
 

--- a/tests/unit/kvmagent/test_imagestore_ipv6.py
+++ b/tests/unit/kvmagent/test_imagestore_ipv6.py
@@ -1,0 +1,36 @@
+from kvmagent.plugins.imagestore import ImageStoreClient
+
+
+TEST_IPV6_ADDRESS = '2001:db8::10'
+TEST_IPV4_ADDRESS = '192.168.10.10'
+TEST_IMAGE_PATH = 'zstore://image-name/image-id'
+TEST_PRIMARY_PATH = '/zstack_ps/rootVolumes/volume.qcow2'
+
+
+def test_imagestore_client_registry_url_wraps_ipv6_only_once():
+    client = ImageStoreClient()
+
+    assert client._build_registry_url(TEST_IPV4_ADDRESS) == '192.168.10.10:8000'
+    assert client._build_registry_url(TEST_IPV6_ADDRESS) == '[2001:db8::10]:8000'
+    assert client._build_registry_url('[2001:db8::10]') == '[2001:db8::10]:8000'
+
+
+def test_download_from_imagestore_uses_bracketed_ipv6_registry_url(monkeypatch):
+    client = ImageStoreClient()
+    commands = []
+
+    monkeypatch.setattr(client, '_check_zstore_cli', lambda: None)
+    monkeypatch.setattr(
+        'kvmagent.plugins.imagestore.shell.call',
+        lambda command: commands.append(command) or '',
+    )
+
+    client.download_from_imagestore(
+        None,
+        TEST_IPV6_ADDRESS,
+        TEST_IMAGE_PATH,
+        TEST_PRIMARY_PATH,
+    )
+
+    assert len(commands) == 1
+    assert ' -url [2001:db8::10]:8000 ' in commands[0]

--- a/tests/unit/zstackctl/test_ctl_management_ipv6.py
+++ b/tests/unit/zstackctl/test_ctl_management_ipv6.py
@@ -118,12 +118,12 @@ def test_management_server_ip_stack_opts_enable_dual_stack_for_ip6():
     assert '-Djava.net.preferIPv6Addresses=true' in opts
 
 
-def test_management_server_ip_stack_opts_keep_ipv4_default():
+def test_management_server_ip_stack_opts_enable_dual_stack_for_ipv4_primary():
     opts = ctl.build_management_server_ip_stack_opts({
         'management.server.ip': '172.24.196.95',
     })
 
-    assert opts == ['-Djava.net.preferIPv4Stack=true']
+    assert opts == ['-Djava.net.preferIPv4Stack=false']
 
 
 def test_ui_ipv6_listen_helpers_update_nginx_conf(tmp_path):

--- a/tests/unit/zstackctl/test_ctl_management_ipv6.py
+++ b/tests/unit/zstackctl/test_ctl_management_ipv6.py
@@ -106,3 +106,37 @@ def test_validate_ip_versions_rejects_invalid_ip(monkeypatch):
     assert errors == [
         'zsha2 nodeip, peerip and dbvip must be valid IP addresses: peerip=invalid-peer'
     ]
+
+
+def test_management_server_ip_stack_opts_enable_dual_stack_for_ip6():
+    opts = ctl.build_management_server_ip_stack_opts({
+        'management.server.ip': '172.24.196.95',
+        'management.server.ip6': 'fd00:172:24:249::95',
+    })
+
+    assert '-Djava.net.preferIPv4Stack=false' in opts
+    assert '-Djava.net.preferIPv6Addresses=true' in opts
+
+
+def test_management_server_ip_stack_opts_keep_ipv4_default():
+    opts = ctl.build_management_server_ip_stack_opts({
+        'management.server.ip': '172.24.196.95',
+    })
+
+    assert opts == ['-Djava.net.preferIPv4Stack=true']
+
+
+def test_ui_ipv6_listen_helpers_update_nginx_conf(tmp_path):
+    conf = tmp_path / 'extend.server.nginx.conf'
+    conf.write_text('        listen 5000;\n        add_header zs-version 5.5.16;\n')
+
+    assert ctl.ui_should_listen_ipv6('::')
+    assert ctl.ensure_ui_nginx_ipv6_listen_conf(str(conf), '5000')
+    assert 'listen [::]:5000;' in conf.read_text()
+
+    assert not ctl.ensure_ui_nginx_ipv6_listen_conf(str(conf), '5000')
+
+
+def test_ui_ipv6_ssl_listen_line_includes_http2():
+    assert ctl.build_ui_nginx_ipv6_listen_line('5443', True, 'true') == \
+        '        listen [::]:5443 ssl http2;'

--- a/tests/unit/zstackctl/test_management_ipv6_helpers.py
+++ b/tests/unit/zstackctl/test_management_ipv6_helpers.py
@@ -72,3 +72,27 @@ def test_ip_addr_output_has_ip_accepts_ipv4_and_ipv6_addresses():
     assert management_network_ipv6.ip_addr_output_has_ip('[fd00:172:24:246::247]', addr_output)
     assert not management_network_ipv6.ip_addr_output_has_ip('fd00:172:24:246::248', addr_output)
     assert not management_network_ipv6.ip_addr_output_has_ip('not-an-ip', addr_output)
+
+
+def test_build_java_ip_stack_opts_switches_to_ipv6_stack_for_ipv6_mn():
+    opts = management_network_ipv6.build_java_ip_stack_opts('fd00:172:24:246::247', [
+        '-Djdk.tls.trustNameService=true',
+        '-Djava.net.preferIPv4Stack=true',
+        '-Djava.net.preferIPv6Addresses=false',
+        '-Xmx12288M',
+    ])
+
+    assert '-Djava.net.preferIPv4Stack=true' not in opts
+    assert '-Djava.net.preferIPv6Addresses=false' not in opts
+    assert '-Djava.net.preferIPv4Stack=false' in opts
+    assert '-Djava.net.preferIPv6Addresses=true' in opts
+    assert '-Xmx12288M' in opts
+
+
+def test_build_java_ip_stack_opts_keeps_ipv4_defaults_for_ipv4_mn():
+    opts = [
+        '-Djava.net.preferIPv4Stack=true',
+        '-Xmx12288M',
+    ]
+
+    assert management_network_ipv6.build_java_ip_stack_opts('172.24.246.247', opts) == opts

--- a/tests/unit/zstackctl/test_management_ipv6_helpers.py
+++ b/tests/unit/zstackctl/test_management_ipv6_helpers.py
@@ -96,3 +96,45 @@ def test_build_java_ip_stack_opts_keeps_ipv4_defaults_for_ipv4_mn():
     ]
 
     assert management_network_ipv6.build_java_ip_stack_opts('172.24.246.247', opts) == opts
+
+
+def test_add_ip6_accepts_ipv6_without_nic():
+    addr_output = '''
+2: br_eth0    inet 172.24.249.182/16 brd 172.24.255.255 scope global br_eth0
+3: eth1    inet 10.10.10.10/24 brd 10.10.10.255 scope global eth1
+'''
+    route_output = 'default via 172.24.0.1 dev eth1 proto static metric 100'
+
+    nic = management_network_ipv6.select_add_ip6_interface(
+        None,
+        '172.24.249.182',
+        route_output,
+        addr_output,
+    )
+
+    assert nic == 'br_eth0'
+    assert management_network_ipv6.build_add_ip6_command(
+        'fd00:172:24:249::182',
+        '64',
+        nic,
+    ) == ['ip', '-6', 'addr', 'add', 'fd00:172:24:249::182/64', 'dev', 'br_eth0']
+
+
+def test_add_ip6_falls_back_to_default_route_interface():
+    assert management_network_ipv6.select_add_ip6_interface(
+        None,
+        None,
+        'default via 172.24.0.1 dev br_eth0 proto static metric 100',
+        '',
+    ) == 'br_eth0'
+
+
+def test_add_ip6_rejects_invalid_input():
+    assert not management_network_ipv6.validate_ipv6('172.24.249.182')
+    assert not management_network_ipv6.validate_ipv6('not-an-ip')
+    assert management_network_ipv6.normalize_ipv6_prefix('129') is None
+    assert management_network_ipv6.normalize_ipv6_prefix('-1') is None
+    assert management_network_ipv6.normalize_ipv6_prefix('64') == 64
+    assert management_network_ipv6.build_add_ip6_command('172.24.249.182', '64', 'br_eth0') is None
+    assert management_network_ipv6.build_add_ip6_command('fd00:172:24:249::182', '129', 'br_eth0') is None
+    assert management_network_ipv6.build_add_ip6_command('fd00:172:24:249::182', '64', 'br eth0') is None

--- a/tests/unit/zstackctl/test_management_ipv6_helpers.py
+++ b/tests/unit/zstackctl/test_management_ipv6_helpers.py
@@ -57,3 +57,18 @@ def test_replace_db_url_host_formats_new_host_by_ip_version():
         'jdbc:mysql://[2001:db8::10]:3306/zstack',
         '192.168.10.20',
     ) == 'jdbc:mysql://192.168.10.20:3306/zstack'
+
+
+def test_ip_addr_output_has_ip_accepts_ipv4_and_ipv6_addresses():
+    addr_output = '''
+2: br_eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500
+    inet 172.24.246.247/16 brd 172.24.255.255 scope global br_eth0
+       valid_lft forever preferred_lft forever
+    inet6 fd00:172:24:246::247/64 scope global
+       valid_lft forever preferred_lft forever
+'''
+    assert management_network_ipv6.ip_addr_output_has_ip('172.24.246.247', addr_output)
+    assert management_network_ipv6.ip_addr_output_has_ip('fd00:172:24:246::247', addr_output)
+    assert management_network_ipv6.ip_addr_output_has_ip('[fd00:172:24:246::247]', addr_output)
+    assert not management_network_ipv6.ip_addr_output_has_ip('fd00:172:24:246::248', addr_output)
+    assert not management_network_ipv6.ip_addr_output_has_ip('not-an-ip', addr_output)

--- a/tests/unit/zstackctl/test_management_ipv6_helpers.py
+++ b/tests/unit/zstackctl/test_management_ipv6_helpers.py
@@ -89,13 +89,19 @@ def test_build_java_ip_stack_opts_switches_to_ipv6_stack_for_ipv6_mn():
     assert '-Xmx12288M' in opts
 
 
-def test_build_java_ip_stack_opts_keeps_ipv4_defaults_for_ipv4_mn():
+def test_build_java_ip_stack_opts_keeps_ipv4_preference_but_enables_dual_stack():
     opts = [
         '-Djava.net.preferIPv4Stack=true',
+        '-Djava.net.preferIPv6Addresses=true',
         '-Xmx12288M',
     ]
 
-    assert management_network_ipv6.build_java_ip_stack_opts('172.24.246.247', opts) == opts
+    actual = management_network_ipv6.build_java_ip_stack_opts('172.24.246.247', opts)
+
+    assert '-Djava.net.preferIPv4Stack=true' not in actual
+    assert '-Djava.net.preferIPv6Addresses=true' not in actual
+    assert '-Djava.net.preferIPv4Stack=false' in actual
+    assert '-Xmx12288M' in actual
 
 
 def test_add_ip6_accepts_ipv6_without_nic():

--- a/tests/unit/zstacklib/test_management_network_ipv6.py
+++ b/tests/unit/zstacklib/test_management_network_ipv6.py
@@ -11,6 +11,17 @@ TEST_HOSTNAME = 'zstack-mn.example.com'
 TEST_PORT = 7070
 TEST_POOL_SIZE = '32'
 TEST_CEPH_PORT = 6789
+TEST_IP_ADDR_OUTPUT = """
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 state UNKNOWN qlen 1000
+    inet 127.0.0.1/8 scope host lo
+    inet6 ::1/128 scope host
+2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 state UP qlen 1000
+    inet 172.24.194.186/20 brd 172.24.207.255 scope global ens3
+    inet6 fd00:172:24:249::186/64 scope global
+    inet6 fe80::a359:8e69:9e:4e5a/64 scope link
+3: ens4: <BROADCAST,MULTICAST> mtu 1500 state DOWN qlen 1000
+    inet6 fd00:172:24:249::187/64 scope global
+"""
 
 
 def _format_ssh_target(user, hostname):
@@ -275,3 +286,14 @@ def test_extract_ceph_mon_host_supports_ipv4_ipv6_and_addrvec_prefixes():
     assert ceph_utils.extract_mon_host('v2:[%s]:3300/0' % TEST_IPV6_ADDRESS) == TEST_IPV6_ADDRESS
     assert ceph_utils.extract_mon_host('v1:%s:%s/0' % (TEST_IPV6_ADDRESS, TEST_CEPH_PORT)) == TEST_IPV6_ADDRESS
     assert ceph_utils.extract_mon_host(TEST_IPV6_ADDRESS) == TEST_IPV6_ADDRESS
+
+
+def test_get_nics_by_cidr_matches_ipv6_addresses(monkeypatch):
+    monkeypatch.setattr(linux.shell, 'call', lambda cmd: TEST_IP_ADDR_OUTPUT)
+
+    assert linux.get_nics_by_cidr('fd00:172:24:249::/64') == [
+        {'ens3': 'fd00:172:24:249::186'}
+    ]
+    assert linux.get_nics_by_cidr('172.24.192.0/20') == [
+        {'ens3': '172.24.194.186'}
+    ]

--- a/tests/unit/zstacklib/test_management_network_ipv6.py
+++ b/tests/unit/zstacklib/test_management_network_ipv6.py
@@ -122,6 +122,12 @@ def test_format_url_host_wraps_ipv6_only_once():
     assert network_ipv6.format_url_host(None) is None
 
 
+def test_format_host_port_wraps_ipv6_only_once():
+    assert network_ipv6.format_host_port(TEST_IPV4_ADDRESS, TEST_PORT) == '192.168.10.10:7070'
+    assert network_ipv6.format_host_port(TEST_IPV6_ADDRESS, TEST_PORT) == '[2001:db8::10]:7070'
+    assert network_ipv6.format_host_port('[2001:db8::10]', TEST_PORT) == '[2001:db8::10]:7070'
+
+
 def test_format_ssh_target_wraps_ipv6_only_once():
     assert linux.format_ssh_target('root', TEST_IPV4_ADDRESS) == 'root@192.168.10.10'
     assert linux.format_ssh_target('root', TEST_IPV6_ADDRESS) == 'root@[2001:db8::10]'

--- a/tests/unit/zstacklib/test_nfs_ipv6_url.py
+++ b/tests/unit/zstacklib/test_nfs_ipv6_url.py
@@ -56,3 +56,33 @@ def test_legacy_linux_nfs_url_parser_supports_bracketed_ipv6(monkeypatch):
     )
     assert linux.is_valid_nfs_url(IPV6_NFS_URL)
     assert resolved_hosts == [('fd00:172:24:249::182', None)]
+
+
+def test_legacy_linux_is_mounted_uses_fixed_string_match_for_ipv6_url(monkeypatch):
+    commands = []
+
+    def fake_run(command):
+        commands.append(command)
+        return 0
+
+    monkeypatch.setattr(linux.shell, 'run', fake_run)
+
+    assert linux.is_mounted('/mnt/nfs', IPV6_NFS_URL)
+    assert commands == [
+        "mount | grep -F '[fd00:172:24:249::182]:/export/zstack-nfs-ps on ' | grep -F '/mnt/nfs ' "
+    ]
+
+
+def test_nfs_operations_is_mounted_uses_fixed_string_match_for_ipv6_url(monkeypatch):
+    commands = []
+
+    def fake_run(command):
+        commands.append(command)
+        return 0
+
+    monkeypatch.setattr(operations.shell, 'run', fake_run)
+
+    assert operations.is_mounted('/mnt/nfs', IPV6_NFS_URL)
+    assert commands == [
+        "mount | grep -F '[fd00:172:24:249::182]:/export/zstack-nfs-ps on ' | grep -F '/mnt/nfs ' "
+    ]

--- a/tests/unit/zstacklib/test_nfs_ipv6_url.py
+++ b/tests/unit/zstacklib/test_nfs_ipv6_url.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from zstacklib.storage.nfs import operations
+from zstacklib.storage.nfs.exceptions import InvalidNfsUrlError
+from zstacklib.utils import linux
+
+IPV4_NFS_URL = '192.168.10.10:/export/nfs'
+HOSTNAME_NFS_URL = 'nfs.example.com:/export/nfs'
+IPV6_NFS_URL = '[fd00:172:24:249::182]:/export/zstack-nfs-ps'
+RAW_IPV6_NFS_URL = 'fd00:172:24:249::182:/export/zstack-nfs-ps'
+
+
+def test_parse_nfs_url_supports_ipv4_hostname_and_bracketed_ipv6():
+    assert operations.parse_nfs_url(IPV4_NFS_URL) == ('192.168.10.10', '/export/nfs')
+    assert operations.parse_nfs_url(HOSTNAME_NFS_URL) == ('nfs.example.com', '/export/nfs')
+    assert operations.parse_nfs_url(IPV6_NFS_URL) == (
+        'fd00:172:24:249::182',
+        '/export/zstack-nfs-ps',
+    )
+
+
+def test_parse_nfs_url_rejects_raw_ipv6():
+    with pytest.raises(InvalidNfsUrlError):
+        operations.parse_nfs_url(RAW_IPV6_NFS_URL)
+
+
+def test_validate_nfs_url_uses_ipv6_capable_resolver(monkeypatch):
+    resolved_hosts = []
+
+    def fake_getaddrinfo(host, port):
+        resolved_hosts.append((host, port))
+        return [(socket.AF_INET6, socket.SOCK_STREAM, 0, '', (host, 0))]
+
+    monkeypatch.setattr(operations.socket, 'getaddrinfo', fake_getaddrinfo)
+
+    assert operations.validate_nfs_url(IPV6_NFS_URL)
+    assert resolved_hosts == [('fd00:172:24:249::182', None)]
+
+
+def test_legacy_linux_nfs_url_parser_supports_bracketed_ipv6(monkeypatch):
+    resolved_hosts = []
+
+    def fake_getaddrinfo(host, port):
+        resolved_hosts.append((host, port))
+        return [(socket.AF_INET6, socket.SOCK_STREAM, 0, '', (host, 0))]
+
+    monkeypatch.setattr(linux.socket, 'getaddrinfo', fake_getaddrinfo)
+
+    assert linux.parse_nfs_url(IPV6_NFS_URL) == (
+        'fd00:172:24:249::182',
+        '/export/zstack-nfs-ps',
+    )
+    assert linux.is_valid_nfs_url(IPV6_NFS_URL)
+    assert resolved_hosts == [('fd00:172:24:249::182', None)]

--- a/tests/unit/zstacklib/test_nfs_ipv6_url.py
+++ b/tests/unit/zstacklib/test_nfs_ipv6_url.py
@@ -88,10 +88,19 @@ def test_nfs_operations_is_mounted_uses_fixed_string_match_for_ipv6_url(monkeypa
     ]
 
 
-def test_legacy_linux_get_host_by_name_supports_ipv6(monkeypatch):
+def test_legacy_linux_get_host_by_name_returns_ipv6_literal_without_dns(monkeypatch):
     def fake_getaddrinfo(host, port):
-        return [(socket.AF_INET6, socket.SOCK_STREAM, 0, '', (host, 0))]
+        raise AssertionError('literal IP must not be resolved by getaddrinfo')
 
     monkeypatch.setattr(linux.socket, 'getaddrinfo', fake_getaddrinfo)
 
     assert linux.get_host_by_name('fd00:172:24:249::182') == 'fd00:172:24:249::182'
+
+
+def test_legacy_linux_get_host_by_name_resolves_hostname(monkeypatch):
+    def fake_getaddrinfo(host, port):
+        return [(socket.AF_INET6, socket.SOCK_STREAM, 0, '', ('fd00:172:24:249::182', 0))]
+
+    monkeypatch.setattr(linux.socket, 'getaddrinfo', fake_getaddrinfo)
+
+    assert linux.get_host_by_name('host.example.com') == 'fd00:172:24:249::182'

--- a/tests/unit/zstacklib/test_nfs_ipv6_url.py
+++ b/tests/unit/zstacklib/test_nfs_ipv6_url.py
@@ -86,3 +86,12 @@ def test_nfs_operations_is_mounted_uses_fixed_string_match_for_ipv6_url(monkeypa
     assert commands == [
         "mount | grep -F '[fd00:172:24:249::182]:/export/zstack-nfs-ps on ' | grep -F '/mnt/nfs ' "
     ]
+
+
+def test_legacy_linux_get_host_by_name_supports_ipv6(monkeypatch):
+    def fake_getaddrinfo(host, port):
+        return [(socket.AF_INET6, socket.SOCK_STREAM, 0, '', (host, 0))]
+
+    monkeypatch.setattr(linux.socket, 'getaddrinfo', fake_getaddrinfo)
+
+    assert linux.get_host_by_name('fd00:172:24:249::182') == 'fd00:172:24:249::182'

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -3,6 +3,7 @@
 
 import argparse
 import hashlib
+import os
 import signal
 import getpass
 import urllib.parse
@@ -48,6 +49,82 @@ from cryptography.hazmat.primitives.serialization import pkcs12
 
 DEFAULT_MYSQL_PORT = '3306'
 DEFAULT_SSH_PORT = '22'
+UI_LISTEN_HOST_PROPERTY = 'listen.host'
+UI_IPV6_ANY_LISTEN_HOSTS = ('::', '[::]')
+JAVA_PREFER_IPV4_STACK_OPT = '-Djava.net.preferIPv4Stack'
+JAVA_PREFER_IPV4_STACK_TRUE = JAVA_PREFER_IPV4_STACK_OPT + '=true'
+JAVA_PREFER_IPV4_STACK_FALSE = JAVA_PREFER_IPV4_STACK_OPT + '=false'
+JAVA_PREFER_IPV6_ADDRESSES_TRUE = '-Djava.net.preferIPv6Addresses=true'
+
+
+def is_ipv6_literal(address):
+    if not address:
+        return False
+
+    try:
+        socket.inet_pton(socket.AF_INET6, address.strip('[]'))
+        return True
+    except socket.error:
+        return False
+
+
+def management_server_should_listen_ipv6(properties):
+    if properties.get('management.server.ip6') or properties.get('management.server.vip6'):
+        return True
+
+    return is_ipv6_literal(properties.get('management.server.ip'))
+
+
+def build_management_server_ip_stack_opts(properties):
+    if management_server_should_listen_ipv6(properties):
+        return [JAVA_PREFER_IPV4_STACK_FALSE, JAVA_PREFER_IPV6_ADDRESSES_TRUE]
+
+    return [JAVA_PREFER_IPV4_STACK_TRUE]
+
+
+def ui_should_listen_ipv6(listen_host):
+    if not listen_host:
+        return False
+
+    return listen_host.strip() in UI_IPV6_ANY_LISTEN_HOSTS
+
+
+def build_ui_nginx_ipv6_listen_line(server_port, enable_ssl=False, enable_http2=False):
+    suffix = ''
+    if enable_ssl:
+        suffix = ' ssl'
+        if str(enable_http2).lower() == 'true':
+            suffix += ' http2'
+
+    return '        listen [::]:%s%s;' % (server_port, suffix)
+
+
+def ensure_ui_nginx_ipv6_listen_conf(conf_path, server_port, enable_ssl=False, enable_http2=False):
+    if not os.path.exists(conf_path):
+        return False
+
+    listen_line = build_ui_nginx_ipv6_listen_line(server_port, enable_ssl, enable_http2)
+    with open(conf_path, 'r') as fd:
+        content = fd.read()
+
+    if listen_line in content:
+        return False
+
+    lines = content.splitlines()
+    insert_at = None
+    for idx, line in enumerate(lines):
+        if line.strip().startswith('listen '):
+            insert_at = idx + 1
+            break
+
+    if insert_at is None:
+        lines.insert(0, listen_line)
+    else:
+        lines.insert(insert_at, listen_line)
+
+    with open(conf_path, 'w') as fd:
+        fd.write('\n'.join(lines) + '\n')
+    return True
 
 mysql_db_config_script='''
 #!/bin/bash
@@ -3113,7 +3190,6 @@ class StartCmd(Command):
             setenv_path = os.path.join(ctl.zstack_home, self.SET_ENV_SCRIPT)
             catalina_opts = [
                 '-Djdk.tls.trustNameService=true',
-                '-Djava.net.preferIPv4Stack=true',
                 '-Dcom.sun.management.jmxremote=true',
                 '-Djava.security.egd=file:/dev/./urandom',
                 '-XX:-OmitStackTraceInFastThrow',
@@ -3123,6 +3199,11 @@ class StartCmd(Command):
                 '-XX:+UseAltSigs',
                 '-Dlog4j2.formatMsgNoLookups=true'
             ]
+            catalina_opts.extend(build_management_server_ip_stack_opts({
+                'management.server.ip': ctl.read_property('management.server.ip'),
+                'management.server.ip6': ctl.read_property('management.server.ip6'),
+                'management.server.vip6': ctl.read_property('management.server.vip6'),
+            }))
 
             if ctl.extra_arguments:
                 catalina_opts.extend(ctl.extra_arguments)
@@ -10784,6 +10865,7 @@ class StartUiCmd(Command):
         cfg_ssl_keystore_password = ctl.read_ui_property("ssl_keystore_password")
         cfg_catalina_opts = ctl.read_ui_property("catalina_opts")
         cfg_redis_password = ctl.read_ui_property("redis_password")
+        cfg_listen_host = ctl.read_ui_property(UI_LISTEN_HOST_PROPERTY)
 
         custom_props = ""
         predefined_props = ["db_url", "db_username", "db_password", "mn_host", "mn_port", "webhook_host", "webhook_port", "server_port", "log", "enable_ssl", "ssl_keyalias", "ssl_keystore", "ssl_keystore_type", "ssl_keystore_password", "catalina_opts"]
@@ -10923,6 +11005,7 @@ class StartUiCmd(Command):
 
         shell("ps aux| grep zstack-ui/scripts/start.sh | awk '{print $2}'|xargs kill -9",is_exception=False)
         script(scmd, no_pipe=True)
+        self._configure_nginx_ipv6_listen(args.server_port, args.enable_ssl, args.enable_http2, cfg_listen_host)
         os.system('mkdir -p /var/run/zstack/')
         with open(StartUiCmd.PORT_FILE, 'w') as fd:
             fd.write(args.server_port)
@@ -10953,6 +11036,20 @@ class StartUiCmd(Command):
             info('successfully started UI server on the local host')
         else:
             info('successfully started UI server on the local host %s://%s:%s' % ('https' if args.enable_ssl else 'http', default_ip, args.server_port))
+
+    def _configure_nginx_ipv6_listen(self, server_port, enable_ssl, enable_http2, listen_host):
+        if not ui_should_listen_ipv6(listen_host):
+            return
+
+        conf_path = os.path.join(ctl.ZSTACK_UI_HOME, 'configs', 'extend.server.nginx.conf')
+        if ensure_ui_nginx_ipv6_listen_conf(conf_path, server_port, enable_ssl, enable_http2):
+            shell('/usr/sbin/nginx -c %s -t && /usr/sbin/nginx -c %s -s reload' %
+                  (os.path.join(ctl.ZSTACK_UI_HOME, 'configs', 'nginx.conf'),
+                   os.path.join(ctl.ZSTACK_UI_HOME, 'configs', 'nginx.conf')))
+
+        if shell_return('which ip6tables >/dev/null 2>&1') == 0:
+            shell('ip6tables-save | grep -- "-A INPUT -p tcp -m tcp --dport %s -j ACCEPT" > /dev/null || ip6tables -I INPUT -p tcp -m tcp --dport %s -j ACCEPT ' %
+                  (server_port, server_port))
 
     def run_mini_ui(self):
         shell_return("systemctl start zstack-mini")
@@ -11019,6 +11116,7 @@ class ConfigUiCmd(Command):
         parser.add_argument('--webhook-port', help="Webhook Host port. [DEFAULT] 5001")
         parser.add_argument('--server-port', help="UI server port. [DEFAULT] 5000")
         parser.add_argument('--ui-address', help="ZStack UI Address.")
+        parser.add_argument('--listen-host', '--listen.host', dest='listen_host', help="UI listen host.")
         parser.add_argument('--log', help="UI log folder. [DEFAULT] %s" % ui_logging_path)
         parser.add_argument('--catalina-opts', help="UI catalina options, seperated by `,`")
 
@@ -11217,6 +11315,8 @@ class ConfigUiCmd(Command):
         # ui_address
         if args.ui_address:
             ctl.write_ui_property("ui_address", args.ui_address.strip())
+        if args.listen_host:
+            ctl.write_ui_property(UI_LISTEN_HOST_PROPERTY, args.listen_host.strip())
 
         # catalina opts
         if args.catalina_opts:

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -3136,6 +3136,11 @@ class StartCmd(Command):
                 info('use CATALINA_OPTS[%s] set in environment zstack environment variables; check out them by "zstack-ctl getenv"' % co)
                 catalina_opts.extend(co.split(' '))
 
+            catalina_opts = management_network_ipv6.build_java_ip_stack_opts(
+                ctl.read_property('management.server.ip'),
+                catalina_opts,
+            )
+
             def has_opt(prefix):
                 for opt in catalina_opts:
                     if opt.startswith(prefix):

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -79,7 +79,7 @@ def build_management_server_ip_stack_opts(properties):
     if management_server_should_listen_ipv6(properties):
         return [JAVA_PREFER_IPV4_STACK_FALSE, JAVA_PREFER_IPV6_ADDRESSES_TRUE]
 
-    return [JAVA_PREFER_IPV4_STACK_TRUE]
+    return [JAVA_PREFER_IPV4_STACK_FALSE]
 
 
 def ui_should_listen_ipv6(listen_host):

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -8145,6 +8145,45 @@ class ChangeIpCmd(Command):
         info("Change ip successfully")
 
 
+class AddIp6Cmd(Command):
+    def __init__(self):
+        super(AddIp6Cmd, self).__init__()
+        self.name = "add_ip6"
+        self.description = "add an IPv6 address to the current management node"
+        ctl.register_command(self)
+
+    def install_argparse_arguments(self, parser):
+        parser.add_argument('--ip', help='The IPv6 address to add to the current management node.', required=True)
+        parser.add_argument('--prefix', help='The IPv6 prefix length, from 0 to 128.', required=True)
+        parser.add_argument('--nic', help='The network interface to configure. By default zstack-ctl selects the current management interface.', required=False)
+
+    def run(self, args):
+        if not management_network_ipv6.validate_ipv6(args.ip):
+            error('add_ip6 requires a valid IPv6 address')
+
+        prefix_length = management_network_ipv6.normalize_ipv6_prefix(args.prefix)
+        if prefix_length is None:
+            error('add_ip6 requires an IPv6 prefix length from 0 to 128')
+
+        if local_ip_exists(args.ip):
+            info('IPv6 address %s already exists, skip' % args.ip)
+            return
+
+        management_ip = ctl.read_property('management.server.ip')
+        addr_output = shell('ip -o addr show', False)
+        route_output = shell('ip route show default', False)
+        nic = management_network_ipv6.select_add_ip6_interface(args.nic, management_ip, route_output, addr_output)
+        if nic is None:
+            error('cannot decide which interface to configure, please pass --nic explicitly')
+
+        command = management_network_ipv6.build_add_ip6_command(args.ip, prefix_length, nic)
+        if command is None:
+            error('failed to build add_ip6 command from input')
+
+        shell_no_pipe(' '.join(command))
+        info('Add IPv6 address %s/%s to interface %s successfully' % (args.ip, prefix_length, nic))
+
+
 class InstallManagementNodeCmd(Command):
     def __init__(self):
         super(InstallManagementNodeCmd, self).__init__()
@@ -12482,6 +12521,7 @@ class AIOSSetUpSystemServicesCmd(Command):
 
 
 def main():
+    AddIp6Cmd()
     AddManagementNodeCmd()
     BootstrapCmd()
     ChangeIpCmd()

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -731,6 +731,10 @@ def replace_db_url_host(db_url, new_host):
     return management_network_ipv6.replace_db_url_host(db_url, new_host)
 
 
+def local_ip_exists(ip):
+    return management_network_ipv6.ip_addr_output_has_ip(ip, shell("ip addr", False))
+
+
 def split_host_port_endpoint(endpoint, default_port):
     endpoint = endpoint.strip() if endpoint else ''
     if endpoint.startswith('['):
@@ -3058,7 +3062,7 @@ class StartCmd(Command):
             mn_ip = ctl.read_property('management.server.ip')
             if not mn_ip:
                 error("management.server.ip not configured")
-            if 0 != shell_return("ip a | grep 'inet ' | grep -w '%s'" % mn_ip):
+            if not local_ip_exists(mn_ip):
                 error("management.server.ip[%s] is not found on any device" % mn_ip)
 
         def check_ha():
@@ -5959,7 +5963,7 @@ class MysqlRestrictConnection(Command):
         mn_ip = ctl.read_property('management.server.ip')
         if not mn_ip:
             error("management.server.ip not configured")
-        if 0 != shell_return("ip a | grep 'inet ' | grep -w '%s'" % mn_ip):
+        if not local_ip_exists(mn_ip):
             error("management.server.ip[%s] is not found on any device" % mn_ip)
 
         return mn_ip
@@ -7826,7 +7830,7 @@ class ChangeIpCmd(Command):
         if status != 0 or (output != "non-root" and output != "root"):
             return
 
-        if shell_return("ip a | grep 'inet ' | grep -w '%s'" % mysql_ip) != 0:
+        if not local_ip_exists(mysql_ip):
             return
 
         if root_password is None:

--- a/zstackctl/zstackctl/management_network_ipv6.py
+++ b/zstackctl/zstackctl/management_network_ipv6.py
@@ -111,18 +111,14 @@ def ip_addr_output_has_ip(ip, addr_output):
 
 
 def build_java_ip_stack_opts(management_ip, catalina_opts):
-    if get_ip_version(management_ip) != IPV6_VERSION:
-        return list(catalina_opts)
-
     opts = [
         opt for opt in catalina_opts
         if not opt.startswith(JAVA_PREFER_IPV4_STACK_PREFIX)
         and not opt.startswith(JAVA_PREFER_IPV6_ADDRESSES_PREFIX)
     ]
-    opts.extend([
-        JAVA_PREFER_IPV4_STACK_PREFIX + 'false',
-        JAVA_PREFER_IPV6_ADDRESSES_PREFIX + 'true',
-    ])
+    opts.append(JAVA_PREFER_IPV4_STACK_PREFIX + 'false')
+    if get_ip_version(management_ip) == IPV6_VERSION:
+        opts.append(JAVA_PREFER_IPV6_ADDRESSES_PREFIX + 'true')
     return opts
 
 

--- a/zstackctl/zstackctl/management_network_ipv6.py
+++ b/zstackctl/zstackctl/management_network_ipv6.py
@@ -18,6 +18,8 @@ IPV6_VERSION = 6
 JDBC_IPV6_HOST_FORMAT = '[%s]'
 IPV6_DB_HOST_PATTERN = r'\[([0-9a-fA-F:]+)\]'
 IPV4_OR_LOCALHOST_DB_HOST_PATTERN = r'(?<![0-9A-Za-z_.-])(?:[0-9]{1,3}(?:\.[0-9]{1,3}){3}|localhost)(?![0-9A-Za-z_.-])'
+JAVA_PREFER_IPV4_STACK_PREFIX = '-Djava.net.preferIPv4Stack='
+JAVA_PREFER_IPV6_ADDRESSES_PREFIX = '-Djava.net.preferIPv6Addresses='
 
 
 def validate_ip(value):
@@ -99,3 +101,19 @@ def ip_addr_output_has_ip(ip, addr_output):
         return False
 
     return re.search(r'\binet6?\s+%s(?:/|\s)' % re.escape(ip), addr_output) is not None
+
+
+def build_java_ip_stack_opts(management_ip, catalina_opts):
+    if get_ip_version(management_ip) != IPV6_VERSION:
+        return list(catalina_opts)
+
+    opts = [
+        opt for opt in catalina_opts
+        if not opt.startswith(JAVA_PREFER_IPV4_STACK_PREFIX)
+        and not opt.startswith(JAVA_PREFER_IPV6_ADDRESSES_PREFIX)
+    ]
+    opts.extend([
+        JAVA_PREFER_IPV4_STACK_PREFIX + 'false',
+        JAVA_PREFER_IPV6_ADDRESSES_PREFIX + 'true',
+    ])
+    return opts

--- a/zstackctl/zstackctl/management_network_ipv6.py
+++ b/zstackctl/zstackctl/management_network_ipv6.py
@@ -84,3 +84,18 @@ def replace_db_url_host(db_url, new_host):
         return db_url.replace(JDBC_IPV6_HOST_FORMAT % old_host, format_host_for_url_or_jdbc(new_host), 1)
 
     return db_url.replace(old_host, format_host_for_url_or_jdbc(new_host), 1)
+
+
+def ip_addr_output_has_ip(ip, addr_output):
+    if ip is None or addr_output is None:
+        return False
+    if isinstance(ip, bytes) and bytes not in STRING_TYPES:
+        ip = ip.decode('utf-8')
+    if not isinstance(ip, STRING_TYPES):
+        return False
+
+    ip = ip.strip('[]')
+    if not validate_ip(ip):
+        return False
+
+    return re.search(r'\binet6?\s+%s(?:/|\s)' % re.escape(ip), addr_output) is not None

--- a/zstackctl/zstackctl/management_network_ipv6.py
+++ b/zstackctl/zstackctl/management_network_ipv6.py
@@ -20,6 +20,13 @@ IPV6_DB_HOST_PATTERN = r'\[([0-9a-fA-F:]+)\]'
 IPV4_OR_LOCALHOST_DB_HOST_PATTERN = r'(?<![0-9A-Za-z_.-])(?:[0-9]{1,3}(?:\.[0-9]{1,3}){3}|localhost)(?![0-9A-Za-z_.-])'
 JAVA_PREFER_IPV4_STACK_PREFIX = '-Djava.net.preferIPv4Stack='
 JAVA_PREFER_IPV6_ADDRESSES_PREFIX = '-Djava.net.preferIPv6Addresses='
+MIN_IPV6_PREFIX_LENGTH = 0
+MAX_IPV6_PREFIX_LENGTH = 128
+IP_COMMAND = 'ip'
+IPV6_ADDR_ADD_ARGUMENTS = ('-6', 'addr', 'add')
+IPV6_DEVICE_ARGUMENT = 'dev'
+INTERFACE_NAME_PATTERN = r'^[0-9A-Za-z_.:-]+$'
+DEFAULT_ROUTE_INTERFACE_PATTERN = r'\bdev\s+([0-9A-Za-z_.:-]+)'
 
 
 def validate_ip(value):
@@ -117,3 +124,78 @@ def build_java_ip_stack_opts(management_ip, catalina_opts):
         JAVA_PREFER_IPV6_ADDRESSES_PREFIX + 'true',
     ])
     return opts
+
+
+def validate_ipv6(value):
+    return get_ip_version(value) == IPV6_VERSION
+
+
+def normalize_ipv6_prefix(prefix):
+    try:
+        prefix_length = int(prefix)
+    except (TypeError, ValueError):
+        return None
+
+    if MIN_IPV6_PREFIX_LENGTH <= prefix_length <= MAX_IPV6_PREFIX_LENGTH:
+        return prefix_length
+    return None
+
+
+def validate_interface_name(nic):
+    return isinstance(nic, STRING_TYPES) and re.match(INTERFACE_NAME_PATTERN, nic) is not None
+
+
+def strip_interface_suffix(nic):
+    return nic.split('@', 1)[0] if nic else nic
+
+
+def find_interface_by_ip(ip, addr_output):
+    if not validate_ip(ip) or not addr_output:
+        return None
+
+    ip = ip.strip('[]')
+    for line in addr_output.splitlines():
+        match = re.match(r'^\d+:\s+([^:\s]+).*?\s+inet6?\s+%s(?:/|\s)' % re.escape(ip), line.strip())
+        if match:
+            return strip_interface_suffix(match.group(1))
+
+    return None
+
+
+def find_default_route_interface(route_output):
+    if not route_output:
+        return None
+
+    for line in route_output.splitlines():
+        if not line.startswith('default '):
+            continue
+        match = re.search(DEFAULT_ROUTE_INTERFACE_PATTERN, line)
+        if match:
+            return strip_interface_suffix(match.group(1))
+
+    return None
+
+
+def select_add_ip6_interface(explicit_nic, management_ip, route_output, addr_output):
+    if explicit_nic:
+        return explicit_nic if validate_interface_name(explicit_nic) else None
+
+    if management_ip:
+        nic = find_interface_by_ip(management_ip, addr_output)
+        if nic:
+            return nic
+
+    nic = find_default_route_interface(route_output)
+    return nic if validate_interface_name(nic) else None
+
+
+def build_add_ip6_command(ip, prefix, nic):
+    prefix_length = normalize_ipv6_prefix(prefix)
+    if not validate_ipv6(ip) or prefix_length is None or not validate_interface_name(nic):
+        return None
+
+    return [IP_COMMAND] + list(IPV6_ADDR_ADD_ARGUMENTS) + [
+        '%s/%s' % (ip.strip('[]'), prefix_length),
+        IPV6_DEVICE_ARGUMENT,
+        nic,
+    ]

--- a/zstacklib/zstacklib/storage/nfs/operations.py
+++ b/zstacklib/zstacklib/storage/nfs/operations.py
@@ -17,6 +17,30 @@ from .exceptions import (
 
 
 MOUNT_TIMEOUT = 180
+NFS_URL_SEPARATOR = ':'
+IPV6_HOST_PREFIX = '['
+IPV6_HOST_SUFFIX = ']'
+
+
+def parse_nfs_url(url: str) -> tuple[str, str]:
+    """Parse nfs url into host and absolute path."""
+    if url.startswith(IPV6_HOST_PREFIX):
+        end = url.find(IPV6_HOST_SUFFIX)
+        if end <= 0:
+            raise InvalidNfsUrlError(url, 'IPv6 host must be enclosed by []')
+
+        host = url[len(IPV6_HOST_PREFIX):end]
+        suffix = url[end + len(IPV6_HOST_SUFFIX):]
+        if not suffix.startswith(NFS_URL_SEPARATOR):
+            raise InvalidNfsUrlError(url, 'url should be [IPv6]:/absolute/path')
+
+        return host, suffix[len(NFS_URL_SEPARATOR):]
+
+    ts = url.split(NFS_URL_SEPARATOR)
+    if len(ts) != 2:
+        raise InvalidNfsUrlError(url, 'url should have one and only one ":"')
+
+    return ts[0], ts[1]
 
 
 def is_mounted(path: str | None = None, url: str | None = None) -> bool:
@@ -50,15 +74,10 @@ def is_mounted_with_alternate_format(path: str | None = None, url: str | None = 
 
 def validate_nfs_url(url: str) -> bool:
     """Validate nfs url."""
-    ts = url.split(':')
-    if len(ts) != 2:
-        raise InvalidNfsUrlError(url, 'url should have one and only one ":"')
-
-    host = ts[0]
-    path = ts[1]
+    host, path = parse_nfs_url(url)
 
     try:
-        socket.gethostbyname(host)
+        socket.getaddrinfo(host, None)
     except socket.gaierror:
         raise InvalidNfsUrlError(url, f'{host} cannot resolve to ip address')
 
@@ -73,13 +92,9 @@ def check_mount_status(url: str, path: str, info: str | None = None) -> None:
     if not url or not path:
         raise ValueError('url and path are required')
 
-    ts = url.split(':')
-    if len(ts) != 2:
-        raise InvalidNfsUrlError(url, 'url should have one and only one ":"')
-
-    host = ts[0]
+    host, _ = parse_nfs_url(url)
     try:
-        socket.gethostbyname(host)
+        socket.getaddrinfo(host, None)
     except socket.gaierror:
         raise InvalidMountDomainError(url, f'{host} cannot resolve to ip address')
 

--- a/zstacklib/zstacklib/storage/nfs/operations.py
+++ b/zstacklib/zstacklib/storage/nfs/operations.py
@@ -49,11 +49,11 @@ def is_mounted(path: str | None = None, url: str | None = None) -> bool:
         url = re.sub(r'/{2,}', '/', url.rstrip('/'))
 
     if url and path:
-        cmdstr = f"mount | grep '{url} on ' | grep '{path} ' "
+        cmdstr = f"mount | grep -F '{url} on ' | grep -F '{path} ' "
     elif not url:
-        cmdstr = f"mount | grep '{path} '"
+        cmdstr = f"mount | grep -F '{path} '"
     elif not path:
-        cmdstr = f"mount | grep '{url} on '"
+        cmdstr = f"mount | grep -F '{url} on '"
     else:
         raise ValueError('path and url cannot both be None')
 

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -69,6 +69,9 @@ KVM_CHECK_EXTENSION = 44547
 DEFAULT_VM_IPA_SIZE = 40
 LIVE_LIBVIRT_XML_DIR = "/var/run/libvirt/qemu"
 MAX_NBD_READ_SIZE = 32768000
+NFS_URL_SEPARATOR = ':'
+IPV6_HOST_PREFIX = '['
+IPV6_HOST_SUFFIX = ']'
 
 def ignoreerror(func):
     @functools.wraps(func)
@@ -639,13 +642,30 @@ def get_hostname_fqdn():
         return socket.getaddrinfo(socket.gethostname(), 0, 0, 0, 0, socket.AI_CANONNAME)[0][3]
     return socket.getaddrinfo(socket.gethostname(), 0, flags=socket.AI_CANONNAME)[0][3]
 
+def parse_nfs_url(url):
+    if url.startswith(IPV6_HOST_PREFIX):
+        end = url.find(IPV6_HOST_SUFFIX)
+        if end <= 0:
+            raise InvalidNfsUrlError(url, 'IPv6 host must be enclosed by []')
+
+        host = url[len(IPV6_HOST_PREFIX):end]
+        suffix = url[end + len(IPV6_HOST_SUFFIX):]
+        if not suffix.startswith(NFS_URL_SEPARATOR):
+            raise InvalidNfsUrlError(url, 'url should be [IPv6]:/absolute/path')
+
+        return host, suffix[len(NFS_URL_SEPARATOR):]
+
+    ts = url.split(NFS_URL_SEPARATOR)
+    if len(ts) != 2:
+        raise InvalidNfsUrlError(url, 'url should have one and only one ":"')
+
+    return ts[0], ts[1]
+
+
 def is_valid_nfs_url(url):
-    ts = url.split(':')
-    if len(ts) != 2: raise InvalidNfsUrlError(url, 'url should have one and only one ":"')
-    host = ts[0]
-    path = ts[1]
+    host, path = parse_nfs_url(url)
     try:
-        socket.gethostbyname(host)
+        socket.getaddrinfo(host, None)
     except socket.gaierror:
         raise InvalidNfsUrlError(url, '%s cannont resolve to ip address' % host)
 

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -2696,18 +2696,24 @@ class Interface(object):
                 'name':self.name,
                 'ips':self.ips})
 
+IP_ADDR_INTERFACE_MARKER = 'mtu'
+IP_ADDR_ADDRESS_FAMILIES = ('inet', 'inet6')
+IP_ADDR_LIST_CMD = "ip a | grep -E 'mtu| inet | inet6 '"
+
+
 def get_eth_ips():
-    nics = shell.call("ip a | grep -E 'mtu| inet '")
+    nics = shell.call(IP_ADDR_LIST_CMD)
     result = dict()
     interf = ''
 
     for i in nics.splitlines():
-        if i.find('mtu') >= 0:
+        fields = i.strip().split()
+        if i.find(IP_ADDR_INTERFACE_MARKER) >= 0:
             interf = re.findall(r':\ .*:\ ', i)[0].split(': ')[1]
             status = True if re.findall(r'UP', i) else False
             result[interf] = Interface({'name':interf, 'status':status, 'ips':list()})
-        elif i.find('inet') >= 0:
-            result[interf].ips.append(re.findall(r'inet\ .*\ scope', i)[0].split(' ')[1].split('/')[0])
+        elif fields and fields[0] in IP_ADDR_ADDRESS_FAMILIES:
+            result[interf].ips.append(fields[1].split('/')[0])
 
     return result
 

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -614,11 +614,13 @@ def fumount(mountpoint, timeout = 10):
     return shell.run("timeout %s fusermount -u %s" % (timeout, mountpoint))
 
 def is_valid_address(address):
-    try:
-        socket.inet_aton(address)
-        return True
-    except socket.error:
-        return False
+    for family in (socket.AF_INET, socket.AF_INET6):
+        try:
+            socket.inet_pton(family, address)
+            return True
+        except socket.error:
+            pass
+    return False
 
 def is_valid_hostname(hostname):
     if is_valid_address(hostname):
@@ -631,6 +633,8 @@ def is_valid_hostname(hostname):
         return False
 
 def get_host_by_name(host):
+    if is_valid_address(host):
+        return host
     return socket.getaddrinfo(host, None)[0][4][0]
 
 def get_hostname():

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -625,13 +625,13 @@ def is_valid_hostname(hostname):
         return True
 
     try:
-        socket.gethostbyname(hostname)
+        socket.getaddrinfo(hostname, None)
         return True
     except socket.error:
         return False
 
 def get_host_by_name(host):
-    return socket.gethostbyname(host)
+    return socket.getaddrinfo(host, None)[0][4][0]
 
 def get_hostname():
     return socket.gethostname()

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -508,11 +508,11 @@ def is_mounted(path=None, url=None):
         url = re.sub(r'/{2,}','/',url.rstrip('/'))
 
     if url and path:
-        cmdstr = "mount | grep -E '%s[ /]+on' | grep '%s ' " % (url, path)
+        cmdstr = "mount | grep -F '%s on ' | grep -F '%s ' " % (url, path)
     elif not url:
-        cmdstr = "mount | grep '%s '" % path
+        cmdstr = "mount | grep -F '%s '" % path
     elif not path:
-        cmdstr = "mount | grep -E '%s[ /]+on'" % url
+        cmdstr = "mount | grep -F '%s on '" % url
     else:
         raise Exception('path and url cannot both be None')
 

--- a/zstacklib/zstacklib/utils/network_ipv6.py
+++ b/zstacklib/zstacklib/utils/network_ipv6.py
@@ -45,6 +45,10 @@ def format_url_host(host):
     return URL_IPV6_HOST_FORMAT % host if IPV6_SEPARATOR in host else host
 
 
+def format_host_port(host, port):
+    return '%s:%s' % (format_url_host(host), port)
+
+
 def get_socket_family(host):
     return socket.AF_INET6 if host and IPV6_SEPARATOR in host else socket.AF_INET
 


### PR DESCRIPTION
## Summary
Submit remaining management-network IPv6 utility commits to feature-5.5.28-IPv6-management-network.

## Changes
- zstack-ctl IPv6 MN address checks, JVM stack handling, add_ip6 command, and dual-stack HA startup support.
- KVM agent IPv6 libvirt migration URI formatting.
- Console proxy IPv6 token/target and dual-stack listener fixes.
- IPv6 handling for imagestore, NFS URL/mount matching, CIDR NIC matching, and literal IP DNS avoidance.
- Focused unit tests for the above helper paths.

## Verification
- These commits were hotfixed and used during the ZSTAC-85504 HA regression.
- VM live migration through IPv6 extraIps passed in the HA dual-host environment.
- No local dirty change is included in this MR; source branch is the pushed shixin remote branch.

Jira: ZSTAC-79206
Linked test task: ZSTAC-85504

sync from gitlab !7158