### PR TITLE
<fix>[kvmagent]: ZSTAC-86047 fix migration iothread xml root

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -2344,7 +2344,9 @@ class VmVolumesRecoveryTask(plugin.TaskDaemon):
             if rpath.endswith(nbddisk.source.name_):
                 saved = v.installPath
                 v.installPath = dstpath
+                root = etree.fromstring(self.domain_xmlobject.dump())
                 ele = VmPlugin._get_new_disk(etree.fromstring(nbddisk.dump()), v)
+                VmPlugin._apply_migration_iothread_vq_mapping(root, ele, v)
                 v.installPath = saved
                 return ele
         raise kvmagent.KvmError("VM: %s: recover volume not found: %s" % (self.vmUuid, v.installPath))
@@ -4735,22 +4737,24 @@ class Vm(object):
             migrate_disks[disk_name] = volume
 
         tree = etree.ElementTree(etree.fromstring(self.get_migratable_xml()))
-        xml_changed = self._split_legacy_rbd_snapshot(tree.getroot())
-        devices = tree.getroot().find('devices')
-        for disk in tree.iterfind('devices/disk'):
+        root = tree.getroot()
+        xml_changed = self._split_legacy_rbd_snapshot(root)
+        devices = root.find('devices')
+        for parent_index, disk in enumerate(list(devices)):
+            if disk.tag != 'disk':
+                continue
             dev = disk.find('target').attrib['dev']
             volume = migrate_disks.get(dev, None)
             new_disk = VmPlugin._get_new_disk(disk, volume)
             if new_disk != disk:
                 if volume:
-                    VmPlugin._apply_migration_iothread_vq_mapping(tree.getroot(), new_disk, volume)
-                parent_index = list(devices).index(disk)
+                    VmPlugin._apply_migration_iothread_vq_mapping(root, new_disk, volume)
                 devices.remove(disk)
                 devices.insert(parent_index, new_disk)
                 xml_changed = True
 
         if xml_changed:
-            return list(migrate_disks.keys()), etree.tostring(tree.getroot(), encoding="unicode")
+            return list(migrate_disks.keys()), etree.tostring(root, encoding="unicode")
         else:
             return None, None
 
@@ -9739,13 +9743,15 @@ class VmPlugin(kvmagent.KvmAgent):
         fpath = linux.write_to_temp_file(vm.domain_xml)
 
         tree = etree.parse(fpath)
-        devices = tree.getroot().find('devices')
-        for disk in tree.iterfind('devices/disk'):
+        root = tree.getroot()
+        devices = root.find('devices')
+        for parent_index, disk in enumerate(list(devices)):
+            if disk.tag != 'disk':
+                continue
             dev = disk.find('target').attrib['dev']
             if dev in migrate_disks:
                 new_disk = VmPlugin._get_new_disk(disk, migrate_disks[dev])
-                VmPlugin._apply_migration_iothread_vq_mapping(tree.getroot(), new_disk, migrate_disks[dev])
-                parent_index = list(devices).index(disk)
+                VmPlugin._apply_migration_iothread_vq_mapping(root, new_disk, migrate_disks[dev])
                 devices.remove(disk)
                 devices.insert(parent_index, new_disk)
 
@@ -9755,12 +9761,12 @@ class VmPlugin(kvmagent.KvmAgent):
     def _build_dest_disk_xml(self, vm, oldVolumePath, newVolume):
         _, disk_name = vm._get_target_disk_by_path(oldVolumePath)
 
-        tree = etree.fromstring(vm.domain_xml)
-
-        for disk in tree.iterfind('devices/disk'):
+        root = etree.fromstring(vm.domain_xml)
+        for disk in root.iterfind('devices/disk'):
             dev = disk.find('target').attrib['dev']
             if dev == disk_name:
                 new_disk = VmPlugin._get_new_disk(disk, newVolume)
+                VmPlugin._apply_migration_iothread_vq_mapping(root, new_disk, newVolume)
                 return dev, linux.write_to_temp_file(etree.tostring(new_disk, encoding="unicode"))
 
     def _do_block_copy(self, vmUuid, disk_name, disk_xml, task_spec):

--- a/tests/unit/kvmagent/test_vm_iothread_vq_mapping.py
+++ b/tests/unit/kvmagent/test_vm_iothread_vq_mapping.py
@@ -2,6 +2,16 @@
 
 import pytest
 
+from zstacklib.utils import plugin
+
+
+class FakeTaskDaemon(object):
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+plugin.TaskDaemon = FakeTaskDaemon
+
 from kvmagent.plugins import vm_plugin
 
 
@@ -49,6 +59,49 @@ def no_retry(*args, **kwargs):
 
 class FakeLibvirtError(Exception):
     pass
+
+
+DOMAIN_XML_WITH_USED_IOTHREAD = '''
+<domain>
+  <iothreadids>
+    <iothread id="101"/>
+  </iothreadids>
+  <devices>
+    <disk type="network" device="disk">
+      <driver name="qemu" type="raw" cache="none" discard="unmap" queues="4"/>
+      <source protocol="cbd" name="old"/>
+      <target dev="vdb" bus="virtio"/>
+    </disk>
+  </devices>
+</domain>
+'''
+
+
+def cbd_migration_volume(**kwargs):
+    values = {
+        'installPath': 'cbd:new-volume',
+        'dev_letter': 'b',
+        'multiQueues': '4',
+        'ioThreads': 2,
+        'physicalBlockSize': None,
+    }
+    values.update(kwargs)
+    return cbd_volume(**values)
+
+
+class FakeDomainXmlVm(object):
+    domain_xml = DOMAIN_XML_WITH_USED_IOTHREAD
+
+    def _get_target_disk_by_path(self, path):
+        return None, 'vdb'
+
+
+def write_temp_file_to(monkeypatch, path):
+    def write_temp_file(content):
+        path.write_text(content)
+        return str(path)
+
+    monkeypatch.setattr(vm_plugin.linux, 'write_to_temp_file', write_temp_file)
 
 
 @pytest.mark.kvmagent
@@ -246,6 +299,79 @@ def test_migration_cbd_disks_allocate_distinct_iothread_ids():
     assert disk_iothread_ids == [['101', '102'], ['103', '104']]
     assert root.find('iothreads').text == '4'
     assert [i.get('id') for i in root.findall('./iothreadids/iothread')] == ['101', '102', '103', '104']
+
+
+@pytest.mark.kvmagent
+def test_build_domain_new_xml_allocates_cbd_iothreads_from_domain_root():
+    vm = vm_plugin.Vm()
+    vm.get_migratable_xml = lambda: DOMAIN_XML_WITH_USED_IOTHREAD
+    vm._get_target_disk_by_path = lambda path: (None, 'vdb')
+
+    disks, dest_xml = vm._build_domain_new_xml({'old': cbd_migration_volume()})
+
+    assert disks == ['vdb']
+    root = vm_plugin.etree.fromstring(dest_xml)
+    iothreads = root.findall('./devices/disk/driver/iothreads/iothread')
+    assert [i.get('id') for i in iothreads] == ['102', '103']
+
+
+@pytest.mark.kvmagent
+def test_vm_plugin_build_domain_new_xml_allocates_cbd_iothreads_from_domain_root(monkeypatch, tmp_path):
+    plugin = object.__new__(vm_plugin.VmPlugin)
+    domain_xml_path = tmp_path / 'domain.xml'
+    write_temp_file_to(monkeypatch, domain_xml_path)
+
+    disks, fpath = plugin._build_domain_new_xml(FakeDomainXmlVm(), {'old': cbd_migration_volume()})
+
+    assert disks == ['vdb']
+    root = vm_plugin.etree.parse(fpath).getroot()
+    iothreads = root.findall('./devices/disk/driver/iothreads/iothread')
+    assert [i.get('id') for i in iothreads] == ['102', '103']
+
+
+@pytest.mark.kvmagent
+def test_vm_plugin_build_dest_disk_xml_allocates_cbd_iothreads_from_domain_root(monkeypatch, tmp_path):
+    plugin = object.__new__(vm_plugin.VmPlugin)
+    disk_xml_path = tmp_path / 'disk.xml'
+    write_temp_file_to(monkeypatch, disk_xml_path)
+
+    dev, fpath = plugin._build_dest_disk_xml(FakeDomainXmlVm(), 'old', cbd_migration_volume())
+
+    assert dev == 'vdb'
+    disk = vm_plugin.etree.parse(fpath).getroot()
+    iothreads = disk.findall('./driver/iothreads/iothread')
+    assert [i.get('id') for i in iothreads] == ['102', '103']
+
+
+@pytest.mark.kvmagent
+def test_retrieve_diskele_allocates_cbd_iothreads_from_domain_root():
+    class FakeNbdDisk(object):
+        class Source(object):
+            name_ = 'old'
+
+        source = Source()
+
+        def dump(self):
+            return '''
+            <disk type="network" device="disk">
+              <driver name="qemu" type="raw" cache="none" discard="unmap" queues="4"/>
+              <source protocol="cbd" name="old"/>
+              <target dev="vdb" bus="virtio"/>
+            </disk>
+            '''
+
+    class FakeDomainXmlObject(object):
+        def dump(self):
+            return DOMAIN_XML_WITH_USED_IOTHREAD
+
+    task = object.__new__(vm_plugin.VmVolumesRecoveryTask)
+    task.volumes = [cbd_migration_volume(installPath='cbd:new-volume?old')]
+    task.domain_xmlobject = FakeDomainXmlObject()
+
+    disk = task.retrieve_diskele(FakeNbdDisk())
+
+    iothreads = disk.findall('./driver/iothreads/iothread')
+    assert [i.get('id') for i in iothreads] == ['102', '103']
 
 
 @pytest.mark.kvmagent


### PR DESCRIPTION
## Summary
Fix ZSTAC-86047 where VM migration from ZStone Ceph to ZBS failed while generating the destination domain XML. The CBD disk IOThread VQ allocator tried to call `getroottree()` on a stdlib `xml.etree.ElementTree.Element`, which does not provide that lxml-only API.

## Changes
- Pass the parsed domain root from `_build_domain_new_xml()` into `_get_new_disk()`.
- Allocate CBD disk IOThread VQ ids by scanning the provided domain root, preserving whole-domain conflict avoidance without using `getroottree()`.
- Add a regression test for domain-root based IOThread id allocation during migration XML rebuild.

## Testing
- [x] `git diff --check upstream/feature-5.5.28-zbs..HEAD`
- [x] `/Users/haidong.pang/.local/share/mise/installs/python/3.14/bin/python3.14 -m py_compile kvmagent/kvmagent/plugins/vm_plugin.py tests/unit/kvmagent/test_vm_iothread_vq_mapping.py`
- [x] Targeted regression test with mise Python 3.14 and repository pytest wheel: `tests/unit/kvmagent/test_vm_iothread_vq_mapping.py::test_build_domain_new_xml_allocates_cbd_iothreads_from_domain_root`

Resolves: ZSTAC-86047

sync from gitlab !7293