### PR TITLE
<fix>[installation]: align the installation information subitems

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -553,7 +553,7 @@ pass(){
 echo_title(){
     echo "\n================">> $ZSTACK_INSTALL_LOG
     echo ""|tee -a $ZSTACK_INSTALL_LOG
-    echo -n " ${STEP}. $*:" |tee -a $ZSTACK_INSTALL_LOG
+    printf "%2d. $*:" ${STEP} |tee -a $ZSTACK_INSTALL_LOG
     STEP=`expr $STEP + 1`
 }
 


### PR DESCRIPTION
## Backport ZSTAC-85584 to 4.8.38

Cherry-pick of original fix from 原单 ZSTAC-56003 (source: 5.0.0).

Original commit: c03e8238b
Local cherry-pick HEAD: 491e22d4d

### Changes
```
 installation/install.sh | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

Related: ZSTAC-85584

sync from gitlab !7171