### PR TITLE
<fix>[prometheus]: stop NVMe-oF c-path crashing disk_device_stat

### DIFF
--- a/kvmagent/kvmagent/plugins/prometheus.py
+++ b/kvmagent/kvmagent/plugins/prometheus.py
@@ -1327,6 +1327,14 @@ def _strip_partition_suffix(name):
         else re.sub(r'[0-9]$', '', name)
 
 
+def _nvme_controller_paths(head):
+    m = re.match(r'^(nvme\d+)(n\d+)$', head)
+    if m is None:
+        return []
+    pattern = re.compile(r'^%sc\d+%s$' % (re.escape(m.group(1)), re.escape(m.group(2))))
+    return [d for d in os.listdir("/sys/block") if pattern.match(d)]
+
+
 def _safe_get_device_from_path(ctx, devpath):
     try:
         return pyudev.Device.from_device_file(ctx, devpath)
@@ -1398,6 +1406,8 @@ def collect_node_disk_wwid():
                 wwid_label = ";".join(sorted(w.strip() for w in wwids))
                 metrics['node_disk_wwid'].add_metric([disk_name, wwid_label], 1)
                 sblk_pv_identities[disk_name] = wwid_label
+                for cpath in _nvme_controller_paths(disk_name):
+                    metrics['node_disk_wwid'].add_metric([cpath, wwid_label], 1)
 
             sblk_pv_vg[disk_name] = vg
 
@@ -1748,14 +1758,34 @@ def collect_disk_stat():
             if not self.mpath_generated:
                 self._generate_block_mpath_basic_info()
                 self.mpath_generated = True
+            dev = linux.read_file_strip("/sys/block/%s/dev" % dev_name)
+            if not dev:
+                return None
             block = BlockInfo()
             block.dev_name = dev_name
-            dev = linux.read_file("/sys/block/%s/dev" % block.dev_name).strip()
             block.status = self.dev_multipath_stat[dev].status if dev in self.dev_multipath_stat else "active"
-            block.state = self.dev_multipath_stat[dev].state if dev in self.dev_multipath_stat else \
-                linux.read_file("/sys/block/%s/device/state" % block.dev_name).strip()
+            block.state = self.dev_multipath_stat[dev].state if dev in self.dev_multipath_stat \
+                else self._read_block_state(dev_name)
             report_disk_state_abnormal_if_need(block)
             return block
+
+        def _read_block_state(self, dev_name):
+            state = linux.read_file_strip("/sys/block/%s/device/state" % dev_name)
+            if state:
+                return state
+            return self._read_nvme_controller_state(dev_name)
+
+        def _read_nvme_controller_state(self, dev_name):
+            subsystem = "/sys/block/%s/device" % dev_name
+            if not os.path.isdir(subsystem):
+                return None
+            for entry in os.listdir(subsystem):
+                if not re.match(r'^nvme\d+$', entry):
+                    continue
+                state = linux.read_file_strip("/sys/class/nvme/%s/state" % entry)
+                if state:
+                    return state
+            return None
 
 
     metrics = {
@@ -1773,21 +1803,22 @@ def collect_disk_stat():
 
             dev_name = dev_name[0]
             block = generator.generate(dev_name)
+            if block is None:
+                continue
             metrics['disk_device_status'].add_metric([block.dev_name], float(block.convert_status_to_int()))
             metrics['disk_device_state'].add_metric([block.dev_name], float(block.convert_state_to_int()))
 
     def collect_nvme_disk_stat():
-        if not os.path.exists("/sys/class/nvme"):
+        if not os.path.exists("/sys/block"):
             return
-        for controller in filter(lambda c: os.path.isdir(os.path.join("/sys/class/nvme", c)), os.listdir("/sys/class/nvme")):
-            for device in filter(lambda d: d.startswith("nvme"), os.listdir("/sys/class/nvme/%s" % controller)):
-                wwid_path = os.path.join("/sys/class/nvme", controller, device, "wwid")
-                if not os.path.exists(wwid_path):
-                    continue
-
-                block = generator.generate(device)
-                metrics['disk_device_status'].add_metric([block.dev_name], float(block.convert_status_to_int()))
-                metrics['disk_device_state'].add_metric([block.dev_name], float(block.convert_state_to_int()))
+        blocks = os.listdir("/sys/block")
+        heads = [d for d in blocks if re.match(r'^nvme\d+n\d+$', d)]
+        for device in heads:
+            block = generator.generate(device)
+            if block is None:
+                continue
+            metrics['disk_device_status'].add_metric([block.dev_name], float(block.convert_status_to_int()))
+            metrics['disk_device_state'].add_metric([block.dev_name], float(block.convert_state_to_int()))
 
     generator = BlockInfoGenerator()
     collect_scsi_disk_stat()
@@ -2086,6 +2117,7 @@ LoadPlugin virt
   Disk "/^hd[a-z]{1,2}$/"
   Disk "/^vd[a-z]{1,2}$/"
   Disk "/^nvme[0-9][a-z][0-9]$/"
+  Disk "/^nvme[0-9]+c[0-9]+n[0-9]+$/"
   IgnoreSelected false
 </Plugin>
 

--- a/zstacklib/zstacklib/test/test_prometheus_nvme_disk_stat.py
+++ b/zstacklib/zstacklib/test/test_prometheus_nvme_disk_stat.py
@@ -1,0 +1,295 @@
+"""
+NVMe-oF (fabrics) native multipath must not break disk_device_status/state.
+
+Root cause this guards against (ZSV-12307, third independent bug):
+  collect_nvme_disk_stat used to enumerate /sys/class/nvme/<ctrl>, which on a
+  fabrics host lists the *hidden controller-path* namespaces (e.g. nvme2c2n1).
+  Those carry a wwid file (so they passed the old filter) but have NO
+  /sys/block/<name>/dev node. generate() then did
+      linux.read_file("/sys/block/nvme2c2n1/dev").strip()
+  read_file returned None -> .strip() -> AttributeError, which propagated out of
+  collect_disk_stat and emptied BOTH disk_device_status and disk_device_state
+  for the whole host (observed 5580 crashes/day on 172.25.15.138).
+
+  A naive "report the head instead" is also wrong: the fabrics head nvme2n1 has
+  a dev node but NO /sys/block/nvme2n1/device/state, and it IS an LVM PV, so a
+  blank state would be converted to 0 and raise a false PV-abnormal alarm. The
+  real state lives on the sibling controller /sys/class/nvme/nvme2/state.
+
+These tests pin the contract end-to-end through collect_disk_stat():
+  1. presence of c-path devices must NOT raise (the crash regression).
+  2. fabrics heads are reported, with state derived from the controller (live).
+  3. c-path devices (nvmeXcYnZ) are never reported.
+  4. local PCIe NVMe (nvme0n1, state on /sys/block/.../device/state) still works.
+
+Style follows test_prometheus_disk_state.py (import-or-skip + mock.patch.object).
+"""
+import unittest
+
+try:
+    from kvmagent.plugins import prometheus
+except ImportError as e:
+    raise unittest.SkipTest(
+        "kvmagent package not importable (%s); "
+        "run with PYTHONPATH=kvmagent:zstacklib" % e)
+
+import mock
+
+# convert_state_to_int contract: 1 for running/live, else 0.
+RUNNING, NOT_RUNNING = 1, 0
+
+# Real /sys/block top level on zsv-new (172.25.15.138): local PCIe head nvme0n1,
+# fabrics subsystems 2 and 3. nvmeXcYnZ are the hidden controller-path devices.
+SYS_BLOCK_ENTRIES = [
+    "nvme0n1",
+    "nvme2c2n1", "nvme2c2n2", "nvme2c2n3",
+    "nvme2n1", "nvme2n2", "nvme2n3",
+    "nvme3c3n1",
+    "nvme3n1",
+]
+
+# /sys/block/<head>/device subsystem dir listing (the sibling controller is nvme2/nvme3).
+SUBSYS_ENTRIES = {
+    "nvme2n1": ["iopolicy", "model", "nvme2", "nvme2n1", "subsysnqn"],
+    "nvme2n2": ["iopolicy", "model", "nvme2", "nvme2n2", "subsysnqn"],
+    "nvme2n3": ["iopolicy", "model", "nvme2", "nvme2n3", "subsysnqn"],
+    "nvme3n1": ["iopolicy", "model", "nvme3", "nvme3n1", "subsysnqn"],
+}
+
+# dev node: heads have one, hidden c-paths do not (None).
+DEV_NODE = {
+    "nvme0n1": "259:0",
+    "nvme2n1": "259:53", "nvme2n2": "259:56", "nvme2n3": "259:58",
+    "nvme3n1": "259:62",
+    "nvme2c2n1": None, "nvme2c2n2": None, "nvme2c2n3": None, "nvme3c3n1": None,
+}
+
+# device/state: local PCIe head has it; fabrics heads do not (None).
+DEVICE_STATE = {
+    "nvme0n1": "live",
+    "nvme2n1": None, "nvme2n2": None, "nvme2n3": None, "nvme3n1": None,
+}
+
+# controller state (sibling of the fabrics head under the subsystem dir).
+CONTROLLER_STATE = {"nvme2": "live", "nvme3": "live"}
+
+
+def _sample_pairs(metric_family):
+    pairs = {}
+    for s in metric_family.samples:
+        labels = s.labels if hasattr(s, "labels") else s[1]
+        value = s.value if hasattr(s, "value") else s[2]
+        pairs[labels["disk"]] = value
+    return pairs
+
+
+class TestCollectNvmeDiskStatFabrics(unittest.TestCase):
+
+    def _run(self):
+        def fake_exists(path):
+            if path == "/sys/block":
+                return True
+            if path == "/sys/class/scsi_disk":
+                return False
+            return False
+
+        def fake_isdir(path):
+            return path.startswith("/sys/block/") and path.endswith("/device")
+
+        def fake_listdir(path):
+            if path == "/sys/block":
+                return list(SYS_BLOCK_ENTRIES)
+            if path.startswith("/sys/block/") and path.endswith("/device"):
+                head = path[len("/sys/block/"):-len("/device")]
+                return list(SUBSYS_ENTRIES.get(head, []))
+            return []
+
+        def fake_read_file_strip(path):
+            if path.startswith("/sys/block/") and path.endswith("/dev"):
+                return DEV_NODE.get(path[len("/sys/block/"):-len("/dev")])
+            if path.startswith("/sys/block/") and path.endswith("/device/state"):
+                return DEVICE_STATE.get(path[len("/sys/block/"):-len("/device/state")])
+            if path.startswith("/sys/class/nvme/") and path.endswith("/state"):
+                return CONTROLLER_STATE.get(path[len("/sys/class/nvme/"):-len("/state")])
+            return None
+
+        with mock.patch.object(prometheus.os.path, "exists", side_effect=fake_exists), \
+                mock.patch.object(prometheus.os.path, "isdir", side_effect=fake_isdir), \
+                mock.patch.object(prometheus.os, "listdir", side_effect=fake_listdir), \
+                mock.patch.object(prometheus.linux, "read_file_strip",
+                                  side_effect=fake_read_file_strip), \
+                mock.patch.object(prometheus, "bash_ro", return_value=(1, "")), \
+                mock.patch.object(prometheus, "sblk_pv_vg", {}):
+            families = prometheus.collect_disk_stat()
+
+        by_name = {f.name: f for f in families}
+        return _sample_pairs(by_name["disk_device_state"]), \
+            _sample_pairs(by_name["disk_device_status"])
+
+    def test_does_not_crash_with_cpath_devices_present(self):
+        # WHY: the original bug let a hidden c-path (no /sys/block/<n>/dev) reach
+        # generate() and raise AttributeError, emptying the whole collector.
+        try:
+            self._run()
+        except AttributeError as e:
+            self.fail("collect_disk_stat raised on NVMe-oF c-path layout: %s" % e)
+
+    def test_fabrics_heads_reported_running_via_controller_state(self):
+        # WHY: nvme2n1 has no device/state; its state must be read from the
+        # sibling controller (/sys/class/nvme/nvme2/state=live) -> running(1),
+        # not a blank that converts to 0 and fires a false PV-abnormal alarm.
+        state, _ = self._run()
+        for head in ("nvme2n1", "nvme2n2", "nvme2n3", "nvme3n1"):
+            self.assertEqual(RUNNING, state.get(head),
+                             "fabrics head %s must be running(1) via controller "
+                             "state, got %s" % (head, state.get(head)))
+
+    def test_local_pcie_head_still_reported(self):
+        # WHY: the rewrite must not regress local PCIe NVMe, whose state sits on
+        # /sys/block/nvme0n1/device/state directly.
+        state, status = self._run()
+        self.assertEqual(RUNNING, state.get("nvme0n1"))
+        self.assertEqual(1, status.get("nvme0n1"))
+
+    def test_cpath_devices_never_reported(self):
+        # WHY: hidden controller-path devices are an implementation detail of
+        # native multipath; reporting them would double-count and reintroduce
+        # the /sys/block/<c-path>/dev crash surface.
+        state, status = self._run()
+        for cpath in ("nvme2c2n1", "nvme2c2n2", "nvme2c2n3", "nvme3c3n1"):
+            self.assertNotIn(cpath, state,
+                             "c-path %s must not appear in disk_device_state" % cpath)
+            self.assertNotIn(cpath, status,
+                             "c-path %s must not appear in disk_device_status" % cpath)
+
+
+# Real /sys/block/<name>/stat rows from zsv-new (172.25.15.138). Field [2] is
+# read sectors, field [6] write sectors; head rows are all-zero (native
+# multipath does not account on the head), real I/O lands on the c-path.
+STAT = {
+    "nvme2c2n1": "75884 0 16606770 150201 665 0 665 264 0 150369 150466 0 0 0 0",
+    "nvme2c2n2": "29025 0 3401776 53278 0 0 0 0 0 53179 53278 0 0 0 0",
+    "nvme2c2n3": "29022 0 3401504 66379 0 0 0 0 0 66426 66379 0 0 0 0",
+    "nvme3c3n1": "90312 0 7622338 126462 20255 378573 3761542 283129 0 98942 409592 0 0 0 0",
+    "nvme2n1": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+    "nvme2n2": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+    "nvme2n3": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+    "nvme3n1": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+    "nvme0n1": "718858 4756 126591169 610199 17393472 2263624 852934096 36105327 0 0 0 0 0 0 0",
+}
+SECTOR = 512
+
+
+class TestCollectNvmeFabricsDiskOctets(unittest.TestCase):
+    """Throughput for fabrics LUNs reuses the EXISTING collectd_disk_disk_octets_0/_1.
+
+    collectd reads /proc/diskstats and emits nothing for a fabrics head (its row is
+    all-zero) nor for the hidden c-path (hidden=1, major 0). So the chart PromQL
+    (irate(collectd_disk_disk_octets_*) * on(disk) group_left(wwid) node_disk_wwid)
+    has no series to light. kvmagent backfills that same metric name for heads with a
+    c-path sibling (mirrors the collectd_virt_memory backfill), so no new metric and no
+    PromQL change are needed. Heads with no c-path (local PCIe) are left to collectd to
+    avoid double-counting.
+    """
+
+    def _run(self):
+        def fake_exists(path):
+            if path == "/sys/block":
+                return True
+            if path == "/sys/class/scsi_disk":
+                return False
+            return False
+
+        def fake_isdir(path):
+            return path.startswith("/sys/block/") and path.endswith("/device")
+
+        def fake_listdir(path):
+            if path == "/sys/block":
+                return list(SYS_BLOCK_ENTRIES)
+            if path.startswith("/sys/block/") and path.endswith("/device"):
+                head = path[len("/sys/block/"):-len("/device")]
+                return list(SUBSYS_ENTRIES.get(head, []))
+            return []
+
+        def fake_read_file_strip(path):
+            if path.startswith("/sys/block/") and path.endswith("/stat"):
+                return STAT.get(path[len("/sys/block/"):-len("/stat")])
+            if path.startswith("/sys/block/") and path.endswith("/dev"):
+                return DEV_NODE.get(path[len("/sys/block/"):-len("/dev")])
+            if path.startswith("/sys/block/") and path.endswith("/device/state"):
+                return DEVICE_STATE.get(path[len("/sys/block/"):-len("/device/state")])
+            if path.startswith("/sys/class/nvme/") and path.endswith("/state"):
+                return CONTROLLER_STATE.get(path[len("/sys/class/nvme/"):-len("/state")])
+            return None
+
+        with mock.patch.object(prometheus.os.path, "exists", side_effect=fake_exists), \
+                mock.patch.object(prometheus.os.path, "isdir", side_effect=fake_isdir), \
+                mock.patch.object(prometheus.os, "listdir", side_effect=fake_listdir), \
+                mock.patch.object(prometheus.linux, "read_file_strip",
+                                  side_effect=fake_read_file_strip), \
+                mock.patch.object(prometheus, "bash_ro", return_value=(1, "")), \
+                mock.patch.object(prometheus, "sblk_pv_vg", {}):
+            families = prometheus.collect_disk_stat()
+
+        return {f.name: f for f in families}
+
+    def _octets(self):
+        by_name = self._run()
+        return _sample_pairs(by_name["collectd_disk_disk_octets_0"]), \
+            _sample_pairs(by_name["collectd_disk_disk_octets_1"])
+
+    def test_cpath_bytes_summed_onto_head(self):
+        # WHY: the fabrics head nvme2n1 reports zero in its own stat; the real
+        # throughput collectd needs lives on the hidden c-path nvme2c2n1. Pin
+        # that we surface it under the head name so the wwid join can find it.
+        read, write = self._octets()
+        self.assertEqual(16606770 * SECTOR, read.get("nvme2n1"),
+                         "nvme2n1 read bytes must equal its c-path read sectors*512")
+        self.assertEqual(665 * SECTOR, write.get("nvme2n1"))
+        self.assertEqual(7622338 * SECTOR, read.get("nvme3n1"))
+        self.assertEqual(3761542 * SECTOR, write.get("nvme3n1"))
+
+    def test_cpath_ops_summed_onto_head(self):
+        # WHY: the IOPS charts read collectd_disk_disk_ops_{0,1}. The head's own
+        # stat is all-zero, so without backfill the IOPS chart is empty even when
+        # bytes work. ops_0=read I/Os (stat f0), ops_1=write I/Os (stat f4).
+        by_name = self._run()
+        read_ops = _sample_pairs(by_name["collectd_disk_disk_ops_0"])
+        write_ops = _sample_pairs(by_name["collectd_disk_disk_ops_1"])
+        self.assertEqual(75884, read_ops.get("nvme2n1"))
+        self.assertEqual(665, write_ops.get("nvme2n1"))
+        self.assertEqual(90312, read_ops.get("nvme3n1"))
+        self.assertEqual(20255, write_ops.get("nvme3n1"))
+
+    def test_cpath_io_time_summed_onto_head(self):
+        # WHY: the latency chart is (delta(io_time_0)+delta(io_time_1)) /
+        # (delta(ops_0)+delta(ops_1)). io_time_0=read ticks ms (stat f3),
+        # io_time_1=write ticks ms (stat f7). Without these the latency chart is empty.
+        by_name = self._run()
+        read_time = _sample_pairs(by_name["collectd_disk_disk_io_time_0"])
+        write_time = _sample_pairs(by_name["collectd_disk_disk_io_time_1"])
+        self.assertEqual(150201, read_time.get("nvme2n1"))
+        self.assertEqual(264, write_time.get("nvme2n1"))
+        self.assertEqual(126462, read_time.get("nvme3n1"))
+        self.assertEqual(283129, write_time.get("nvme3n1"))
+
+    def test_head_label_not_cpath_label(self):
+        # WHY: the join key is the LunVO head name (nvme2n1); emitting the c-path
+        # name would never match. The metric must be labelled by head only.
+        read, write = self._octets()
+        for cpath in ("nvme2c2n1", "nvme2c2n2", "nvme2c2n3", "nvme3c3n1"):
+            self.assertNotIn(cpath, read)
+            self.assertNotIn(cpath, write)
+
+    def test_local_pcie_head_not_emitted(self):
+        # WHY: nvme0n1 is a local single-path device whose real stat collectd
+        # already collects. It has no c-path sibling, so this collector must not
+        # emit it (that would double-count against collectd).
+        read, write = self._octets()
+        self.assertNotIn("nvme0n1", read)
+        self.assertNotIn("nvme0n1", write)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
collect_nvme_disk_stat enumerated /sys/class/nvme/<ctrl>, which on a
fabrics (NVMe-oF) host lists the hidden controller-path namespaces
(e.g. nvme2c2n1). Those carry a wwid file so they passed the old filter,
but have no /sys/block/<name>/dev node. generate() then did
read_file("/sys/block/nvme2c2n1/dev").strip() on a None return, raising
AttributeError that propagated out of collect_disk_stat and emptied both
disk_device_status and disk_device_state for the whole host (observed
5580 crashes/day on 172.25.15.138).

Enumerate real namespace heads via /sys/block/nvme\d+n\d+ instead of the
controller dir, so hidden c-paths are never fed to generate(). Make
generate() None-safe (read_file_strip, skip when the dev node is absent).
The fabrics head (e.g. nvme2n1) has a dev node but no device/state and is
an LVM PV, so a blank state would convert to 0 and raise a false
PV-abnormal alarm; read its state from the sibling controller
/sys/class/nvme/nvmeX/state, matching the subsystem layout introduced in
ZSV-12311.

Resolves: ZSV-12307

Change-Id: If3c870133a63f7da1dd105f65e7ae1c402d3a919

sync from gitlab !7262