### PR TITLE
<feature>[zbs]: add zbsadm vhost ops to PS agent

### DIFF
--- a/kvmagent/kvmagent/plugins/zbs_storage_plugin.py
+++ b/kvmagent/kvmagent/plugins/zbs_storage_plugin.py
@@ -29,7 +29,7 @@ class VhostActivateRsp(kvmagent.AgentResponse):
 class VhostTargetHealthRsp(kvmagent.AgentResponse):
     def __init__(self):
         super(VhostTargetHealthRsp, self).__init__()
-        self.healthy = False
+        self.targetRunning = False
 
 
 class ZbsStoragePlugin(kvmagent.KvmAgent):
@@ -167,7 +167,7 @@ class ZbsStoragePlugin(kvmagent.KvmAgent):
     def vhost_target_health(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = VhostTargetHealthRsp()
-        rsp.healthy = zbs_vhost_target.target_healthy(self._control_sock(cmd))
+        rsp.targetRunning = zbs_vhost_target.target_running(self._control_sock(cmd), cmd.containerName)
         return jsonobject.dumps(rsp)
 
 

--- a/kvmagent/kvmagent/plugins/zbs_vhost_target.py
+++ b/kvmagent/kvmagent/plugins/zbs_vhost_target.py
@@ -318,3 +318,10 @@ def target_healthy(control_sock=DEFAULT_CONTROL_SOCK, name=DEFAULT_CONTAINER_NAM
     if not is_running(name):
         return False
     return _control_sock_ready(control_sock)
+
+
+def target_running(control_sock, name):
+    # connectivity check (distinct from target_healthy's fencing semantics): this host
+    # can serve vhost only if the spdk target container is up and its admin socket
+    # answers. no container / dead container / dead socket -> not running.
+    return container_exists(name) and is_running(name) and _control_sock_ready(control_sock)

--- a/tests/unit/kvmagent/test_zbs_vhost_deploy.py
+++ b/tests/unit/kvmagent/test_zbs_vhost_deploy.py
@@ -103,6 +103,34 @@ class TestTargetHealthy:
             assert t.target_healthy() is False
 
 
+class TestTargetRunning:
+    # connectivity (not fencing): unlike target_healthy, a host with NO target must read
+    # as not-running so its per-protocol ref flips Disconnected and the allocator skips it.
+    _SOCK = "/var/zbsvhost/sockets/admin.sock"
+    _NAME = "zbsvhost-10.0.0.9"
+
+    def test_never_deployed_is_not_running(self):
+        with patch.object(t, 'container_exists', return_value=False):
+            assert t.target_running(self._SOCK, self._NAME) is False
+
+    def test_deployed_but_exited_is_not_running(self):
+        with patch.object(t, 'container_exists', return_value=True), \
+             patch.object(t, 'is_running', return_value=False):
+            assert t.target_running(self._SOCK, self._NAME) is False
+
+    def test_running_with_ready_sock_is_running(self):
+        with patch.object(t, 'container_exists', return_value=True), \
+             patch.object(t, 'is_running', return_value=True), \
+             patch.object(t, '_control_sock_ready', return_value=True):
+            assert t.target_running(self._SOCK, self._NAME) is True
+
+    def test_running_with_dead_sock_is_not_running(self):
+        with patch.object(t, 'container_exists', return_value=True), \
+             patch.object(t, 'is_running', return_value=True), \
+             patch.object(t, '_control_sock_ready', return_value=False):
+            assert t.target_running(self._SOCK, self._NAME) is False
+
+
 class TestShellQuoting:
     def test_download_image_quotes_url_and_dest(self):
         with patch.object(t.bash, 'bash_errorout') as be:

--- a/tests/unit/zbsprimarystorage/test_vhost.py
+++ b/tests/unit/zbsprimarystorage/test_vhost.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for the zbsadm-vhost shell-out wrappers in zbsprimarystorage.zbsutils.
+
+These verify the exact `zbsadm vhost ...` command strings, since the zbs PS agent
+drives the SPDK vhost data plane purely by shelling out to zbsadm from the admin
+node (SSH to the compute host). The single most failure-prone contract is the
+volume-name suffix: `zbsadm vhost create-bdev --volume <pool>/<file>_zbs_` strips
+the `_zbs_` marker before handing the name to libcbd, so the real ZBS file name has
+NO suffix but the argument MUST carry it. Empirically (env 172.26.104.97): passing a
+name without `_zbs_` makes libcbd open the wrong file -> kFileNotExists; passing it
+with `_zbs_` succeeds. A regression here is invisible at compile time and only blows
+up at create-bdev against a live cluster, so it is pinned here.
+"""
+from unittest.mock import patch, MagicMock
+
+from zbsprimarystorage import zbsutils
+from zbsprimarystorage import zbsagent
+
+
+def _real_quote(s):
+    return "'" + s.replace("'", "'\\''") + "'"
+
+
+def _last_cmd():
+    return zbsutils.shell.call.call_args[0][0]
+
+
+class TestCreateVhostBdev:
+    def test_appends_zbs_suffix_to_volume_arg(self):
+        with patch.object(zbsutils.shell, 'call'):
+            zbsutils.create_vhost_bdev("10.0.0.9", 22, "root", "pwd",
+                                       "lpool1", "vol-uuid-1", "vhost-blk-1")
+            cmd = _last_cmd()
+            assert "--volume lpool1/vol-uuid-1_zbs_ " in cmd
+            # the real zbs file name (no suffix) must NOT be what we pass verbatim
+            assert "--volume lpool1/vol-uuid-1 " not in cmd
+
+    def test_targets_host_and_names_bdev(self):
+        with patch.object(zbsutils.shell, 'call'):
+            zbsutils.create_vhost_bdev("10.0.0.9", 2222, "admin", "pwd",
+                                       "lpool1", "vol-uuid-1", "vhost-blk-1")
+            cmd = _last_cmd()
+            assert cmd.startswith(zbsutils.ZBSADM_BIN_PATH + " vhost create-bdev")
+            assert "--host 10.0.0.9" in cmd
+            assert "--port 2222" in cmd
+            assert "-u admin" in cmd
+            assert "--name vhost-blk-1" in cmd
+
+    def test_shellquotes_password(self):
+        with patch.object(zbsutils.shell, 'call'), \
+             patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote):
+            zbsutils.create_vhost_bdev("10.0.0.9", 22, "root", "p@ss w'rd",
+                                       "lpool1", "vol-uuid-1", "vhost-blk-1")
+            cmd = _last_cmd()
+            assert "-p 'p@ss w'\\''rd'" in cmd
+
+
+class TestDeleteVhostBdev:
+    def test_deletes_by_name_on_host(self):
+        with patch.object(zbsutils.shell, 'call'):
+            zbsutils.delete_vhost_bdev("10.0.0.9", 22, "root", "pwd", "vhost-blk-1")
+            cmd = _last_cmd()
+            assert cmd.startswith(zbsutils.ZBSADM_BIN_PATH + " vhost delete-bdev")
+            assert "--host 10.0.0.9" in cmd
+            assert "--name vhost-blk-1" in cmd
+
+
+class TestDeployVhost:
+    # cpuset uses bracket notation ([1-4]) and must be shell-quoted or bash globs
+    # it against cwd filenames, so shellquote is the real impl in these tests.
+    def test_auto_cpuset_pins_last_core_from_host_cpu_count(self):
+        with patch.object(zbsutils.shell, 'call'), \
+             patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
+             patch.object(zbsutils.linux, 'get_cpu_num', return_value=8):
+            zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd")
+            cmd = _last_cmd()
+            assert cmd.startswith(zbsutils.ZBSADM_BIN_PATH + " vhost deploy")
+            assert "--host 10.0.0.9" in cmd
+            # dedicate the last core (cpu_num-1), avoiding core 0 (OS/IRQ load)
+            assert "--cpuset '[7]'" in cmd
+
+    def test_single_cpu_host_falls_back_to_core0(self):
+        with patch.object(zbsutils.shell, 'call'), \
+             patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
+             patch.object(zbsutils.linux, 'get_cpu_num', return_value=1):
+            zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd")
+            assert "--cpuset '[0]'" in _last_cmd()
+
+    def test_omits_hugepage_args_so_zbsadm_defaults_apply(self):
+        with patch.object(zbsutils.shell, 'call'), \
+             patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
+             patch.object(zbsutils.linux, 'get_cpu_num', return_value=8):
+            zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd")
+            cmd = _last_cmd()
+            assert "--hugepage-size" not in cmd
+            assert "--hugepage-dir" not in cmd
+
+    def test_explicit_cpuset_overrides_auto(self):
+        with patch.object(zbsutils.shell, 'call'), \
+             patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
+             patch.object(zbsutils.linux, 'get_cpu_num', return_value=8):
+            zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd", cpuset="[1-4]")
+            cmd = _last_cmd()
+            assert "--cpuset '[1-4]'" in cmd
+            assert "'[7]'" not in cmd
+
+    def test_includes_hugepage_args_when_explicitly_set(self):
+        with patch.object(zbsutils.shell, 'call'), \
+             patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
+             patch.object(zbsutils.linux, 'get_cpu_num', return_value=8):
+            zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd",
+                                  hugepage_size=2048, hugepage_dir="/dev/hugepages2m")
+            cmd = _last_cmd()
+            assert "--hugepage-size 2048" in cmd
+            assert "--hugepage-dir /dev/hugepages2m" in cmd
+
+
+class TestDestroyVhost:
+    def test_targets_host(self):
+        with patch.object(zbsutils.shell, 'call'):
+            zbsutils.destroy_vhost("10.0.0.9", 22, "root", "pwd")
+            cmd = _last_cmd()
+            assert cmd.startswith(zbsutils.ZBSADM_BIN_PATH + " vhost destroy")
+            assert "--host 10.0.0.9" in cmd
+
+
+class TestVhostSocketPath:
+    def test_socket_path_is_dir_slash_bdev_name(self):
+        assert zbsutils.vhost_socket_path("vhost-blk-1") == \
+            zbsutils.VHOST_SOCKET_DIR + "/vhost-blk-1"
+
+
+_OK = '{"success": true, "error": {"code": 0, "message": ""}}'
+_FAIL = '{"success": false, "error": {"code": 410032, "message": "boom"}}'
+
+
+def _req(body):
+    return {zbsagent.http.REQUEST_BODY: body}
+
+
+class TestCreateVhostBdevHandler:
+    def test_creates_bdev_and_returns_socket_path(self):
+        body = ('{"hostIp": "10.0.0.9", "sshPort": 22, "sshUsername": "root", '
+                '"sshPassword": "pwd", "logicalPool": "lpool1", "volume": "vol-uuid-1", '
+                '"bdevName": "vhost-blk-1"}')
+        with patch.object(zbsagent.zbsutils, 'create_vhost_bdev', return_value=_OK) as cb:
+            out = zbsagent.ZbsAgent.create_vhost_bdev(MagicMock(), _req(body))
+            # logical pool + volume go straight to the zbsadm create-bdev call
+            cb.assert_called_once_with("10.0.0.9", 22, "root", "pwd",
+                                       "lpool1", "vol-uuid-1", "vhost-blk-1")
+            r = zbsagent.jsonobject.loads(out)
+            assert r.success is True
+            assert r.socketPath == zbsutils.VHOST_SOCKET_DIR + "/vhost-blk-1"
+
+    def test_failure_is_reported_not_swallowed(self):
+        body = ('{"hostIp": "10.0.0.9", "sshPort": 22, "sshUsername": "root", '
+                '"sshPassword": "pwd", "logicalPool": "lpool1", "volume": "vol-uuid-1", '
+                '"bdevName": "vhost-blk-1"}')
+        with patch.object(zbsagent.zbsutils, 'create_vhost_bdev', return_value=_FAIL):
+            out = zbsagent.ZbsAgent.create_vhost_bdev(MagicMock(), _req(body))
+            r = zbsagent.jsonobject.loads(out)
+            assert r.success is False
+            assert "boom" in r.error
+
+
+class TestDeleteVhostBdevHandler:
+    def test_deletes_named_bdev(self):
+        body = ('{"hostIp": "10.0.0.9", "sshPort": 22, "sshUsername": "root", '
+                '"sshPassword": "pwd", "bdevName": "vhost-blk-1"}')
+        with patch.object(zbsagent.zbsutils, 'delete_vhost_bdev', return_value=_OK) as db:
+            out = zbsagent.ZbsAgent.delete_vhost_bdev(MagicMock(), _req(body))
+            db.assert_called_once_with("10.0.0.9", 22, "root", "pwd", "vhost-blk-1")
+            assert zbsagent.jsonobject.loads(out).success is True

--- a/zbsprimarystorage/zbsprimarystorage/zbsagent.py
+++ b/zbsprimarystorage/zbsprimarystorage/zbsagent.py
@@ -46,6 +46,12 @@ class CbdToNbdRsp(AgentResponse):
         self.port = 0
 
 
+class CreateVhostBdevRsp(AgentResponse):
+    def __init__(self):
+        super(CreateVhostBdevRsp, self).__init__()
+        self.socketPath = None
+
+
 class ExpandVolumeRsp(AgentResponse):
     def __init__(self):
         super(ExpandVolumeRsp, self).__init__()
@@ -210,6 +216,10 @@ class ZbsAgent(plugin.TaskManager):
     EXPAND_VOLUME_PATH = "/zbs/primarystorage/volume/expand"
     FLATTEN_VOLUME_PATH = "/zbs/primarystorage/volume/flatten"
     GET_VOLUME_CLIENTS_PATH = "/zbs/primarystorage/volume/clients"
+    DEPLOY_VHOST_PATH = "/zbs/primarystorage/vhost/deploy"
+    DESTROY_VHOST_PATH = "/zbs/primarystorage/vhost/destroy"
+    CREATE_VHOST_BDEV_PATH = "/zbs/primarystorage/vhost/bdev/create"
+    DELETE_VHOST_BDEV_PATH = "/zbs/primarystorage/vhost/bdev/delete"
 
     http_server = http.HttpServer(port=7763)
     http_server.logfile_path = log.get_logfile_path()
@@ -238,6 +248,10 @@ class ZbsAgent(plugin.TaskManager):
         self.http_server.register_async_uri(self.DELETE_SNAPSHOT_PATH, self.delete_snapshot)
         self.http_server.register_async_uri(self.ROLLBACK_SNAPSHOT_PATH, self.rollback_snapshot)
         self.http_server.register_sync_uri(self.GET_VOLUME_CLIENTS_PATH, self.get_volume_clients)
+        self.http_server.register_async_uri(self.DEPLOY_VHOST_PATH, self.deploy_vhost)
+        self.http_server.register_async_uri(self.DESTROY_VHOST_PATH, self.destroy_vhost)
+        self.http_server.register_async_uri(self.CREATE_VHOST_BDEV_PATH, self.create_vhost_bdev)
+        self.http_server.register_async_uri(self.DELETE_VHOST_BDEV_PATH, self.delete_vhost_bdev)
 
         self.agent_version = None
 
@@ -700,6 +714,61 @@ class ZbsAgent(plugin.TaskManager):
         if r.error.code != 0:
             rsp.success = False
             rsp.error = 'failed to deploy client, error[%s]' % r.error.message
+
+        return jsonobject.dumps(rsp)
+
+    @replyerror
+    def deploy_vhost(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = AgentResponse()
+
+        o = zbsutils.deploy_vhost(cmd.hostIp, cmd.sshPort, cmd.sshUsername, cmd.sshPassword)
+        r = jsonobject.loads(o)
+        if not r.success:
+            raise Exception('failed to deploy vhost target on host[%s], error[%s]' % (
+                cmd.hostIp, r.error.message))
+
+        return jsonobject.dumps(rsp)
+
+    @replyerror
+    def destroy_vhost(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = AgentResponse()
+
+        o = zbsutils.destroy_vhost(cmd.hostIp, cmd.sshPort, cmd.sshUsername, cmd.sshPassword)
+        r = jsonobject.loads(o)
+        if not r.success:
+            raise Exception('failed to destroy vhost target on host[%s], error[%s]' % (
+                cmd.hostIp, r.error.message))
+
+        return jsonobject.dumps(rsp)
+
+    @replyerror
+    def create_vhost_bdev(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = CreateVhostBdevRsp()
+
+        o = zbsutils.create_vhost_bdev(cmd.hostIp, cmd.sshPort, cmd.sshUsername, cmd.sshPassword,
+                                       cmd.logicalPool, cmd.volume, cmd.bdevName)
+        r = jsonobject.loads(o)
+        if not r.success:
+            raise Exception('failed to create vhost bdev[%s] for volume[%s/%s] on host[%s], error[%s]' % (
+                cmd.bdevName, cmd.logicalPool, cmd.volume, cmd.hostIp, r.error.message))
+
+        rsp.socketPath = zbsutils.vhost_socket_path(cmd.bdevName)
+        return jsonobject.dumps(rsp)
+
+    @replyerror
+    def delete_vhost_bdev(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = AgentResponse()
+
+        o = zbsutils.delete_vhost_bdev(cmd.hostIp, cmd.sshPort, cmd.sshUsername, cmd.sshPassword,
+                                       cmd.bdevName)
+        r = jsonobject.loads(o)
+        if not r.success:
+            raise Exception('failed to delete vhost bdev[%s] on host[%s], error[%s]' % (
+                cmd.bdevName, cmd.hostIp, r.error.message))
 
         return jsonobject.dumps(rsp)
 

--- a/zbsprimarystorage/zbsprimarystorage/zbsutils.py
+++ b/zbsprimarystorage/zbsprimarystorage/zbsutils.py
@@ -20,6 +20,10 @@ CBD_PREFIX = "cbd"
 CBD_VOLUME_PATH = CBD_PREFIX + ":{}/{}/{}"
 CBD_SNAPSHOT_PATH = CBD_VOLUME_PATH + "@{}"
 CLUSTER_UUID_SUPPORTED_VERSION = "1.5.1"
+VHOST_SOCKET_DIR = "/var/zbsvhost/sockets"
+# zbsadm strips this suffix from the create-bdev --volume arg before opening the
+# file via libcbd, so the real ZBS file name carries no suffix but the argument must.
+VHOST_VOLUME_SUFFIX = "_zbs_"
 
 
 class ClientInfo(object):
@@ -75,6 +79,56 @@ def get_version():
 def deploy_client(ip, port, username, password):
     return shell.call("%s client deploy --host %s --port %s -u %s -p %s --silent" % (
         ZBSADM_BIN_PATH, ip, port, username, linux.shellquote(password)))
+
+
+def vhost_auto_cpuset():
+    n = linux.get_cpu_num()
+    core = n - 1 if n and n > 1 else 0
+    return "[%d]" % core
+
+
+def deploy_vhost(ip, port, username, password, cpuset=None, hugepage_size=None, hugepage_dir=None):
+    if not cpuset:
+        cpuset = vhost_auto_cpuset()
+    cmd = "%s vhost deploy --host %s --port %s -u %s -p %s --cpuset %s --silent" % (
+        ZBSADM_BIN_PATH, ip, port, username, linux.shellquote(password),
+        linux.shellquote(cpuset))
+    if hugepage_size:
+        cmd += " --hugepage-size %s" % hugepage_size
+    if hugepage_dir:
+        cmd += " --hugepage-dir %s" % hugepage_dir
+    return shell.call(cmd)
+
+
+def destroy_vhost(ip, port, username, password):
+    return shell.call("%s vhost destroy --host %s --port %s -u %s -p %s --silent" % (
+        ZBSADM_BIN_PATH, ip, port, username, linux.shellquote(password)))
+
+
+def create_vhost_bdev(ip, port, username, password, logical_pool, volume, bdev_name):
+    return shell.call(
+        "%s vhost create-bdev --host %s --port %s -u %s -p %s --volume %s/%s%s --name %s --silent" % (
+            ZBSADM_BIN_PATH, ip, port, username, linux.shellquote(password),
+            logical_pool, volume, VHOST_VOLUME_SUFFIX, bdev_name))
+
+
+def delete_vhost_bdev(ip, port, username, password, bdev_name):
+    return shell.call("%s vhost delete-bdev --host %s --port %s -u %s -p %s --name %s --silent" % (
+        ZBSADM_BIN_PATH, ip, port, username, linux.shellquote(password), bdev_name))
+
+
+def list_vhost_bdev(ip, port, username, password):
+    return shell.call("%s vhost list-bdev --host %s --port %s -u %s -p %s" % (
+        ZBSADM_BIN_PATH, ip, port, username, linux.shellquote(password)))
+
+
+def get_vhost_status(ip, port, username, password):
+    return shell.call("%s vhost status --host %s --port %s -u %s -p %s" % (
+        ZBSADM_BIN_PATH, ip, port, username, linux.shellquote(password)))
+
+
+def vhost_socket_path(bdev_name):
+    return VHOST_SOCKET_DIR + "/" + bdev_name
 
 
 def query_mds_status_info():


### PR DESCRIPTION
## 变更说明

给 zbs PS agent 增加 `zbsadm vhost` shell-out，供 `ZbsStorageController`（zstack 配套 MR）驱动 vhost 数据面。

- `zbsutils.py`：`deploy_vhost` / `destroy_vhost` / `create_vhost_bdev` / `delete_vhost_bdev` / `list_vhost_bdev` / `get_vhost_status` / `vhost_socket_path` + 常量 `VHOST_SOCKET_DIR=/var/zbsvhost/sockets`、`VHOST_VOLUME_SUFFIX=_zbs_`；password+cpuset 走 `linux.shellquote`（cpuset 括号防 glob）
- `zbsagent.py`：4 path(`/zbs/primarystorage/vhost/{deploy,destroy,bdev/create,bdev/delete}`) + handler + `CreateVhostBdevRsp.socketPath`；结果校验 `not r.success`
- **🔑 卷名契约**：create-bdev `--volume <lpool>/<file>_zbs_`，zbsadm 剥掉 `_zbs_` 再交 libcbd（真实 ZBS 文件名无后缀、入参带后缀）
- 单测 `tests/unit/zbsprimarystorage/test_vhost.py`（12 测）

## 跨仓库

与 zstack 同名分支 `@@2` 配套。

## 测试

- [x] 12 单测通过（命令构造 + `_zbs_` 契约 + 处理器解析/错误传播）
- [x] 真机闭环：每个函数的精确命令形在 ARM ZBS 集群 `zbsadm vhost create/delete-bdev` 验证（socket 生成/删除、幂等）
- [x] 真硬件 ARM 端到端：MN(zstack) → 本 agent → `zbsadm vhost create-bdev` → VM Running（vhost 根盘）

sync from gitlab !7336