### PR TITLE
<fix>[ha]: fix allowRule semantics in kill_vm_by_xml path (ZSTAC-85964 backport 4.8.38)

### DIFF
--- a/kvmagent/kvmagent/plugins/ha_plugin.py
+++ b/kvmagent/kvmagent/plugins/ha_plugin.py
@@ -1211,7 +1211,7 @@ def get_runnning_vm_root_volume_on_ps(maxAttempts, strategy, mountPath, isFlushb
             continue
 
         on_storage_vm_uuids.append(vm.uuid)
-        if is_allow_fencer(host_storage_name, vm.uuid):
+        if not_exec_kill_vm(strategy, vm.uuid, host_storage_name):
             logger.debug("fencer detect ha strategy is %s skip fence vm[uuid:%s]" % (strategy, vm.uuid))
             continue
 

--- a/kvmagent/kvmagent/test/test_ha_fencer.py
+++ b/kvmagent/kvmagent/test/test_ha_fencer.py
@@ -232,6 +232,30 @@ class TestFencerCallsKillVmByXml(unittest.TestCase):
                 return
         self.fail("get_runnning_vm_root_volume_on_ps not found in source")
 
+    def test_get_runnning_vm_uses_not_exec_kill_vm_not_is_allow_fencer(self):
+        """get_runnning_vm_root_volume_on_ps must use not_exec_kill_vm to skip VMs (not is_allow_fencer).
+
+        allowRules lists VMs that SHOULD be killed even in Permissive strategy (e.g. VPC/SLB system VMs).
+        Using is_allow_fencer directly as the skip condition reverses the semantics:
+        VMs in allowRules would be skipped instead of killed.
+        """
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.FunctionDef) and node.name == 'get_runnning_vm_root_volume_on_ps':
+                calls = []
+                for call_node in ast.walk(node):
+                    if isinstance(call_node, ast.Call):
+                        if isinstance(call_node.func, ast.Name):
+                            calls.append(call_node.func.id)
+                        elif isinstance(call_node.func, ast.Attribute):
+                            calls.append(call_node.func.attr)
+                self.assertIn('not_exec_kill_vm', calls,
+                              "get_runnning_vm_root_volume_on_ps must use not_exec_kill_vm to skip VMs")
+                self.assertNotIn('is_allow_fencer', calls,
+                                 "get_runnning_vm_root_volume_on_ps must NOT call is_allow_fencer directly "
+                                 "(allowRules VMs should be killed, not skipped)")
+                return
+        self.fail("get_runnning_vm_root_volume_on_ps not found in source")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
Backport 5.x fix for ZSTAC-85964 to 4.8.38.

## Source
- source: ZSTAC-85195, MR 7050, commit b1f3cc02
- Branch: `shixin-ZSTAC-85964-4.8.38`
- Target: `4.8.38`

## Verification
- Cherry-pick completed in isolated worktree.
- `git diff --check` run for all backport branches; warnings, if any, are noted in Source above.
- No full Maven/Groovy suite was run locally for this batch backport.

Jira: http://jira.zstack.io/browse/ZSTAC-85964

sync from gitlab !7274