### PR TITLE
<fix>[zstacklib]: avoid processor fact hang for 4.8.38

### DIFF
--- a/zstacklib/ansible/zstacklib.py
+++ b/zstacklib/ansible/zstacklib.py
@@ -1505,7 +1505,7 @@ def get_remote_host_info_obj(host_post_info):
     runner_args = ZstackRunnerArg()
     runner_args.host_post_info = host_post_info
     runner_args.module_name = 'setup'
-    runner_args.module_args = ('gather_subset=machine,processor '
+    runner_args.module_args = ('gather_subset=machine '
                                'filter=ansible_dist*,ansible_machine,'
                                'ansible_processor,ansible_kernel')
     zstack_runner = ZstackRunner(runner_args)
@@ -1521,14 +1521,19 @@ def get_remote_host_info_obj(host_post_info):
 
     ret = result['contacted'][host]
     if 'ansible_facts' in ret:
+        # trying get cpu info
+        command = 'cat /proc/cpuinfo | grep -i -E "model name|vendor"'
+        (status, cpu_info_output) = run_remote_command(command,
+                                                       host_post_info,
+                                                       return_status=True,
+                                                       return_output=True)
         facts = ret['ansible_facts']
         host_info.distro = facts['ansible_distribution'].split()[0].lower()
         host_info.major_version_str = \
             facts['ansible_distribution_major_version']
         host_info.distro_release = facts['ansible_distribution_release']
         host_info.distro_version = facts['ansible_distribution_version']
-        host_info.cpu_info = ' '.join(str(p) for p in
-                                      facts['ansible_processor']).lower()
+        host_info.cpu_info = cpu_info_output.lower()
         host_info.host_arch = facts['ansible_machine']
         host_info.kernel_version = facts['ansible_kernel']
 


### PR DESCRIPTION
## Root Cause

The ansible setup task used to collect host CPU information with `gather_subset=machine,processor`. In affected ansible versions, the `processor` subset also collects block-device facts. If a block device is stuck, host info collection can hang and block agent deployment or reconnect workflows.

## Resolve

- Backport the 5.4.0 fix that removes `processor` from ansible setup gather_subset.
- Collect CPU vendor/model information with a direct remote shell command against `/proc/cpuinfo` instead of ansible processor facts.
- Preserve the existing machine, distro, architecture, and kernel fact collection path.

## Updated Behavior

Host info collection no longer depends on ansible processor fact gathering, so stuck block devices should not block the CPU-info portion of agent deployment host detection.

## Verification

```bash
git show --check f1261e4af
python -m py_compile zstacklib/ansible/zstacklib.py
```

## Residual Risk

No physical stuck-block-device environment was available in this backport pass. Functional validation should be covered by QA reconnect/deploy-agent verification.

## Jira

Resolves: ZSTAC-85990
Related: ZSTAC-65284

sync from gitlab !7304