### PR TITLE
<fix>[zstackctl]: ZSTAC-85711 block MN IP family switch

### DIFF
--- a/tests/unit/zstackctl/test_ctl_management_ipv6.py
+++ b/tests/unit/zstackctl/test_ctl_management_ipv6.py
@@ -3,6 +3,7 @@ import json
 import socket
 import sys
 import types
+from types import SimpleNamespace
 
 import pytest
 
@@ -212,4 +213,36 @@ def test_change_ip_ipv4_path_cleans_old_ipv6_rules(monkeypatch):
         'iptables -A INPUT -p tcp --dport 3306 -j REJECT',
         'iptables -I INPUT -p tcp --dport 3306 -d 172.24.246.247 -j ACCEPT',
         'iptables -I INPUT -p tcp --dport 3306 -d 127.0.0.1 -j ACCEPT',
+    ]
+
+
+def test_change_ip_rejects_management_ip_address_family_switch(monkeypatch):
+    class ChangeIpRejected(Exception):
+        pass
+
+    errors = []
+
+    def fail(message):
+        errors.append(message)
+        raise ChangeIpRejected(message)
+
+    monkeypatch.setattr(ctl, 'check_ha', lambda: False)
+    monkeypatch.setattr(ctl.os.path, 'isfile', lambda path: True)
+    monkeypatch.setattr(ctl.ctl, 'read_property', lambda name: '172.24.249.182')
+    monkeypatch.setattr(ctl, 'error', fail)
+
+    cmd = ctl.ChangeIpCmd.__new__(ctl.ChangeIpCmd)
+    monkeypatch.setattr(cmd, 'isVirtualIp', lambda ip: False)
+
+    with pytest.raises(ChangeIpRejected):
+        cmd.run(SimpleNamespace(
+            ip='fd00:172:24:249::182',
+            cloudbus_server_ip=None,
+            mysql_ip=None,
+            root_password=None,
+        ))
+
+    assert errors == [
+        'changing management.server.ip address family is not supported: '
+        'old_ip=172.24.249.182, new_ip=fd00:172:24:249::182'
     ]

--- a/tests/unit/zstackctl/test_management_ipv6_helpers.py
+++ b/tests/unit/zstackctl/test_management_ipv6_helpers.py
@@ -41,6 +41,14 @@ def test_has_mixed_ip_versions_detects_ha_node_mismatch():
     ])
 
 
+def test_same_ip_version_transition_rejects_family_switch():
+    assert management_network_ipv6.is_same_ip_version_transition('192.168.10.10', '192.168.10.20')
+    assert management_network_ipv6.is_same_ip_version_transition('2001:db8::10', '[2001:db8::20]')
+    assert not management_network_ipv6.is_same_ip_version_transition('192.168.10.10', '2001:db8::20')
+    assert not management_network_ipv6.is_same_ip_version_transition('2001:db8::10', '192.168.10.20')
+    assert not management_network_ipv6.is_same_ip_version_transition('192.168.10.10', 'not-an-ip')
+
+
 def test_extract_db_url_host_reads_ipv4_ipv6_and_localhost():
     assert management_network_ipv6.extract_db_url_host('jdbc:mysql://192.168.10.10:3306/zstack') == '192.168.10.10'
     assert management_network_ipv6.extract_db_url_host('jdbc:mysql://[2001:db8::10]:3306/zstack') == '2001:db8::10'

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -8018,6 +8018,10 @@ class ConfiguredCollectLogCmd(Command):
 
 
 class ChangeIpCmd(Command):
+    ADDRESS_FAMILY_CHANGE_ERROR = (
+        'changing management.server.ip address family is not supported: old_ip=%s, new_ip=%s'
+    )
+
     def __init__(self):
         super(ChangeIpCmd, self).__init__()
         self.name = "change_ip"
@@ -8192,7 +8196,7 @@ class ChangeIpCmd(Command):
             error("please change to single management before change ip")
 
         zstack_conf_file = ctl.properties_file_path
-        for input_ip in [cloudbus_server_ip, mysql_ip]:
+        for input_ip in [args.ip, cloudbus_server_ip, mysql_ip]:
             if not validate_ip(input_ip):
                 info("The ip address you input: %s seems not a valid ip" % input_ip)
                 return 1
@@ -8207,6 +8211,8 @@ class ChangeIpCmd(Command):
                 if not validate_ip(old_ip):
                     info("The ip address[%s] read from [%s] seems not a valid ip" % (old_ip, zstack_conf_file))
                     return 1
+                if not management_network_ipv6.is_same_ip_version_transition(old_ip, args.ip):
+                    error(self.ADDRESS_FAMILY_CHANGE_ERROR % (old_ip, args.ip))
 
             # read from env other than /etc/hostname in case of impact of DHCP SERVER
             old_hostname = shell("hostname").replace("\n","")

--- a/zstackctl/zstackctl/management_network_ipv6.py
+++ b/zstackctl/zstackctl/management_network_ipv6.py
@@ -97,6 +97,12 @@ def has_mixed_ip_versions(ips):
     return len(versions) > 1
 
 
+def is_same_ip_version_transition(old_ip, new_ip):
+    old_version = get_ip_version(old_ip)
+    new_version = get_ip_version(new_ip)
+    return old_version is not None and new_version is not None and old_version == new_version
+
+
 def extract_db_url_host(db_url):
     ipv6_hosts = re.findall(IPV6_DB_HOST_PATTERN, db_url)
     if ipv6_hosts:


### PR DESCRIPTION
## Summary
Reject zstack-ctl change_ip when management.server.ip would switch between IPv4 and IPv6.

## Changes
- Validate old and target management.server.ip address family before writing /etc/hosts or properties.
- Add focused zstackctl helper and command-path tests.

## Testing
- python3 -m py_compile zstackctl/zstackctl/management_network_ipv6.py zstackctl/zstackctl/ctl.py tests/unit/zstackctl/test_management_ipv6_helpers.py tests/unit/zstackctl/test_ctl_management_ipv6.py
- PYTHONPATH=zstackctl python3 direct helper checks: PASS
- pytest not installed in this environment; pytest case added for CI.

Replaces MR: http://dev.zstack.io:9080/zstackio/zstack-utility/-/merge_requests/7173
Resolves: ZSTAC-85711

sync from gitlab !7175