### PR TITLE
<fix>[storage,ha,baremetal]: backport ZSTAC-85590/85577/85583 to 4.8.38

### DIFF
--- a/baremetalpxeserver/baremetalpxeserver/pxeserveragent.py
+++ b/baremetalpxeserver/baremetalpxeserver/pxeserveragent.py
@@ -846,7 +846,7 @@ echo "ONBOOT=yes" >> $IFCFGFILE
         if os.path.exists(os.path.join(self.VSFTPD_ROOT_PATH, cmd.imageUuid, "Extra", "qemu-kvm-ev")):
             context['extra_repo'] = "repo --name=qemu-kvm-ev --baseurl=ftp://%s/%s/Extra/qemu-kvm-ev" % (
             pxeserver_dhcp_nic_ip, cmd.imageUuid)
-            context['pxeserver_dhcp_nic_ip'] = pxeserver_dhcp_nic_ip
+        context['pxeserver_dhcp_nic_ip'] = pxeserver_dhcp_nic_ip
 
         custom = simplejson.loads(cmd.customPreconfigurations) if cmd.customPreconfigurations is not None else {}
         context.update(custom)

--- a/kvmagent/kvmagent/plugins/ha_plugin.py
+++ b/kvmagent/kvmagent/plugins/ha_plugin.py
@@ -756,7 +756,7 @@ class FileSystemHeartbeatController(AbstractStorageFencer):
 
         r = bash.bash_r("timeout 5 virsh list")
         if r == 0:
-            vm_uuids = find_ps_running_vm(self.ps_uuid)
+            vm_uuids = find_ps_running_vm(self.mount_path)
         else:
             _, vm_uuids = get_runnning_vm_root_volume_on_ps(self.max_attempts, self.strategy, self.mount_path, isFlushbufs=False, vm_uuid_only=True)
 

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -441,7 +441,7 @@ def get_multipath_dmname(dev_name):
     r = bash.bash_r("multipath /dev/%s -l | grep policy" % dev_name)
     if r != 0:
         return None
-    return bash.bash_o("multipath -l /dev/%s | head -n1 | grep -Eo 'dm-[[:digits:]]+'" % dev_name).strip()
+    return bash.bash_o("multipath -l /dev/%s | head -n1 | grep -Eo 'dm-[[:digit:]]+'" % dev_name).strip()
 
 
 def get_multipath_name(dev_name):


### PR DESCRIPTION
## Backport to 4.8.38 — cross-repo group `@@3` (zstack-utility + zstack + premium, must merge together)

Cherry-picked from 5.5.x:
- **ZSTAC-85590 (P0)** `06e22f072` `<fix>[ha]: use mount_path instead of ps_uuid for SMP fencer VM matching` — heartbeat file vm_uuids empty
- **ZSTAC-85577** `8881789a5` `<fix>[zstacklib]: fix typo` — sblk dm device grep (`dm-[[:digits:]]`→`dm-[[:digit:]]`)
- **ZSTAC-85583** `736ede002d` `<fix>[baremetalpxeserver]: set pxe_dhcp_nic_ip for all type iso` — conflict resolved: dedent assignment outside the `qemu-kvm-ev` if-block

Full premium build green locally. Integration cases run by CI.

sync from gitlab !7251