### PR TITLE
<fix>[kvmagent]: ZSTAC-83890 backport suspect-host pre-fence to 4.8.38

### DIFF
--- a/kvmagent/kvmagent/plugins/ha_plugin.py
+++ b/kvmagent/kvmagent/plugins/ha_plugin.py
@@ -68,6 +68,22 @@ class GetVmFencerRuleRsp(AgentRsp):
         self.allowRules = None
         self.blockRules = None
 
+class FenceVmOnSuspectHostCmd(kvmagent.AgentCommand):
+    @log.sensitive_fields("targetHostPrivateKey")
+    def __init__(self):
+        super(FenceVmOnSuspectHostCmd, self).__init__()
+        self.vmUuid = None
+        self.targetHostUuid = None
+        self.targetHostIp = None
+        self.targetHostUsername = None
+        self.targetHostPrivateKey = None
+        self.targetHostSshPort = None
+        self.sshTimeoutSec = None
+
+class FenceVmOnSuspectHostRsp(AgentRsp):
+    def __init__(self):
+        super(FenceVmOnSuspectHostRsp, self).__init__()
+
 class DelVpcHaFromHostRsp(AgentRsp):
     def __init__(self):
         super(DelVpcHaFromHostRsp, self).__init__()
@@ -1403,6 +1419,7 @@ class HaPlugin(kvmagent.KvmAgent):
     ADD_VM_FENCER_RULE_TO_HOST = "/add/vm/fencer/rule/to/host"
     REMOVE_VM_FENCER_RULE_FROM_HOST = "/remove/vm/fencer/rule/from/host"
     GET_VM_FENCER_RULE = "/get/vm/fencer/rule/"
+    FENCE_VM_ON_SUSPECT_HOST_PATH = "/ha/vm/fenceonsuspecthost"
 
 
     RET_SUCCESS = "success"
@@ -2046,6 +2063,84 @@ class HaPlugin(kvmagent.KvmAgent):
         rsp.vmUuids = list(set(runningVms))
         return jsonobject.dumps(rsp)
 
+    def _is_pre_fence_ssh_unreachable(self, rc, out, err):
+        if rc != 255:
+            return False
+
+        output = "%s\n%s" % (out if out else "", err if err else "")
+        unreachable_errors = [
+            "Connection timed out",
+            "No route to host",
+            "Connection refused",
+        ]
+        return any(e in output for e in unreachable_errors)
+
+    @kvmagent.replyerror
+    def fence_vm_on_suspect_host(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = FenceVmOnSuspectHostRsp()
+
+        vm_uuid = cmd.vmUuid
+        target_ip = cmd.targetHostIp.strip() if cmd.targetHostIp else ""
+        if not target_ip:
+            rsp.success = False
+            rsp.error = "targetHostIp is required to fence vm[%s] on suspect host" % vm_uuid
+            logger.warn(rsp.error)
+            return jsonobject.dumps(rsp)
+
+        target_user = cmd.targetHostUsername if cmd.targetHostUsername else "root"
+        target_port = int(cmd.targetHostSshPort) if cmd.targetHostSshPort else 22
+        target_private_key = cmd.targetHostPrivateKey
+        ssh_timeout = int(cmd.sshTimeoutSec) if cmd.sshTimeoutSec else 20
+
+        remote_cmd = (
+            "(timeout 8 virsh destroy {uuid} >/dev/null 2>&1 || true); "
+            "pkill -9 -f '[q]emu-[ks].*{uuid}' >/dev/null 2>&1 || true; "
+            "sleep 1; "
+            "if pgrep -f '[q]emu-[ks].*{uuid}' >/dev/null 2>&1; then echo QEMU_ALIVE; exit 2; fi; "
+            "echo QEMU_DEAD"
+        ).format(uuid=vm_uuid)
+
+        private_key_file = linux.write_to_temp_file(target_private_key if target_private_key else "")
+        os.chmod(private_key_file, 0o600)
+        ssh_argv = (
+            "timeout %d ssh -i %s -p %d "
+            "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "
+            "-o ConnectTimeout=5 -o ServerAliveInterval=5 -o ServerAliveCountMax=2 "
+            "-o BatchMode=no %s@%s %s"
+        ) % (ssh_timeout, private_key_file, target_port, target_user, target_ip,
+             linux.shellquote(remote_cmd))
+
+        logger.info("fence vm[%s] on suspect host[%s] via this peer" % (vm_uuid, target_ip))
+        try:
+            try:
+                s = shell.ShellCmd(ssh_argv)
+                s(False)
+            except Exception as e:
+                rsp.success = False
+                rsp.error = "failed to execute ssh command for suspect host[%s]: %s" % (target_ip, str(e))
+                logger.warn(rsp.error)
+                return jsonobject.dumps(rsp)
+            rc, out, err = s.return_code, s.stdout, s.stderr
+
+            if rc == 0:
+                logger.info("vm[%s] confirmed dead on suspect host[%s]" % (vm_uuid, target_ip))
+            elif rc == 2:
+                rsp.success = False
+                rsp.error = "qemu still alive on %s after force-destroy attempt" % target_ip
+            elif self._is_pre_fence_ssh_unreachable(rc, out, err):
+                logger.info("ssh to suspect host[%s] failed (rc=%s, err=%s), treat as unreachable"
+                            % (target_ip, rc, err))
+            else:
+                rsp.success = False
+                rsp.error = "failed to fence vm[%s] on suspect host[%s], ssh rc=%s, stdout=%s, stderr=%s" % (
+                    vm_uuid, target_ip, rc, out, err)
+                logger.warn(rsp.error)
+        finally:
+            linux.rm_file_force(private_key_file)
+
+        return jsonobject.dumps(rsp)
+
     @kvmagent.replyerror
     def sanlock_scan_host(self, req):
         def parseLockspaceHostIdPair(s):
@@ -2147,6 +2242,8 @@ class HaPlugin(kvmagent.KvmAgent):
         http_server.register_async_uri(self.ADD_VM_FENCER_RULE_TO_HOST, self.add_vm_fencer_rule_to_host)
         http_server.register_async_uri(self.REMOVE_VM_FENCER_RULE_FROM_HOST, self.remove_vm_fencer_rule_from_host)
         http_server.register_async_uri(self.GET_VM_FENCER_RULE, self.get_vm_fencer_rule)
+        http_server.register_async_uri(self.FENCE_VM_ON_SUSPECT_HOST_PATH, self.fence_vm_on_suspect_host,
+                                       cmd=FenceVmOnSuspectHostCmd())
 
 
     def stop(self):

--- a/kvmagent/kvmagent/test/test_ha_pre_fence_vm_on_suspect_host.py
+++ b/kvmagent/kvmagent/test/test_ha_pre_fence_vm_on_suspect_host.py
@@ -1,0 +1,116 @@
+import time
+
+from kvmagent.test.utils import pytest_utils
+from kvmagent.test.utils.stub import *
+from kvmagent.plugins.ha_plugin import HaPlugin
+from zstacklib.test.utils import env
+from zstacklib.utils.http import REQUEST_BODY
+from zstacklib.utils import bash, jsonobject
+from unittest import TestCase
+
+
+init_kvmagent()
+
+PKG_NAME = __name__
+
+__ENV_SETUP__ = {
+    'self': {}
+}
+
+
+## describe: case will manage by ztest
+class TestHaPreFenceVmOnSuspectHost(TestCase, pytest_utils.PytestExtension):
+    @classmethod
+    def setUpClass(cls):
+        cls.ha_plugin = HaPlugin()
+        cls.vm_uuid = 'zstac83890-fence-ssh-kill-0001'
+        cls.workdir = '/tmp/zstac83890-fence'
+
+    def _cleanup_qemu_like_process(self):
+        bash.bash_ro("pkill -9 -f '[q]emu-[ks].*%s' 2>/dev/null || true" % self.vm_uuid)
+        bash.bash_ro("rm -rf %s" % self.workdir)
+
+    def _qemu_like_process_exists(self):
+        r, o = bash.bash_ro("pgrep -f '[q]emu-[ks].*%s'" % self.vm_uuid)
+        return r == 0 and o.strip() != ''
+
+    def _wait_qemu_like_process_started(self):
+        for _ in range(20):
+            if self._qemu_like_process_exists():
+                return
+            time.sleep(0.5)
+        self.fail('failed to start qemu-like process for vm[%s]' % self.vm_uuid)
+
+    def _wait_qemu_like_process_killed(self):
+        for _ in range(20):
+            if not self._qemu_like_process_exists():
+                return
+            time.sleep(0.5)
+        self.fail('qemu-like process still alive after pre-fence for vm[%s]' % self.vm_uuid)
+
+    def _start_qemu_like_process(self):
+        bash.bash_errorout('mkdir -p %s' % self.workdir)
+        bash.bash_errorout(
+            "nohup bash -c 'exec -a \"qemu-system-x86_64 -name guest=%s\" sleep 300' "
+            "> %s/qemu-like.log 2>&1 &" % (self.vm_uuid, self.workdir)
+        )
+        self._wait_qemu_like_process_started()
+
+    def _make_request_without_logging_private_key(self, body):
+        return {
+            REQUEST_BODY: jsonobject.dumps(body, include_protected_attr=True)
+        }
+
+    def _get_current_host_ssh_ip(self):
+        current_host = env.get_test_environment_metadata()
+        target_ip = current_host.get('ip', '') if hasattr(current_host, 'get') else ''
+        target_ip = target_ip.strip() if target_ip else ''
+        if target_ip:
+            return target_ip
+
+        r, o = bash.bash_ro(
+            "ip -4 route get 1.1.1.1 | awk '{for (i=1; i<=NF; i++) if ($i == \"src\") {print $(i+1); exit}}'"
+        )
+        if r == 0 and o.strip():
+            return o.strip().splitlines()[0]
+
+        return '127.0.0.1'
+
+    def test_pre_fence_ssh_unreachable_classification(self):
+        self.assertTrue(self.ha_plugin._is_pre_fence_ssh_unreachable(
+            255, '', 'ssh: connect to host 192.0.2.10 port 22: Connection timed out'))
+        self.assertTrue(self.ha_plugin._is_pre_fence_ssh_unreachable(
+            255, '', 'ssh: connect to host 192.0.2.10 port 22: No route to host'))
+        self.assertTrue(self.ha_plugin._is_pre_fence_ssh_unreachable(
+            255, '', 'ssh: connect to host 192.0.2.10 port 22: Connection refused'))
+
+        self.assertFalse(self.ha_plugin._is_pre_fence_ssh_unreachable(
+            255, '', 'Permission denied (publickey,password).'))
+        self.assertFalse(self.ha_plugin._is_pre_fence_ssh_unreachable(
+            255, '', 'Authentication failed.'))
+        self.assertFalse(self.ha_plugin._is_pre_fence_ssh_unreachable(
+            1, '', 'local command failed'))
+
+    @pytest_utils.ztest_decorater
+    def test_fence_vm_on_suspect_host_ssh_kills_qemu_process(self):
+        target_ip = self._get_current_host_ssh_ip()
+
+        self._cleanup_qemu_like_process()
+        try:
+            self._start_qemu_like_process()
+
+            rsp = self.ha_plugin.fence_vm_on_suspect_host(self._make_request_without_logging_private_key({
+                'vmUuid': self.vm_uuid,
+                'targetHostUuid': 'zstac83890-target-host',
+                'targetHostIp': target_ip,
+                'targetHostUsername': 'root',
+                'targetHostPrivateKey': env.get_private_key(),
+                'targetHostSshPort': 22,
+                'sshTimeoutSec': 20
+            }))
+            rsp = jsonobject.loads(rsp)
+
+            self.assertEqual(True, rsp.success, rsp.error)
+            self._wait_qemu_like_process_killed()
+        finally:
+            self._cleanup_qemu_like_process()


### PR DESCRIPTION
## Summary
Backport the KVM agent suspect-host pre-fence endpoint for ZSTAC-83890 to 4.8.38.

## Changes
- Add `/ha/vm/fenceonsuspecthost` endpoint.
- Add SSH-based suspect-host qemu cleanup and result classification.
- Add unit coverage for the pre-fence endpoint.

## Testing
- [x] `git diff --check upstream/4.8.38..HEAD`
- [x] `python3 -m py_compile kvmagent/kvmagent/plugins/ha_plugin.py kvmagent/kvmagent/test/test_ha_pre_fence_vm_on_suspect_host.py`

Resolves: ZSTAC-83890

sync from gitlab !7168