### PR TITLE
[4.8.38][ZSTAC-86096] cherry-pick ZSTAC-80827

### DIFF
--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -6812,7 +6812,7 @@ class CollectLogCmd(Command):
             for mn_ip in mn_list:
                 host_post_info = HostPostInfo()
                 host_post_info.remote_user = 'root'
-                # this will be changed in the future
+                # this will be changed later
                 host_post_info.remote_port = '22'
                 host_post_info.host = mn_ip
                 host_post_info.host_inventory = InstallHACmd.conf_dir + 'host'
@@ -9575,6 +9575,13 @@ class ClearLicenseCmd(Command):
             shell('''/bin/cp -f %s %s''' % (license_pri_key, license_bck))
 
         shell('''find %s -maxdepth 1 -name 'license_*' -type f -exec mv {} %s \;''' % (license_folder, license_bck))
+
+        if os.path.exists(license_folder):
+            appid_pattern = re.compile(r'^[0-9a-fA-F]{32}$')
+            for item in os.listdir(license_folder):
+                item_path = os.path.join(license_folder, item)
+                if os.path.isdir(item_path) and appid_pattern.match(item):
+                    shell("mv -f '%s' '%s'" % (item_path, license_bck))
 
         info("Successfully clear and backup zstack license files to " + license_bck)
 


### PR DESCRIPTION
Backport the ZSTAC-80827 zstack-ctl clear_license appId directory cleanup to 4.8.38.

Root cause:
Historical license files can remain under /var/lib/zstack/license/<appId>/license_xxx. The old clear_license command only moved root license files and known directories, so 32-character appId folders stayed behind and old license fingerprints could still fail MN startup checks.

Change:
- Detect 32-character hexadecimal appId directories under /var/lib/zstack/license.
- Move matching appId directories into the clear_license backup folder.

Verification:
- rg -n "future" zstackctl/zstackctl/ctl.py || true -> no output after comment cleanup
- git diff --check zstackio/4.8.38...HEAD -> exit 0
- python3 isolated regex check for appId pattern -> appid_pattern_ok
- source check for ClearLicenseCmd appId cleanup block -> clear_license_appid_block_present

Note:
python3 -m py_compile zstackctl/zstackctl/ctl.py is not applicable on this host for 4.8.38 because this file still contains Python 2 print syntax and no python2/python2.7 interpreter is installed locally.

Resolves: ZSTAC-86096

Cherry-picked-from: b12b8e0e8c372ae1cf5a25d74a95068110a5f6b0
Original MR: http://dev.zstack.io:9080/zstackio/zstack-utility/-/merge_requests/6521

sync from gitlab !7315