### PR TITLE
&lt;fix&gt;[cephprimarystorage]: reject pool create on unusable crush rule

### DIFF
--- a/cephprimarystorage/cephprimarystorage/cephagent.py
+++ b/cephprimarystorage/cephprimarystorage/cephagent.py
@@ -1,3 +1,4 @@
+import json
 import math
 import tempfile
 import time
@@ -1150,6 +1151,65 @@ class CephAgent(plugin.TaskManager):
         logger.debug('get echoed')
         return ''
 
+    @staticmethod
+    def _default_pool_crush_rule_id(default_rule_cfg):
+        # `ceph osd pool create <name> <pg>` without an explicit rule uses
+        # osd_pool_default_crush_rule; a negative value falls back to rule 0.
+        try:
+            rule_id = int(str(default_rule_cfg).strip())
+        except (TypeError, ValueError):
+            rule_id = -1
+        return rule_id if rule_id >= 0 else 0
+
+    @staticmethod
+    def _crush_rule_take_roots(rule_dump_json, rule_id):
+        for rule in json.loads(rule_dump_json):
+            if rule.get('rule_id') == rule_id:
+                return [step.get('item_name') for step in rule.get('steps', [])
+                        if str(step.get('op', '')).startswith('take')]
+        return []
+
+    @staticmethod
+    def _crush_roots_have_weighted_osd(crush_tree_json, root_names):
+        tree = json.loads(crush_tree_json)
+        nodes = tree.get('nodes', []) if isinstance(tree, dict) else tree
+        node_by_id = {n.get('id'): n for n in nodes}
+        name_to_id = {n.get('name'): n.get('id') for n in nodes}
+
+        def subtree_has_weighted_osd(node_id):
+            node = node_by_id.get(node_id)
+            if node is None:
+                return False
+            if node.get('type') == 'osd':
+                return (node.get('crush_weight') or 0) > 0
+            return any(subtree_has_weighted_osd(child) for child in node.get('children', []))
+
+        return any(subtree_has_weighted_osd(name_to_id.get(name)) for name in root_names)
+
+    def _ensure_default_pool_crush_rule_usable(self, pool_name):
+        # auto-created pools inherit the default crush rule; if that rule maps to a
+        # crush root with no weighted OSD the pool gets 0 capacity and is unusable,
+        # so reject up front instead of leaving a dead pool behind (ZSTAC-85651).
+        try:
+            rule_id = self._default_pool_crush_rule_id(
+                shell.call('ceph config get mon osd_pool_default_crush_rule'))
+            roots = self._crush_rule_take_roots(
+                shell.call('ceph osd crush rule dump -f json'), rule_id)
+            if not roots:
+                return
+            usable = self._crush_roots_have_weighted_osd(
+                shell.call('ceph osd crush tree -f json'), roots)
+        except Exception as e:
+            logger.warn('skip default crush rule check for pool[%s]: %s' % (pool_name, str(e)))
+            return
+
+        if not usable:
+            raise Exception(
+                'cannot auto-create pool[%s]: the default crush rule[id:%s] maps to crush root%s '
+                'with no weighted OSD, the new pool would get 0 capacity and be unusable. '
+                'Please create the pool manually with a usable crush rule, then add it with '
+                'isCreate=false.' % (pool_name, rule_id, roots))
+
     @replyerror
     def add_pool(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
@@ -1169,6 +1229,7 @@ class CephAgent(plugin.TaskManager):
                     'current ceph storage type only support add exist pool, please create it manually')
 
         if realname not in pool_names:
+            self._ensure_default_pool_crush_rule_usable(realname)
             shell.call('ceph osd pool create %s 128' % realname)
 
         rsp = AgentResponse()
@@ -1204,6 +1265,7 @@ class CephAgent(plugin.TaskManager):
             if ceph.is_xsky() or ceph.is_sandstone():
                 raise Exception('The ceph storage type to be added does not support auto initialize pool, please create it manually')
 
+            self._ensure_default_pool_crush_rule_usable(pool.name)
             shell.call('ceph osd pool create %s 128' % pool.name)
 
         rsp = InitRsp()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,7 @@ _THIRD_PARTY_MOCKS = [
     'xxhash',  # cephbackupstorage
     'cherrypy', 'cherrypy.lib', 'cherrypy.lib.static',  # cephbackupstorage
     'cherrypy._cpreqbody', 'cherrypy._cprequest',  # cephbackupstorage
+    'xms_client', 'xms_client.api', 'xms_client.rest',  # thirdpartycephdriver (xsky)
 ]
 for _mod_name in _THIRD_PARTY_MOCKS:
     if _mod_name not in sys.modules:

--- a/tests/unit/ceph/test_ceph_pool_crush_rule.py
+++ b/tests/unit/ceph/test_ceph_pool_crush_rule.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import pytest
+from typing import cast
+from unittest.mock import MagicMock
+
+try:
+    import tests.conftest  # noqa: F401
+
+    module = importlib.import_module("cephprimarystorage.cephagent")
+    module = importlib.reload(module)
+except (ImportError, ModuleNotFoundError) as e:
+    pytest.skip(f"Cannot import cephprimarystorage: {e}", allow_module_level=True)
+
+
+CephAgent = module.CephAgent
+
+# rule 0 takes crush root "default"
+RULE_DUMP = (
+    '[{"rule_id":0,"rule_name":"replicated_rule","steps":['
+    '{"op":"take","item":-1,"item_name":"default"},'
+    '{"op":"chooseleaf_firstn","num":0,"type":"host"},'
+    '{"op":"emit"}]}]'
+)
+
+# "default" root carries a weighted OSD -> usable
+TREE_HEALTHY = (
+    '{"nodes":['
+    '{"id":-1,"name":"default","type":"root","children":[-3]},'
+    '{"id":-3,"name":"host01","type":"host","children":[0]},'
+    '{"id":0,"name":"osd.0","type":"osd","crush_weight":0.292}'
+    '],"stray":[]}'
+)
+
+# the ZSTAC-85651 topology: "default" root is empty, OSDs live under a custom root
+TREE_EMPTY_DEFAULT = (
+    '{"nodes":['
+    '{"id":-1,"name":"default","type":"root","children":[]},'
+    '{"id":-9,"name":"custom","type":"root","children":[-3]},'
+    '{"id":-3,"name":"host01","type":"host","children":[0]},'
+    '{"id":0,"name":"osd.0","type":"osd","crush_weight":0.292}'
+    '],"stray":[]}'
+)
+
+
+def _shell_returning(config, rule_dump, tree):
+    def _call(command):
+        if 'osd_pool_default_crush_rule' in command:
+            return config
+        if 'crush rule dump' in command:
+            return rule_dump
+        if 'crush tree' in command:
+            return tree
+        raise AssertionError('unexpected command: %s' % command)
+    return _call
+
+
+class TestDefaultPoolCrushRuleId:
+    def test_negative_falls_back_to_zero(self):
+        assert CephAgent._default_pool_crush_rule_id("-1") == 0
+
+    def test_explicit_rule_id(self):
+        assert CephAgent._default_pool_crush_rule_id(" 3 ") == 3
+
+    def test_garbage_falls_back_to_zero(self):
+        assert CephAgent._default_pool_crush_rule_id("not-a-number") == 0
+        assert CephAgent._default_pool_crush_rule_id(None) == 0
+
+
+class TestCrushRuleTakeRoots:
+    def test_resolves_take_root(self):
+        assert CephAgent._crush_rule_take_roots(RULE_DUMP, 0) == ["default"]
+
+    def test_missing_rule_returns_empty(self):
+        assert CephAgent._crush_rule_take_roots(RULE_DUMP, 7) == []
+
+
+class TestCrushRootsHaveWeightedOsd:
+    def test_healthy_root_is_usable(self):
+        assert CephAgent._crush_roots_have_weighted_osd(TREE_HEALTHY, ["default"]) is True
+
+    def test_empty_default_root_is_unusable(self):
+        assert CephAgent._crush_roots_have_weighted_osd(TREE_EMPTY_DEFAULT, ["default"]) is False
+
+    def test_custom_root_with_osd_is_usable(self):
+        assert CephAgent._crush_roots_have_weighted_osd(TREE_EMPTY_DEFAULT, ["custom"]) is True
+
+
+@pytest.mark.ceph
+class TestEnsureDefaultPoolCrushRuleUsable:
+    def _agent(self):
+        return CephAgent.__new__(CephAgent)
+
+    def test_passes_when_default_root_has_weighted_osd(self):
+        module.shell.call = MagicMock(side_effect=_shell_returning("-1", RULE_DUMP, TREE_HEALTHY))
+        # must not raise
+        self._agent()._ensure_default_pool_crush_rule_usable("p1")
+
+    def test_rejects_when_default_root_has_no_weighted_osd(self):
+        module.shell.call = MagicMock(side_effect=_shell_returning("-1", RULE_DUMP, TREE_EMPTY_DEFAULT))
+        with pytest.raises(Exception) as ei:
+            self._agent()._ensure_default_pool_crush_rule_usable("p1")
+        assert "0 capacity" in str(ei.value)
+
+    def test_fail_open_when_ceph_query_errors(self):
+        def _boom(command):
+            raise RuntimeError("ceph unreachable")
+        module.shell.call = MagicMock(side_effect=_boom)
+        # query failure must not block pool creation
+        self._agent()._ensure_default_pool_crush_rule_usable("p1")


### PR DESCRIPTION
## 问题
SUG-2561 环境通过 UI/API `AddCephPrimaryStoragePool isCreate=true` 自动建池，落到默认 crush rule（replicated_rule → take default），而 default root 下无带权 OSD → MAX AVAIL 0 → ZStack 侧 total/available 容量为 0，业务不可用。

## 修复
`cephagent.py` 的 `add_pool`/`init` 在 `ceph osd pool create` 前增加 `_ensure_default_pool_crush_rule_usable`：解析 `osd_pool_default_crush_rule` → `crush rule dump` 取 take root → `crush tree` 检查该 root 下有无带权 OSD，没有则报清晰错误拒绝建池。查询失败 fail-open，保证不回归既有流程。

## 测试
- 新增 `tests/unit/ceph/test_ceph_pool_crush_rule.py`：11 个单测（空 root→拒绝、健康→放行、查询失败→fail-open、rule_id 回退）。
- RED→GREEN：破坏检查（永远放行）→ reject 用例 FAIL；恢复 → 11 passed。
- 现网健康集群回归：`default_rule_id=0 take_roots=['default'] usable=True`，健康建池不被误拦。
- `conftest.py` 补 `xms_client` stub 使 ceph 单测可在本机运行。

Resolves: ZSTAC-85651

sync from gitlab !7259