### PR TITLE
<fix>[kvmagent]: Avoid blindly setting virtual memory config

### DIFF
--- a/kvmagent/zstack-kvmagent
+++ b/kvmagent/zstack-kvmagent
@@ -46,8 +46,10 @@ apply_resource_settings() {
 	fi
 	
 	# try to avoid 'hung_task_timeout_secs' issue
-	sysctl -w vm.dirty_ratio=10 > /dev/null
-	sysctl -w vm.dirty_background_ratio=5 > /dev/null
+	if lsblk -o NAME,ROTA,TYPE 2>/dev/null | awk '$3 == "disk" {print $2}' | grep -q "1"; then
+		sysctl -w vm.dirty_ratio=10 > /dev/null
+		sysctl -w vm.dirty_background_ratio=5 > /dev/null
+	fi
 
 	echo 0 > /sys/kernel/mm/ksm/merge_across_nodes || true
 


### PR DESCRIPTION
During startup, detect and skip
virtual memory config (e.g., vm.dirty_ratio)
if no HDD is present.

Resolves: ZSTAC-69429
Resolves: ZSV-8914

Change-Id: I7167796d6a6f6e6965716364666d76797a616f75

sync from gitlab !7255