### PR TITLE
[AI] Add kvmagent host model cache operations

### DIFF
--- a/kvmagent/kvmagent/plugins/virtiofs_plugin.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_plugin.py
@@ -203,6 +203,20 @@ def _get_cmd_attr(obj, name, default=None):
     return getattr(obj, name, default)
 
 
+def _classify_host_model_cache_failure(error):
+    error = str(error or '')
+    lowered = error.lower()
+    if 'capacity' in lowered or 'available' in lowered:
+        return 'CapacityCheck', 'InsufficientHostCacheStorage'
+    if 'permission' in lowered or 'denied' in lowered:
+        return 'AgentExecution', 'PermissionDenied'
+    if 'outside allowed' in lowered or 'must be absolute' in lowered or 'does not exist' in lowered or 'not a directory' in lowered:
+        return 'PreparedSourceValidation', 'SourcePathInvalid'
+    if 'timeout' in lowered:
+        return 'AgentExecution', 'AgentTimeout'
+    return 'AgentExecution', 'Unknown'
+
+
 def get_vm_domain(vm_uuid):
     """Get libvirt domain for VM
 
@@ -480,6 +494,9 @@ class VirtiofsPlugin(kvmagent.KvmAgent):
     ATTACH_VIRTIOFS_PATH = "/virtiofs/attach"
     DETACH_VIRTIOFS_PATH = "/virtiofs/detach"
     STATUS_VIRTIOFS_PATH = "/virtiofs/status"
+    HOST_MODEL_CACHE_REPORT_PATH = "/virtiofs/host-model-cache/report"
+    HOST_MODEL_CACHE_PREPARE_PATH = "/virtiofs/host-model-cache/prepare"
+    HOST_MODEL_CACHE_CLEANUP_PATH = "/virtiofs/host-model-cache/cleanup"
 
     def start(self):
         """Initialize virtiofsd path and register HTTP endpoints."""
@@ -489,6 +506,9 @@ class VirtiofsPlugin(kvmagent.KvmAgent):
         http_server.register_async_uri(self.ATTACH_VIRTIOFS_PATH, self.attach_virtiofs)
         http_server.register_async_uri(self.DETACH_VIRTIOFS_PATH, self.detach_virtiofs)
         http_server.register_async_uri(self.STATUS_VIRTIOFS_PATH, self.virtiofs_status)
+        http_server.register_async_uri(self.HOST_MODEL_CACHE_REPORT_PATH, self.report_host_model_cache)
+        http_server.register_async_uri(self.HOST_MODEL_CACHE_PREPARE_PATH, self.prepare_host_model_cache)
+        http_server.register_async_uri(self.HOST_MODEL_CACHE_CLEANUP_PATH, self.cleanup_host_model_cache)
 
     def stop(self):
         """No-op; virtiofs plugin has no background resources to clean up."""
@@ -661,4 +681,72 @@ class VirtiofsPlugin(kvmagent.KvmAgent):
         supported, version = check_libvirt_version()
         rsp.libvirtVersion = version
         rsp.virtiofsHotplugSupported = supported
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def report_host_model_cache(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = jsonobject.JsonObject()
+        rsp.success = False
+        try:
+            source_root = _get_cmd_attr(cmd, 'sourceRoot', _get_cmd_attr(cmd, 'sourceRootPath', None))
+            report = virtiofs_source.report_source_root(source_root)
+            rsp.sourceRoot = report.get('sourceRoot')
+            rsp.physicalTotalBytes = report.get('physicalTotalBytes')
+            rsp.physicalAvailableBytes = report.get('physicalAvailableBytes')
+            rsp.cacheEntries = report.get('cacheEntries', [])
+            rsp.success = True
+            logger.info("Reported host model cache root[%s], entries=%s, available=%s" % (
+                rsp.sourceRoot, len(rsp.cacheEntries), rsp.physicalAvailableBytes))
+        except Exception as e:
+            logger.warning("Failed to report host model cache: %s" % str(e))
+            rsp.error = str(e)
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def prepare_host_model_cache(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = jsonobject.JsonObject()
+        rsp.success = False
+        try:
+            source_root = _get_cmd_attr(cmd, 'sourceRoot', _get_cmd_attr(cmd, 'sourceRootPath', None))
+            source_path = _get_cmd_attr(cmd, 'sourcePath', None)
+            required_capacity = _get_cmd_attr(cmd, 'requiredCapacityBytes', None)
+            entry = virtiofs_source.prepare_host_model_cache(source_root, source_path, required_capacity)
+            rsp.cacheEntry = entry
+            rsp.success = True
+            logger.info("Prepared host model cache path[%s], size=%s" % (
+                entry.get('sourcePath'), entry.get('sizeBytes')))
+        except Exception as e:
+            phase, code = _classify_host_model_cache_failure(e)
+            rsp.failurePhase = phase
+            rsp.failureCode = code
+            rsp.failureMessage = str(e)
+            rsp.error = str(e)
+            logger.warning("Failed to prepare host model cache, phase=%s code=%s error=%s" % (
+                phase, code, str(e)))
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def cleanup_host_model_cache(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = jsonobject.JsonObject()
+        rsp.success = False
+        try:
+            source_root = _get_cmd_attr(cmd, 'sourceRoot', _get_cmd_attr(cmd, 'sourceRootPath', None))
+            source_path = _get_cmd_attr(cmd, 'sourcePath', None)
+            result = virtiofs_source.cleanup_host_model_cache(source_root, source_path)
+            rsp.sourcePath = result.get('sourcePath')
+            rsp.bytesReclaimed = result.get('bytesReclaimed')
+            rsp.success = True
+            logger.info("Cleaned host model cache path[%s], bytesReclaimed=%s" % (
+                rsp.sourcePath, rsp.bytesReclaimed))
+        except Exception as e:
+            phase, code = _classify_host_model_cache_failure(e)
+            rsp.failurePhase = phase
+            rsp.failureCode = code
+            rsp.failureMessage = str(e)
+            rsp.error = str(e)
+            logger.warning("Failed to cleanup host model cache, phase=%s code=%s error=%s" % (
+                phase, code, str(e)))
         return jsonobject.dumps(rsp)

--- a/kvmagent/kvmagent/plugins/virtiofs_source.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_source.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 
 
 try:
@@ -136,6 +137,94 @@ def check_available_capacity(path, required_capacity_bytes):
         raise Exception('virtiofs source path[%s] available capacity[%s bytes] is less than required capacity[%s bytes]. '
                         'Please move the virtiofs source root to a disk with enough capacity or free host storage space.' % (
                             path, available, required_capacity_bytes))
+
+
+def statvfs_capacity(path):
+    try:
+        stat = os.statvfs(path)
+    except OSError as exc:
+        raise Exception('failed to check virtiofs source root capacity for path[%s]: %s' % (path, exc))
+    return {
+        'physicalTotalBytes': long(stat.f_blocks * stat.f_frsize),
+        'physicalAvailableBytes': long(stat.f_bavail * stat.f_frsize),
+    }
+
+
+def directory_size(path):
+    total = 0
+    for root, dirs, files in os.walk(path):
+        for name in files:
+            fpath = os.path.join(root, name)
+            try:
+                total += os.path.getsize(fpath)
+            except OSError:
+                pass
+    return long(total)
+
+
+def cache_entry(source_root, source_path):
+    root = _normalize_root(source_root)
+    path = ensure_under(source_path, root, 'sourcePath', allow_root=False)
+    if not os.path.exists(path):
+        raise Exception('sourcePath[%s] does not exist' % source_path)
+    if not os.path.isdir(path):
+        raise Exception('sourcePath[%s] is not a directory' % source_path)
+    return {
+        'sourcePath': path,
+        'sizeBytes': directory_size(path),
+        'sourceMtime': long(os.path.getmtime(path)),
+        'checksum': None,
+        'contentVersion': None,
+    }
+
+
+def report_source_root(source_root):
+    root = _normalize_root(source_root or HOST_SOURCE_ROOT)
+    if not os.path.exists(root):
+        raise Exception('sourceRoot[%s] does not exist' % root)
+    if not os.path.isdir(root):
+        raise Exception('sourceRoot[%s] is not a directory' % root)
+
+    result = statvfs_capacity(root)
+    result['sourceRoot'] = root
+    result['cacheEntries'] = []
+
+    registry = SourceRegistry(os.path.join(root, '.registry')).load()
+    for entry in registry.values():
+        path = entry.get('path') if isinstance(entry, dict) else None
+        if not path:
+            continue
+        try:
+            result['cacheEntries'].append(cache_entry(root, path))
+        except Exception:
+            pass
+    return result
+
+
+def prepare_host_model_cache(source_root, source_path, required_capacity_bytes=None):
+    root = _normalize_root(source_root or HOST_SOURCE_ROOT)
+    if not os.path.exists(root):
+        raise Exception('sourceRoot[%s] does not exist' % root)
+    check_available_capacity(root, required_capacity_bytes)
+    return cache_entry(root, source_path)
+
+
+def cleanup_host_model_cache(source_root, source_path):
+    root = _normalize_root(source_root or HOST_SOURCE_ROOT)
+    path = ensure_under(source_path, root, 'sourcePath', allow_root=False)
+    if not os.path.exists(path):
+        return {
+            'sourcePath': path,
+            'bytesReclaimed': 0,
+        }
+    if not os.path.isdir(path):
+        raise Exception('sourcePath[%s] is not a directory' % source_path)
+    bytes_reclaimed = directory_size(path)
+    shutil.rmtree(path)
+    return {
+        'sourcePath': path,
+        'bytesReclaimed': bytes_reclaimed,
+    }
 
 
 def _safe_id(value, prefix):

--- a/kvmagent/kvmagent/plugins/virtiofs_source.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_source.py
@@ -117,7 +117,7 @@ def _parse_required_capacity(value):
     if value is None or value == '':
         return None
     try:
-        required = long(value)
+        required = int(value)
     except Exception:
         raise Exception('requiredCapacityBytes[%s] must be a number' % value)
     if required < 0:
@@ -145,8 +145,8 @@ def statvfs_capacity(path):
     except OSError as exc:
         raise Exception('failed to check virtiofs source root capacity for path[%s]: %s' % (path, exc))
     return {
-        'physicalTotalBytes': long(stat.f_blocks * stat.f_frsize),
-        'physicalAvailableBytes': long(stat.f_bavail * stat.f_frsize),
+        'physicalTotalBytes': int(stat.f_blocks * stat.f_frsize),
+        'physicalAvailableBytes': int(stat.f_bavail * stat.f_frsize),
     }
 
 
@@ -159,7 +159,7 @@ def directory_size(path):
                 total += os.path.getsize(fpath)
             except OSError:
                 pass
-    return long(total)
+    return int(total)
 
 
 def cache_entry(source_root, source_path):
@@ -172,7 +172,7 @@ def cache_entry(source_root, source_path):
     return {
         'sourcePath': path,
         'sizeBytes': directory_size(path),
-        'sourceMtime': long(os.path.getmtime(path)),
+        'sourceMtime': int(os.path.getmtime(path)),
         'checksum': None,
         'contentVersion': None,
     }


### PR DESCRIPTION
## Summary
- Add kvmagent virtiofs host-cache report, prepare, and cleanup operations.
- Report host filesystem capacity and cache entries to the management node.
- Keep policy and scheduling decisions in the control plane.

## Scope
- VM/cloud-host model service deployment only.
- Target branch: feature-5.5.28-aios.

## Verification
- verify-case container: python -m py_compile kvmagent/kvmagent/plugins/virtiofs_plugin.py kvmagent/kvmagent/plugins/virtiofs_source.py

Related core/premium MRs use the same source branch suffix @@3.

sync from gitlab !7320