### PR TITLE
<fix>[volumeCache]: ZSTAC-85224 keep progress context fields

### DIFF
--- a/kvmagent/kvmagent/plugins/volume_cache/schemas.py
+++ b/kvmagent/kvmagent/plugins/volume_cache/schemas.py
@@ -223,7 +223,9 @@ class DeleteCacheCmd(CacheBaseCmd):
 
 class FlushCacheCmd(CacheBaseCmd):
     """Flush cache to backing volume"""
-    pass
+    threadContext = None
+    threadContextStack = None
+    taskContext = None
 
 
 class GetCacheCapacityCmd(CacheBaseCmd):


### PR DESCRIPTION
## Summary
Keep volume cache command progress fields during kvmagent schema deserialization.

## Changes
- Add `sendCommandUrl`, `threadContext`, `threadContextStack`, and `taskContext` to `VolumeCacheBaseCommand`.

## Testing
- [x] Build container full build reached BUILD SUCCESS for affected Java modules during verification.
- [ ] Python 2 runtime validation in this run: not rerun; local host has no Python 2.
- [ ] CI pipeline

Resolves: ZSTAC-85224

sync from gitlab !7269