### PR TITLE
<fix>[install]: ZSTAC-85283 add alinux4 nfs branch

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -3446,6 +3446,16 @@ cs_setup_nfs(){
         chkconfig rpcbind on >>$ZSTACK_INSTALL_LOG 2>&1
         service rpcbind restart >>$ZSTACK_INSTALL_LOG 2>&1
         service nfs restart >>$ZSTACK_INSTALL_LOG 2>&1
+    elif [[ "$OS" = "ALINUX4" ]]; then
+        for service in rpcbind nfs-server; do
+            systemctl enable $service >>$ZSTACK_INSTALL_LOG 2>&1 || fail "failed to setup NFS server"
+            systemctl restart $service >>$ZSTACK_INSTALL_LOG 2>&1 || fail "failed to setup NFS server"
+        done
+        for service in nfs-lock nfs-idmap; do
+            systemctl cat $service >/dev/null 2>&1 || continue
+            systemctl enable $service >>$ZSTACK_INSTALL_LOG 2>&1 || fail "failed to setup NFS server"
+            systemctl restart $service >>$ZSTACK_INSTALL_LOG 2>&1 || fail "failed to setup NFS server"
+        done
     elif [[ $REDHAT_WITHOUT_CENTOS6 =~ $OS ]]; then
         systemctl enable rpcbind >>$ZSTACK_INSTALL_LOG 2>&1
         systemctl enable nfs-server >>$ZSTACK_INSTALL_LOG 2>&1
@@ -3823,7 +3833,7 @@ is_install_marketplace_server(){
 is_install_fluentbit_server(){
     echo_subtitle "Install fluentbit server"
     if [ "$BASEARCH" = "x86_64" ]; then
-        if [ "$ZSTACK_RELEASE" = "h84r" ] || [ "$ZSTACK_RELEASE" = "uos20r" ]; then
+        if [ "$ZSTACK_RELEASE" = "h84r" ] || [ "$ZSTACK_RELEASE" = "uos20r" ] || [ "$OS" = "ALINUX4" ]; then
             echo "Installing libpq for fluent-bit..." >> $ZSTACK_INSTALL_LOG
             yum install libpq --disablerepo="*" --enablerepo=$ZSTACK_YUM_REPOS -y >> $ZSTACK_INSTALL_LOG 2>&1
             if [ $? -ne 0 ]; then


### PR DESCRIPTION
## Summary
Add an ALinux4-specific NFS service setup branch for ZSTAC-85283 so ZOps/bin installation does not fail on missing legacy NFS units.

## Changes
- On `OS=ALINUX4`, require `rpcbind` and `nfs-server` to enable/restart successfully.
- Only enable/restart `nfs-lock` and `nfs-idmap` when those units exist, matching ALinux4 service availability.
- Leave existing CentOS/RedHat branches unchanged.

## Testing
- [x] `bash -n installation/install.sh`
- [x] `git diff --check upstream/5.5.28..HEAD`
- [ ] CI pipeline
- [ ] Real ALinux4 full install/upgrade regression after rebuild

Resolves: ZSTAC-85283

sync from gitlab !7330