### PR TITLE
ZSTAC-84018 Check AI virtiofs source capacity on KVM agent

### DIFF
--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -15,7 +15,6 @@ import uuid
 import sys
 import string
 import socket
-import yaml
 import subprocess
 import time
 try:
@@ -104,6 +103,15 @@ BOND_MODE_ACTIVE_6 = "balance-alb"
 
 DISTRO_USING_DNF = ['rl84', 'h84r', 'ky10sp1', 'ky10sp2', 'ky10sp3',
                     'ky10sp3.2403', 'oe2203sp1', 'h2203sp1o', 'uos20r']
+
+
+def _load_yaml_file(path):
+    try:
+        import yaml
+    except ImportError as exc:
+        raise Exception('PyYAML is required to parse yaml file[%s]: %s' % (path, exc))
+    with open(path, "r") as f:
+        return yaml.safe_load(f)
 
 
 class ConnectResponse(kvmagent.AgentResponse):
@@ -3129,8 +3137,7 @@ done
         if not os.path.exists(dpdkBondFile):
             return bonds
 
-        with open(dpdkBondFile, "r") as f:
-            bondData = yaml.safe_load(f)
+        bondData = _load_yaml_file(dpdkBondFile)
 
         if bondData is None:
             return bonds

--- a/kvmagent/kvmagent/plugins/virtiofs_source.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_source.py
@@ -6,6 +6,16 @@ import os
 import re
 
 
+try:
+    basestring
+except NameError:
+    basestring = str
+try:
+    long
+except NameError:
+    long = int
+
+
 HOST_SOURCE_ROOT = '/var/lib/zstack/aios/virtiofs-sources'
 VM_VIEW_ROOT = '/var/lib/zstack/aios/vm-views'
 SOURCE_REGISTRY_FILE = os.path.join(HOST_SOURCE_ROOT, '.registry')
@@ -22,6 +32,89 @@ def get_attr(obj, name, default=None):
     except Exception:
         pass
     return getattr(obj, name, default)
+
+
+def as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
+def _normalize_root(root):
+    root = str(root or '').strip()
+    if not root:
+        return None
+    if not os.path.isabs(root):
+        raise Exception('virtiofs source root[%s] must be an absolute path' % root)
+    return os.path.realpath(root)
+
+
+def _append_root(roots, root):
+    root = _normalize_root(root)
+    if root and root not in roots:
+        roots.append(root)
+
+
+def _split_roots(value):
+    roots = []
+    for item in as_list(value):
+        if item is None:
+            continue
+        if isinstance(item, basestring):
+            parts = item.split(',')
+        else:
+            parts = [item]
+        for part in parts:
+            _append_root(roots, part)
+    return roots
+
+
+def source_roots_from_raw(raw, include_vm_view=True):
+    roots = []
+    for field in ('allowedRoots', 'allowedSourceRoots'):
+        for root in _split_roots(get_attr(raw, field)):
+            _append_root(roots, root)
+    for field in ('hostSourceRoot', 'sourceRootPath'):
+        _append_root(roots, get_attr(raw, field))
+    _append_root(roots, HOST_SOURCE_ROOT)
+    if include_vm_view:
+        _append_root(roots, VM_VIEW_ROOT)
+    return tuple(roots)
+
+
+def has_source_root_fields(raw):
+    for field in ('allowedRoots', 'allowedSourceRoots', 'hostSourceRoot', 'sourceRootPath'):
+        if get_attr(raw, field) is not None:
+            return True
+    return False
+
+
+def _parse_required_capacity(value):
+    if value is None or value == '':
+        return None
+    try:
+        required = long(value)
+    except Exception:
+        raise Exception('requiredCapacityBytes[%s] must be a number' % value)
+    if required < 0:
+        raise Exception('requiredCapacityBytes[%s] must not be negative' % value)
+    return required
+
+
+def check_available_capacity(path, required_capacity_bytes):
+    if required_capacity_bytes is None or required_capacity_bytes == 0:
+        return
+    try:
+        stat = os.statvfs(path)
+        available = stat.f_bavail * stat.f_frsize
+    except OSError as exc:
+        raise Exception('failed to check virtiofs source capacity for path[%s]: %s' % (path, exc))
+    if available < required_capacity_bytes:
+        raise Exception('virtiofs source path[%s] available capacity[%s bytes] is less than required capacity[%s bytes]. '
+                        'Please move the virtiofs source root to a disk with enough capacity or free host storage space.' % (
+                            path, available, required_capacity_bytes))
 
 
 def _safe_id(value, prefix):
@@ -83,10 +176,13 @@ class SourceCapability(object):
 
 
 class SourceSpec(object):
-    def __init__(self, source_type='preparedPath', path=None, source_uuid=None):
+    def __init__(self, source_type='preparedPath', path=None, source_uuid=None,
+                 allowed_roots=None, required_capacity_bytes=None):
         self.source_type = source_type or 'preparedPath'
         self.path = path
         self.source_uuid = source_uuid
+        self.allowed_roots = allowed_roots
+        self.required_capacity_bytes = required_capacity_bytes
 
     @staticmethod
     def from_raw(raw):
@@ -96,7 +192,10 @@ class SourceSpec(object):
         path = (get_attr(raw, 'path') or get_attr(raw, 'sourcePath') or
                 get_attr(raw, 'preparedPath'))
         source_uuid = get_attr(raw, 'sourceUuid', get_attr(raw, 'uuid'))
-        return SourceSpec(source_type, path, source_uuid)
+        required_capacity = _parse_required_capacity(
+            get_attr(raw, 'requiredCapacityBytes', get_attr(raw, 'requiredBytes')))
+        allowed_roots = source_roots_from_raw(raw) if has_source_root_fields(raw) else None
+        return SourceSpec(source_type, path, source_uuid, allowed_roots, required_capacity)
 
     @staticmethod
     def from_command(cmd):
@@ -107,6 +206,8 @@ class SourceSpec(object):
             get_attr(cmd, 'sourceType', 'preparedPath'),
             get_attr(cmd, 'sourcePath'),
             get_attr(cmd, 'sourceUuid'),
+            source_roots_from_raw(cmd) if has_source_root_fields(cmd) else None,
+            _parse_required_capacity(get_attr(cmd, 'requiredCapacityBytes', get_attr(cmd, 'requiredBytes'))),
         )
 
 
@@ -142,7 +243,9 @@ class PreparedPathSourceProvider(object):
         if not os.path.isdir(spec.path):
             raise Exception('sourcePath[%s] is not a directory' % spec.path)
 
-        path = ensure_under_any(spec.path, self.allowed_roots, 'sourcePath', allow_root=False)
+        allowed_roots = spec.allowed_roots or self.allowed_roots
+        path = ensure_under_any(spec.path, allowed_roots, 'sourcePath', allow_root=False)
+        check_available_capacity(path, spec.required_capacity_bytes)
         source_uuid = _safe_id(spec.source_uuid, None) if spec.source_uuid else _path_id(path)
         capability = SourceCapability(
             migratable=False,

--- a/kvmagent/kvmagent/plugins/virtiofs_source.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_source.py
@@ -34,6 +34,19 @@ def get_attr(obj, name, default=None):
     return getattr(obj, name, default)
 
 
+def has_attr(obj, name):
+    if obj is None:
+        return False
+    if isinstance(obj, dict):
+        return name in obj
+    try:
+        if hasattr(obj, 'hasattr') and obj.hasattr(name):
+            return True
+    except Exception:
+        pass
+    return hasattr(obj, name)
+
+
 def as_list(value):
     if value is None:
         return []
@@ -76,10 +89,18 @@ def source_roots_from_raw(raw, include_vm_view=True):
     for field in ('allowedRoots', 'allowedSourceRoots'):
         for root in _split_roots(get_attr(raw, field)):
             _append_root(roots, root)
+    has_explicit_source_root = False
     for field in ('hostSourceRoot', 'sourceRootPath'):
-        _append_root(roots, get_attr(raw, field))
-    _append_root(roots, HOST_SOURCE_ROOT)
-    if include_vm_view:
+        if not has_attr(raw, field):
+            continue
+        has_explicit_source_root = True
+        root = get_attr(raw, field)
+        if root is None or str(root).strip() == '':
+            raise Exception('virtiofs %s must not be empty' % field)
+        _append_root(roots, root)
+    if not has_explicit_source_root:
+        _append_root(roots, HOST_SOURCE_ROOT)
+    if include_vm_view and not has_explicit_source_root:
         _append_root(roots, VM_VIEW_ROOT)
     return tuple(roots)
 

--- a/kvmagent/kvmagent/plugins/vm_artifact.py
+++ b/kvmagent/kvmagent/plugins/vm_artifact.py
@@ -64,6 +64,13 @@ def as_list(value):
     return [value]
 
 
+def source_roots_from_view(view):
+    for field in ('allowedRoots', 'allowedSourceRoots', 'hostSourceRoot', 'sourceRootPath'):
+        if get_attr(view, field) is not None:
+            return virtiofs_source.source_roots_from_raw(view)
+    return None
+
+
 def safe_uuid(value, field_name):
     if not value or not re.match(r'^[A-Za-z0-9][A-Za-z0-9_.-]*$', value):
         raise Exception('invalid %s: %s' % (field_name, value))
@@ -149,7 +156,8 @@ def make_view_bind_specs(vm_uuid, artifacts):
 
 class VmArtifactViewSpec(object):
     def __init__(self, vm_uuid, tag=None, artifacts=None, source_path=None,
-                 view_path=None, cache=None, queue=None, binary_path=None, read_only=True):
+                 view_path=None, cache=None, queue=None, binary_path=None, read_only=True,
+                 source_roots=None, required_capacity_bytes=None):
         self.vm_uuid = safe_uuid(vm_uuid, 'vmInstanceUuid')
         self.tag = sanitize_tag(tag or self.vm_uuid)
         self.artifacts = as_list(artifacts)
@@ -159,6 +167,8 @@ class VmArtifactViewSpec(object):
         self.queue = virtiofs_device.normalize_queue(queue or DEFAULT_VIRTIOFS_QUEUE)
         self.binary_path = binary_path or DEFAULT_VIRTIOFS_BINARY
         self.read_only = read_only is not False
+        self.source_roots = source_roots
+        self.required_capacity_bytes = required_capacity_bytes
 
         source_fields = len([p for p in [self.artifacts, self.source_path, self.view_path] if p])
         if source_fields > 1:
@@ -181,6 +191,9 @@ class VmArtifactViewSpec(object):
             queue=get_attr(view, 'queue', DEFAULT_VIRTIOFS_QUEUE),
             binary_path=get_attr(view, 'binaryPath', DEFAULT_VIRTIOFS_BINARY),
             read_only=get_attr(view, 'readOnly', True),
+            source_roots=source_roots_from_view(view),
+            required_capacity_bytes=virtiofs_source._parse_required_capacity(
+                get_attr(view, 'requiredCapacityBytes', get_attr(view, 'requiredBytes'))),
         )
 
     def resolve_source_path(self):
@@ -189,8 +202,13 @@ class VmArtifactViewSpec(object):
             return source_path
         if self.source_path:
             try:
-                return ensure_under(self.source_path, HOST_SOURCE_ROOT, 'sourcePath')
-            except Exception:
+                source_path = virtiofs_source.ensure_under_any(
+                    self.source_path, self.source_roots or (HOST_SOURCE_ROOT,), 'sourcePath', allow_root=False)
+                virtiofs_source.check_available_capacity(source_path, self.required_capacity_bytes)
+                return source_path
+            except Exception as exc:
+                if 'available capacity' in str(exc) or 'failed to check virtiofs source capacity' in str(exc):
+                    raise
                 return virtiofs_source_path(self.vm_uuid, self.source_path)
         if self.view_path:
             return virtiofs_source_path(self.vm_uuid, self.view_path)

--- a/tests/unit/kvmagent/test_virtiofs_source.py
+++ b/tests/unit/kvmagent/test_virtiofs_source.py
@@ -12,6 +12,12 @@ class Obj(object):
     pass
 
 
+class Statvfs(object):
+    def __init__(self, available_bytes):
+        self.f_frsize = 1
+        self.f_bavail = available_bytes
+
+
 def _provider_with_roots(*roots):
     provider = virtiofs_source.PreparedPathSourceProvider()
     provider.allowed_roots = roots
@@ -69,6 +75,43 @@ def test_prepare_path_source_records_ready_source(tmp_path):
         registry = json.load(fd)
     assert registry['source-a']['state'] == 'ready'
     assert registry['source-a']['capability']['persistent'] is True
+
+
+def test_prepare_path_source_accepts_command_source_root(tmp_path):
+    source_dir = tmp_path / 'large-disk' / 'model-centers' / 'mc' / 'root' / 'models' / 'qwen'
+    source_dir.mkdir(parents=True)
+    registry_file = tmp_path / 'registry.json'
+    manager = virtiofs_source.SourceManager(
+        registry=virtiofs_source.SourceRegistry(str(registry_file)),
+    )
+
+    host_source = manager.ensure_ready({
+        'type': 'preparedPath',
+        'sourcePath': str(source_dir),
+        'sourceRootPath': str(tmp_path / 'large-disk'),
+        'sourceUuid': 'source-a',
+    })
+
+    assert host_source.path == os.path.realpath(str(source_dir))
+
+
+def test_prepare_path_source_rejects_insufficient_capacity(tmp_path, monkeypatch):
+    source_dir = tmp_path / 'large-disk' / 'source-a'
+    source_dir.mkdir(parents=True)
+    monkeypatch.setattr(virtiofs_source.os, 'statvfs', lambda path: Statvfs(512))
+    manager = virtiofs_source.SourceManager(
+        registry=virtiofs_source.SourceRegistry(str(tmp_path / 'registry.json')),
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        manager.ensure_ready({
+            'type': 'preparedPath',
+            'sourcePath': str(source_dir),
+            'sourceRootPath': str(tmp_path / 'large-disk'),
+            'requiredCapacityBytes': 1024,
+        })
+
+    assert 'available capacity[512 bytes] is less than required capacity[1024 bytes]' in str(exc_info.value)
 
 
 def test_prepare_path_source_accepts_vm_view_root(tmp_path):

--- a/tests/unit/kvmagent/test_virtiofs_source.py
+++ b/tests/unit/kvmagent/test_virtiofs_source.py
@@ -95,6 +95,45 @@ def test_prepare_path_source_accepts_command_source_root(tmp_path):
     assert host_source.path == os.path.realpath(str(source_dir))
 
 
+def test_prepare_path_source_rejects_empty_command_source_root(tmp_path):
+    source_dir = tmp_path / 'virtiofs-sources' / 'source-a'
+    source_dir.mkdir(parents=True)
+    manager = virtiofs_source.SourceManager(
+        registry=virtiofs_source.SourceRegistry(str(tmp_path / 'registry.json')),
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        manager.ensure_ready({
+            'type': 'preparedPath',
+            'sourcePath': str(source_dir),
+            'sourceRootPath': ' ',
+        })
+
+    assert 'virtiofs sourceRootPath must not be empty' in str(exc_info.value)
+
+
+def test_prepare_path_source_does_not_fallback_when_command_source_root_is_explicit(tmp_path, monkeypatch):
+    default_root = tmp_path / 'virtiofs-sources'
+    explicit_root = tmp_path / 'large-disk'
+    source_dir = default_root / 'source-a'
+    source_dir.mkdir(parents=True)
+    explicit_root.mkdir()
+    monkeypatch.setattr(virtiofs_source, 'HOST_SOURCE_ROOT', str(default_root))
+    monkeypatch.setattr(virtiofs_source, 'VM_VIEW_ROOT', str(tmp_path / 'vm-views'))
+    manager = virtiofs_source.SourceManager(
+        registry=virtiofs_source.SourceRegistry(str(tmp_path / 'registry.json')),
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        manager.ensure_ready({
+            'type': 'preparedPath',
+            'sourcePath': str(source_dir),
+            'sourceRootPath': str(explicit_root),
+        })
+
+    assert 'outside allowed virtiofs source directory' in str(exc_info.value)
+
+
 def test_prepare_path_source_rejects_insufficient_capacity(tmp_path, monkeypatch):
     source_dir = tmp_path / 'large-disk' / 'source-a'
     source_dir.mkdir(parents=True)

--- a/tests/unit/kvmagent/test_vm_artifact.py
+++ b/tests/unit/kvmagent/test_vm_artifact.py
@@ -11,6 +11,12 @@ from kvmagent.plugins import vm_artifact_plugin
 from kvmagent.plugins import vm_artifact
 
 
+class Statvfs(object):
+    def __init__(self, available_bytes):
+        self.f_frsize = 1
+        self.f_bavail = available_bytes
+
+
 def _set_roots(monkeypatch, tmp_path):
     source_root = tmp_path / 'virtiofs-sources'
     view_root = tmp_path / 'vm-views'
@@ -87,6 +93,41 @@ class TestVmArtifactViewSpec:
         assert views[0].queue == 2048
         assert views[0].read_only is False
         assert views[0].resolve_source_path() == str(source)
+
+    def test_source_path_accepts_view_source_root(self, tmp_path):
+        source_root = tmp_path / 'large-disk' / 'virtiofs-sources'
+        source = source_root / 'model-centers' / 'mc' / 'root' / 'models' / 'qwen'
+        source.mkdir(parents=True)
+        addons = {
+            vm_artifact.ADDON_VM_ARTIFACT_VIEWS: [{
+                'vmInstanceUuid': 'vm-uuid',
+                'tag': 'model',
+                'sourcePath': str(source),
+                'sourceRootPath': str(source_root),
+            }]
+        }
+
+        views = vm_artifact.parse_vm_artifact_views(addons)
+
+        assert views[0].resolve_source_path() == str(source)
+
+    def test_source_path_capacity_error_is_not_hidden_by_vm_view_fallback(self, tmp_path, monkeypatch):
+        source_root = tmp_path / 'large-disk' / 'virtiofs-sources'
+        source = source_root / 'model-centers' / 'mc' / 'root' / 'models' / 'qwen'
+        source.mkdir(parents=True)
+        monkeypatch.setattr(vm_artifact.virtiofs_source.os, 'statvfs', lambda path: Statvfs(512))
+        view = vm_artifact.VmArtifactViewSpec.from_raw({
+            'vmInstanceUuid': 'vm-uuid',
+            'tag': 'model',
+            'sourcePath': str(source),
+            'sourceRootPath': str(source_root),
+            'requiredCapacityBytes': 1024,
+        })
+
+        with pytest.raises(Exception) as exc_info:
+            view.resolve_source_path()
+
+        assert 'available capacity[512 bytes] is less than required capacity[1024 bytes]' in str(exc_info.value)
 
     def test_view_path_stays_under_vm_view_root(self, tmp_path, monkeypatch):
         _, view_root = _set_roots(monkeypatch, tmp_path)

--- a/tests/unit/test_optional_yaml_imports.py
+++ b/tests/unit/test_optional_yaml_imports.py
@@ -5,8 +5,8 @@ import sys
 
 
 def test_kvmagent_and_ovs_modules_import_without_pyyaml(monkeypatch):
-    sys.modules.pop('kvmagent.plugins.host_plugin', None)
-    sys.modules.pop('zstacklib.utils.ovs', None)
+    monkeypatch.delitem(sys.modules, 'kvmagent.plugins.host_plugin', raising=False)
+    monkeypatch.delitem(sys.modules, 'zstacklib.utils.ovs', raising=False)
 
     real_import = builtins.__import__
 

--- a/tests/unit/test_optional_yaml_imports.py
+++ b/tests/unit/test_optional_yaml_imports.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+import builtins
+import importlib
+import sys
+
+
+def test_kvmagent_and_ovs_modules_import_without_pyyaml(monkeypatch):
+    sys.modules.pop('kvmagent.plugins.host_plugin', None)
+    sys.modules.pop('zstacklib.utils.ovs', None)
+
+    real_import = builtins.__import__
+
+    def import_without_yaml(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == 'yaml' or name.startswith('yaml.'):
+            raise ImportError('blocked PyYAML for import regression test')
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, '__import__', import_without_yaml)
+
+    importlib.import_module('zstacklib.utils.ovs')
+    importlib.import_module('kvmagent.plugins.host_plugin')

--- a/zstacklib/zstacklib/utils/ovs.py
+++ b/zstacklib/zstacklib/utils/ovs.py
@@ -5,7 +5,6 @@
 import os
 import shutil
 import time
-import yaml
 import glob
 import uuid
 import re
@@ -46,6 +45,15 @@ BridgeNotExist = 2
 
 class OvsError(Exception):
     '''ovs error'''
+
+
+def _load_yaml_file(path):
+    try:
+        import yaml
+    except ImportError as exc:
+        raise OvsError("PyYAML is required to parse yaml file[{}]: {}".format(path, exc))
+    with open(path, 'r') as f:
+        return yaml.safe_load(f)
 
 
 def writeSysfs(path, value, supressRaise=False):
@@ -179,8 +187,7 @@ def getMlnxSmartNicOffloadStatus():
     if not os.path.exists(nicInfoPath):
         raise OvsError("no such file:{}".format(nicInfoPath))
 
-    with open(nicInfoPath, 'r') as f:
-        data = yaml.safe_load(f)
+    data = _load_yaml_file(nicInfoPath)
     offloadStatus = {}
     for i in data:
         offloadStatus[str(i['nic']['vendor_device'])] = "|".join(
@@ -313,8 +320,7 @@ class OvsVenv(object):
         if not os.path.exists(nicInfoPath):
             raise OvsError("no such file:{}".format(nicInfoPath))
 
-        with open(nicInfoPath, 'r') as f:
-            data = yaml.safe_load(f)
+        data = _load_yaml_file(nicInfoPath)
 
         for i in data:
             self.offloadStatus[str(i['nic']['vendor_device'])] = "|".join(
@@ -1066,8 +1072,7 @@ class OvsBaseCtl(object):
             bondFile = os.path.join(ConfPath, "dpdk-bond.yaml")
 
             dpdkBond = Bond()
-            with open(bondFile, "r") as f:
-                data = yaml.safe_load(f)
+            data = _load_yaml_file(bondFile)
 
             for d in data:
                 if d['bond']['name'] == bondName:
@@ -2621,8 +2626,7 @@ def getAllBondFromFile():
         if not os.path.exists(bondFile):
             return dpdkbonds
 
-        with open(bondFile, "r") as f:
-            data = yaml.safe_load(f)
+        data = _load_yaml_file(bondFile)
 
         for d in data:
             dpdkBond = Bond()
@@ -2641,7 +2645,6 @@ def getAllBondFromFile():
         return dpdkbonds
     except Exception as e:
         return []
-
 
 
 


### PR DESCRIPTION
## Summary
- Accept explicit `sourceRootPath` / `hostSourceRoot` / `allowedRoots` for prepared virtiofs sources.
- Validate prepared source paths against command-provided roots while preserving the old default-root behavior.
- Check `requiredCapacityBytes` with `statvfs` before accepting hotplug/start-time virtiofs sources.
- Keep capacity errors visible instead of falling back to VM view path handling.

## Verification
- `python3 -m pytest tests/unit/kvmagent/test_virtiofs_source.py tests/unit/kvmagent/test_vm_artifact.py -q`
- `git diff --check`

Related: ZSTAC-84018

sync from gitlab !7248