### PR TITLE
<fix>[cephps]: idempotent rbd rm on ENOENT

### DIFF
--- a/cephprimarystorage/cephprimarystorage/cephagent.py
+++ b/cephprimarystorage/cephprimarystorage/cephagent.py
@@ -1079,10 +1079,6 @@ class CephAgent(plugin.TaskManager):
         driver = self.get_driver(cmd)
         driver.do_deletion(cmd)
 
-        @linux.retry(times=30, sleep_time=5)
-        def do_deletion():
-            shell.call('rbd rm %s' % path)
-
         def do_zeroed(path):
             try:
                 nbd_dev = nbd.connect(path)
@@ -1095,8 +1091,6 @@ class CephAgent(plugin.TaskManager):
 
         if cmd.zeroed:
             do_zeroed(path)
-            
-        do_deletion()
 
         self._set_capacity_to_response(rsp)
         return jsonobject.dumps(rsp)

--- a/cephprimarystorage/cephprimarystorage/cephdriver.py
+++ b/cephprimarystorage/cephprimarystorage/cephdriver.py
@@ -64,7 +64,17 @@ class CephDriver(object):
     def do_deletion(self, cmd):
         path = self._normalize_install_path(cmd.installPath)
 
-        shell.call('rbd rm %s' % path)
+        try:
+            shell.call('rbd rm %s' % path)
+        except shell.ShellError as e:
+            # XSky's librbd_proxy starts async GC on the first rbd rm and
+            # immediately reports the image as gone (XBD result -2), so any
+            # subsequent retry sees ENOENT. The desired end-state is achieved,
+            # treat as idempotent success.
+            if 'No such file or directory' in str(e):
+                logger.warn('rbd image %s already gone, treat delete as success: %s' % (path, str(e)))
+                return
+            raise
 
     def create_snapshot(self, cmd, rsp):
         spath = self._normalize_install_path(cmd.snapshotPath)

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -2106,6 +2106,13 @@ class Vm(object):
     def get_name(self):
         return self.domain_xmlobject.description.text_
 
+    def get_migratable_xml(self):
+        try:
+            return self.domain.XMLDesc(libvirt.VIR_DOMAIN_XML_MIGRATABLE)
+        except Exception as e:
+            logger.warn("unable to get migratable xml for vm[uuid:%s], %s" % (self.uuid, str(e)))
+            return self.domain_xml
+
     def refresh(self):
         (state, _, _, _, _) = self.domain.info()
         self.state = self.power_state[state]
@@ -3226,7 +3233,7 @@ class Vm(object):
             migrate_disks[disk_name] = volume
 
         xml_changed = False
-        tree = etree.ElementTree(etree.fromstring(self.domain_xml))
+        tree = etree.ElementTree(etree.fromstring(self.get_migratable_xml()))
         devices = tree.getroot().find('devices')
         for disk in tree.iterfind('devices/disk'):
             dev = disk.find('target').attrib['dev']

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -2108,6 +2108,12 @@ class Vm(object):
 
     def get_migratable_xml(self):
         try:
+            libvirt_version, libvirt_release = linux.get_libvirt_rpm_info()
+            if ((libvirt_version != '' and libvirt_release != '')
+                and (LooseVersion(libvirt_version) == LooseVersion('6.0.0'))
+                and (LooseVersion(libvirt_release) < LooseVersion('560'))):
+                return self.domain_xml
+
             return self.domain.XMLDesc(libvirt.VIR_DOMAIN_XML_MIGRATABLE)
         except Exception as e:
             logger.warn("unable to get migratable xml for vm[uuid:%s], %s" % (self.uuid, str(e)))

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -1008,7 +1008,7 @@ def qcow2_create(dst, size):
 def qemu_img_resize(target, size, fmt='qcow2', force=False, cmd=None):
     fmt_option = '-f %s' % fmt
     force_option = '--shrink' if force else ''
-    if cmd.kvmHostAddons.encryptKey:
+    if cmd is not None and cmd.kvmHostAddons is not None and cmd.kvmHostAddons.encryptKey:
         encrypt_opt = secret.get_qemu_resize_encrypt_options(cmd, target)
         shell.check_run('/usr/bin/qemu-img resize %s %s' % (encrypt_opt, size))
     else:

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -2422,6 +2422,18 @@ def get_libvirt_version():
     return shell.call("libvirtd --version").split()[-1]
 
 
+def get_libvirt_rpm_info():
+    cmd_get_version = shell.ShellCmd("rpm -q --qf '%{VERSION}' libvirt")
+    cmd_get_version(False)
+    cmd_get_release = shell.ShellCmd("rpm -q --qf '%{RELEASE}' libvirt")
+    cmd_get_release(False)
+    if cmd_get_version.return_code != 0 or cmd_get_release.return_code != 0:
+        return '', ''
+    libvirt_release = cmd_get_release.stdout.strip().split('.')[0]
+    libvirt_version = cmd_get_version.stdout.strip()
+    return libvirt_version, libvirt_release
+
+
 def get_unmanaged_vms(include_not_zstack_but_in_virsh = False):
     libvirt_uuid_pattern = "'[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}'"
     cmd = shell.ShellCmd("pgrep -a 'qemu-kvm|qemu-system' | grep -E -o '\-uuid %s' | awk '{print $2}'" % libvirt_uuid_pattern)


### PR DESCRIPTION
XSky's librbd_proxy starts async GC on the first rbd rm and
immediately reports the image as gone (XBD result -2), so
every subsequent attempt sees ENOENT. The 4.4.52-sm delete
path failed in two compounding ways:

1. cephdriver.do_deletion let the ENOENT propagate, and the
   @retry(times=30) decorator exhausted retries before
   bubbling up. The mgmt server marked the delete as failed,
   kept the volume record, and subsequent volume creation hit
   insufficient capacity even though XSky had already freed it.

2. cephagent.delete() defined a redundant inner do_deletion()
   closure and called it AFTER driver.do_deletion(cmd). The
   second rbd rm always saw ENOENT because the first call had
   already removed the image; the closure had no ENOENT
   handling so the whole delete failed on every call.

Fix: cephdriver.do_deletion catches shell.ShellError and
treats 'No such file or directory' as idempotent success.
cephagent.delete drops the redundant nested closure and
relies on driver.do_deletion which is now idempotent.

Verified:
- UT mocks shell.call to raise ShellError('No such file or
  directory'); do_deletion returns without exception and does
  not retry.
- E2E on the reporter's environment (172.24.249.48): full
  create -> delete lifecycle succeeds with a single rbd rm;
  direct do_deletion on an already-gone image logs
  'already gone, treat delete as success' and returns
  normally.

Resolves: ZSTAC-85229

Change-Id: I91750a0622016977caa1d3e8bf9003d3d8e9b56a

sync from gitlab !7237