### PR TITLE
ZSTAC-85711 support dhcpv6 duid leases

### DIFF
--- a/kvmagent/kvmagent/plugins/mevoco.py
+++ b/kvmagent/kvmagent/plugins/mevoco.py
@@ -2468,6 +2468,8 @@ dhcp-range={{g}}
                     dnslist = ['[%s]' % dns for dns in d.dns6]
                     dhcp_info['dns6'] = ",".join(dnslist)
                 dhcp_info['dhcp6Duid'] = make_dhcpv6_duid_uuid(getattr(d, 'vmUuid', None))
+                if dhcp_info['dhcp6Duid']:
+                    restart_dnsmasq = True
                 routes = []
                 # add classless-static-route (option 121) for gateway:
                 if d.isDefaultL3Network:
@@ -2644,6 +2646,8 @@ dhcp-range={{range}}
                 if d.dnsDomain is not None:
                     dhcp_info['domainList'] = ",".join(d.dnsDomain)
                 dhcp_info['dhcp6Duid'] = make_dhcpv6_duid_uuid(getattr(d, 'vmUuid', None))
+                if dhcp_info['dhcp6Duid']:
+                    restart_dnsmasq = True
                 info.append(dhcp_info)
 
                 if not rebuild:

--- a/kvmagent/kvmagent/plugins/mevoco.py
+++ b/kvmagent/kvmagent/plugins/mevoco.py
@@ -45,6 +45,19 @@ def get_iptables_cmd():
 
 IP6TABLES_CMD = iptables.get_ip6tables_cmd()
 HOST_ARCH = platform.machine()
+DHCPV6_DUID_UUID_PREFIX = '00:04'
+UUID_HEX_LENGTH = 32
+
+
+def make_dhcpv6_duid_uuid(vm_uuid):
+    if not vm_uuid:
+        return None
+
+    uuid_hex = vm_uuid.replace('-', '').lower()
+    if len(uuid_hex) != UUID_HEX_LENGTH or not re.match('^[0-9a-f]+$', uuid_hex):
+        return None
+
+    return DHCPV6_DUID_UUID_PREFIX + ':' + ':'.join(uuid_hex[i:i + 2] for i in range(0, UUID_HEX_LENGTH, 2))
 
 
 class NamespaceInfraEnv(object):
@@ -2454,6 +2467,7 @@ dhcp-range={{g}}
                 if d.dns6 is not None:
                     dnslist = ['[%s]' % dns for dns in d.dns6]
                     dhcp_info['dns6'] = ",".join(dnslist)
+                dhcp_info['dhcp6Duid'] = make_dhcpv6_duid_uuid(getattr(d, 'vmUuid', None))
                 routes = []
                 # add classless-static-route (option 121) for gateway:
                 if d.isDefaultL3Network:
@@ -2477,8 +2491,14 @@ dhcp-range={{g}}
 {% for d in dhcp -%}
 {% if d.isDefaultL3Network -%}
 {{d.mac}},set:{{d.tag}},{{d.address}},{{d.hostname}},infinite
+{% if d.ip6 and d.dhcp6Duid -%}
+id:{{d.dhcp6Duid}},set:{{d.tag}},[{{d.ip6}}],{{d.hostname}},infinite
+{% endif -%}
 {% else -%}
 {{d.mac}},set:{{d.tag}},{{d.address}},infinite
+{% if d.ip6 and d.dhcp6Duid -%}
+id:{{d.dhcp6Duid}},set:{{d.tag}},[{{d.ip6}}],infinite
+{% endif -%}
 {% endif -%}
 {% endfor -%}
 '''
@@ -2623,6 +2643,7 @@ dhcp-range={{range}}
                     dhcp_info['dnslist'] = ",".join(dnslist)
                 if d.dnsDomain is not None:
                     dhcp_info['domainList'] = ",".join(d.dnsDomain)
+                dhcp_info['dhcp6Duid'] = make_dhcpv6_duid_uuid(getattr(d, 'vmUuid', None))
                 info.append(dhcp_info)
 
                 if not rebuild:
@@ -2631,6 +2652,9 @@ dhcp-range={{range}}
             dhcp_conf = '''\
 {% for d in dhcp -%}
 {{d.mac}},set:{{d.tag}},[{{d.ip6}}],{{d.hostname}},infinite
+{% if d.dhcp6Duid -%}
+id:{{d.dhcp6Duid}},set:{{d.tag}},[{{d.ip6}}],{{d.hostname}},infinite
+{% endif -%}
 {% endfor -%}
 '''
 
@@ -2726,6 +2750,7 @@ tag:{{o.tag}},option6:domain-search,{{o.domainList}}
 
         bash_errorout('''\
 sed -i '/{{MAC}},/d' {{DHCP}};
+sed -i '/set:{{TAG}},/d' {{DHCP}};
 sed -i '/,{{IP}},/d' {{DHCP}};
 sed -i '/^$/d' {{DHCP}};
 sed -i '/{{TAG}},/d' {{OPTION}};

--- a/tests/unit/kvmagent/test_mevoco_handlers.py
+++ b/tests/unit/kvmagent/test_mevoco_handlers.py
@@ -1188,6 +1188,55 @@ class TestMevocoDoApplyDhcp:
         assert "id:00:04:85:b7:d8:8b:37:4f:44:7b:b7:4a:7c:f6:fd:8e:0d:4d" in dhcp_conf
         assert "[2026:6:9:1::5d:c9c3],2026-6-9-1--5d-c9c3,infinite" in dhcp_conf
 
+    def test_do_apply_dhcp_restarts_dnsmasq_for_dhcpv6_duid_host(self, tmp_path: object):
+        plugin = _make_plugin()
+        plugin.DNSMASQ_CONF_FOLDER = str(tmp_path)
+        plugin.DNSMASQ_LOG_LOGROTATE_PATH = os.path.join(str(tmp_path), "logrotate")
+        plugin._restart_dnsmasq = MagicMock()
+        plugin._refresh_dnsmasq = MagicMock()
+
+        linux = cast(MagicMock, importlib.import_module("zstacklib.utils.linux"))
+        linux.mkdir = MagicMock(side_effect=lambda path, _mode=None: os.makedirs(path, exist_ok=True))
+        linux.touch_file = MagicMock(side_effect=lambda path: open(path, "a", encoding="utf-8").close())
+
+        shell = cast(MagicMock, importlib.import_module("zstacklib.utils.shell"))
+        shell.call = MagicMock(return_value="5")
+        setattr(mevoco, "bash_errorout", MagicMock())
+
+        dhcp_v6 = _Obj(
+            namespaceName="ns6",
+            bridgeName="br1",
+            mac="fa:70:fd:24:dc:00",
+            ip="",
+            ip6="2026:6:9:1::5d:c9c3",
+            ipVersion=6,
+            nicType="VNIC",
+            dns=[],
+            dns6=[],
+            dnsDomain=[],
+            gateway=None,
+            netmask="",
+            hostname="2026-6-9-1--5d-c9c3",
+            mtu=None,
+            isDefaultL3Network=True,
+            hostRoutes=[],
+            vmMultiGateway=False,
+            enableRa=False,
+            firstIp="2026:6:9:1::2",
+            endIp="2026:6:9:1:ffff:ffff:ffff:ffff",
+            prefixLength=64,
+            vmUuid="85b7d88b-374f-447b-b74a-7cf6fd8e0d4d",
+        )
+
+        plugin.do_apply_dhcp(_IterDict({"ns6": [dhcp_v6]}), rebuild=True)
+        plugin._restart_dnsmasq.reset_mock()
+        plugin._refresh_dnsmasq.reset_mock()
+
+        plugin.do_apply_dhcp(_IterDict({"ns6": [dhcp_v6]}), rebuild=False)
+
+        plugin._restart_dnsmasq.assert_called_once()
+        plugin._refresh_dnsmasq.assert_not_called()
+
     def test_do_apply_dhcp_writes_configs_for_v4_and_v6(self, tmp_path: object):
         plugin = _make_plugin()
         plugin.DNSMASQ_CONF_FOLDER = str(tmp_path)

--- a/tests/unit/kvmagent/test_mevoco_handlers.py
+++ b/tests/unit/kvmagent/test_mevoco_handlers.py
@@ -1134,6 +1134,60 @@ class TestMevocoApplyUserdataInternals:
 
 @pytest.mark.kvmagent
 class TestMevocoDoApplyDhcp:
+    def test_make_dhcpv6_duid_uuid_from_vm_uuid(self):
+        duid = mevoco.make_dhcpv6_duid_uuid("85b7d88b-374f-447b-b74a-7cf6fd8e0d4d")
+
+        assert duid == "00:04:85:b7:d8:8b:37:4f:44:7b:b7:4a:7c:f6:fd:8e:0d:4d"
+        assert mevoco.make_dhcpv6_duid_uuid("not-a-uuid") is None
+
+    def test_do_apply_dhcp_writes_duid_uuid_static_host_for_dhcpv6(self, tmp_path: object):
+        plugin = _make_plugin()
+        plugin.DNSMASQ_CONF_FOLDER = str(tmp_path)
+        plugin.DNSMASQ_LOG_LOGROTATE_PATH = os.path.join(str(tmp_path), "logrotate")
+        plugin._restart_dnsmasq = MagicMock()
+
+        linux = cast(MagicMock, importlib.import_module("zstacklib.utils.linux"))
+        linux.mkdir = MagicMock(side_effect=lambda path, _mode=None: os.makedirs(path, exist_ok=True))
+        linux.touch_file = MagicMock(side_effect=lambda path: open(path, "a", encoding="utf-8").close())
+
+        shell = cast(MagicMock, importlib.import_module("zstacklib.utils.shell"))
+        shell.call = MagicMock(return_value="5")
+
+        dhcp_v6 = _Obj(
+            namespaceName="ns6",
+            bridgeName="br1",
+            mac="fa:70:fd:24:dc:00",
+            ip="",
+            ip6="2026:6:9:1::5d:c9c3",
+            ipVersion=6,
+            nicType="VNIC",
+            dns=[],
+            dns6=[],
+            dnsDomain=[],
+            gateway=None,
+            netmask="",
+            hostname="2026-6-9-1--5d-c9c3",
+            mtu=None,
+            isDefaultL3Network=True,
+            hostRoutes=[],
+            vmMultiGateway=False,
+            enableRa=False,
+            firstIp="2026:6:9:1::2",
+            endIp="2026:6:9:1:ffff:ffff:ffff:ffff",
+            prefixLength=64,
+            vmUuid="85b7d88b-374f-447b-b74a-7cf6fd8e0d4d",
+        )
+
+        plugin.do_apply_dhcp(_IterDict({"ns6": [dhcp_v6]}), rebuild=True)
+
+        dhcp_path = os.path.join(str(tmp_path), "ns6", "hosts.dhcp")
+        with open(dhcp_path, encoding="utf-8") as fd:
+            dhcp_conf = fd.read()
+
+        assert "fa:70:fd:24:dc:00,set:fa70fd24dc00,[2026:6:9:1::5d:c9c3]" in dhcp_conf
+        assert "id:00:04:85:b7:d8:8b:37:4f:44:7b:b7:4a:7c:f6:fd:8e:0d:4d" in dhcp_conf
+        assert "[2026:6:9:1::5d:c9c3],2026-6-9-1--5d-c9c3,infinite" in dhcp_conf
+
     def test_do_apply_dhcp_writes_configs_for_v4_and_v6(self, tmp_path: object):
         plugin = _make_plugin()
         plugin.DNSMASQ_CONF_FOLDER = str(tmp_path)


### PR DESCRIPTION
Root cause:
- dnsmasq receives DHCPv6 requests from guests identified by DUID-UUID, not by MAC.
- kvmagent generated only MAC-based IPv6 static host entries, so dnsmasq could not match the client and logged no addresses available.

Fix:
- Generate DHCPv6 DUID-UUID from vmUuid when kvmagent receives DHCP payloads.
- Write id:<duid> dnsmasq host entries for IPv6 leases and clean stale tag-based lease rows.

Companion MR:
- zstack MR 10155 passes vmUuid in flat DHCP payloads.

Verification:
- git diff --check: PASS
- python3 -m py_compile kvmagent/kvmagent/plugins/mevoco.py tests/unit/kvmagent/test_mevoco_handlers.py: PASS
- Direct Python DUID conversion check: PASS

sync from gitlab !7244