### PR TITLE
<fix>[kvmagent]: install collectd-disk on el7 hosts

### DIFF
--- a/kvmagent/ansible/kvm.py
+++ b/kvmagent/ansible/kvm.py
@@ -213,12 +213,12 @@ def install_kvm_pkg():
 
         releasever_mapping = {
             'c74': 'qemu-kvm ',
-            'c76': 'qemu-kvm libvirt-admin seabios-bin nping elfutils-libelf-devel',
-            'c79': 'qemu-kvm libvirt-admin seabios-bin nping elfutils-libelf-devel',
+            'c76': 'qemu-kvm libvirt-admin seabios-bin nping elfutils-libelf-devel collectd-disk',
+            'c79': 'qemu-kvm libvirt-admin seabios-bin nping elfutils-libelf-devel collectd-disk',
             'h76c': ('%s qemu-kvm libvirt-admin seabios-bin nping '
-                     'elfutils-libelf-devel vconfig OVMF libicu') % helix_rhel_rpms,
+                     'elfutils-libelf-devel vconfig OVMF libicu collectd-disk') % helix_rhel_rpms,
             'h79c': ('%s qemu-kvm libvirt-admin seabios-bin nping '
-                     'elfutils-libelf-devel vconfig OVMF libicu') % helix_rhel_rpms,
+                     'elfutils-libelf-devel vconfig OVMF libicu collectd-disk') % helix_rhel_rpms,
             'h84r': ('%s qemu-kvm libvirt-daemon libvirt-daemon-kvm '
                      'seabios-bin elfutils-libelf-devel collectd-disk') % helix_rhel_rpms,
             'rl84': 'qemu-kvm libvirt-daemon libvirt-daemon-kvm seabios-bin elfutils-libelf-devel',


### PR DESCRIPTION
## ZSTAC-86131

### Background
el7 compute nodes upgrade collectd from 5.8 to 5.12.0. With collectd-5.8 el7 hosts installed only collectd and collectd-virt. collectd-5.12 splits the disk plugin into a separate collectd-disk package, so el7 hosts now must also install collectd-disk, otherwise disk metrics collection breaks after the upgrade.

### Changes
| Module | Change |
|--------|--------|
| kvmagent/ansible/kvm.py | Add collectd-disk to el7 releasever entries (c74, c76, c79) in install_kvm_pkg releasever_mapping |

### Why el7 only
os_base_dep already installs collectd-virt for all rpm-based distros. collectd-disk is added per distro via distro_mapping (kylin, uniontech, rocky) or releasever_mapping (h84r, euler20, oe2203sp1, h2203sp1o, nfs4). el7 (centos distro_head, releasever c74/c76/c79) was the only path missing collectd-disk. The change is scoped to the three el7 releasever entries so other distros are unaffected.

### Note
The matching rpm repo-data change (shipping collectd-disk in the el7 repo) is handled separately.

Related: ZSTAC-86131

sync from gitlab !7323