### PR TITLE
<fix>[kvmagent]: ZSTAC-86123 preserve CDP NBD iothread mapping

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -6883,7 +6883,9 @@ class Vm(object):
                 driver_elements = {'name': 'qemu', 'type': 'raw', 'cache': 'none', 'discard': 'unmap'}
                 if is_virtio_blk(_v) and _v.multiQueues:
                     driver_elements["queues"] = _v.multiQueues
-                e(disk, 'driver', None, driver_elements)
+                driver = e(disk, 'driver', None, driver_elements)
+                if not _v.useVirtioSCSI:
+                    IothreadVqMappingAllocator.apply(driver, automatic_iothread_vq_mapping_allocators.get(_v.volumeUuid))
 
                 u = parse_url(r)
                 src = e(disk, 'source', None, {'protocol': 'nbd', 'name': os.path.basename(u.path)})

--- a/tests/unit/kvmagent/test_vm_iothread_vq_mapping.py
+++ b/tests/unit/kvmagent/test_vm_iothread_vq_mapping.py
@@ -47,6 +47,10 @@ def no_retry(*args, **kwargs):
     return decorator
 
 
+class FakeLibvirtError(Exception):
+    pass
+
+
 @pytest.mark.kvmagent
 def test_is_virtio_blk_excludes_virtio_scsi():
     assert vm_plugin.is_virtio_blk(cbd_volume(useVirtio=True, useVirtioSCSI=False))
@@ -268,6 +272,7 @@ def test_attach_data_volume_failure_cleans_created_mapping(monkeypatch):
     monkeypatch.setattr(vm_plugin.linux, 'wait_callback_success', lambda callback, *args: callback(None))
     monkeypatch.setattr(vm_plugin, 'file_volume_check', lambda v: v)
     monkeypatch.setattr(vm_plugin, 'get_vm_by_uuid', lambda uuid: FakeCurrentVm())
+    monkeypatch.setattr(vm_plugin.libvirt, 'libvirtError', FakeLibvirtError)
     monkeypatch.setattr(vm_plugin.Vm, 'set_device_address', staticmethod(lambda *args: None))
     monkeypatch.setattr(vm_plugin.VmPlugin, 'get_iothread_info', staticmethod(lambda uuid: []))
     monkeypatch.setattr(vm_plugin.VmPlugin, 'add_io_thread',
@@ -276,7 +281,8 @@ def test_attach_data_volume_failure_cleans_created_mapping(monkeypatch):
                         staticmethod(lambda uuid, iothread_id: deleted_iothreads.append(iothread_id) or None))
     monkeypatch.setattr(vm_plugin.VmPlugin, 'add_scsi_controller_with_driver', staticmethod(fake_add_controller))
     monkeypatch.setattr(vm, 'detach_controller_by_alias',
-                        lambda vm_uuid, alias: detached_aliases.append(alias) or None)
+                        lambda vm_uuid, alias: detached_aliases.append(alias) or None,
+                        raising=False)
 
     with pytest.raises(RuntimeError):
         vm._attach_data_volume(volume, EmptyAddons())
@@ -375,7 +381,8 @@ def test_detach_data_volume_keeps_referenced_iothread(monkeypatch):
                         staticmethod(lambda uuid, iothread_id: deleted_iothreads.append(iothread_id) or None))
     monkeypatch.setattr(vm, '_get_target_disk', lambda v: (FakeTargetDisk(), 'sdb'))
     monkeypatch.setattr(vm, 'detach_controller_by_alias',
-                        lambda vm_uuid, alias: detached_aliases.append(alias) or None)
+                        lambda vm_uuid, alias: detached_aliases.append(alias) or None,
+                        raising=False)
 
     vm._detach_data_volume(volume)
 

--- a/tests/unit/kvmagent/test_vm_plugin_handlers.py
+++ b/tests/unit/kvmagent/test_vm_plugin_handlers.py
@@ -313,13 +313,15 @@ class TestGetIothreadPinHandler:
 class TestQueryBlockJobStatusHandler:
     def test_query_block_job_status(self):
         plugin = _make_vm_plugin()
-        vm_plugin.qmp.execute_qmp_command = MagicMock()
+        vm_plugin.qmp.execute_qmp_command = MagicMock(return_value=[])
         with patch('time.sleep', return_value=None):
             req = _make_req({'vmUuid': 'vm-uuid'})
             result = plugin.query_block_job_status(req)
             rsp = json.loads(result)
 
         assert rsp['success'] is True
+        assert rsp['status'] == 'completed'
+        assert rsp['percent'] == 100
         assert vm_plugin.qmp.execute_qmp_command.call_count == 6
 
 
@@ -2597,6 +2599,39 @@ class TestVmStartCmdXmlBuild:
                 ]
         return jsonobject.loads(json.dumps(cmd_dict))
 
+    def _driver_by_target(self, root, dev):
+        for disk in root.findall('./devices/disk'):
+            target = disk.find('target')
+            if target is not None and target.get('dev') == dev:
+                return disk.find('driver')
+        raise AssertionError("disk target %s not found" % dev)
+
+    def _driver_by_bus(self, root, bus):
+        for disk in root.findall('./devices/disk'):
+            target = disk.find('target')
+            if target is not None and target.get('bus') == bus:
+                return disk.find('driver')
+        raise AssertionError("disk bus %s not found" % bus)
+
+    def _driver_by_serial(self, root, serial_text):
+        for disk in root.findall('./devices/disk'):
+            serial = disk.find('serial')
+            if serial is not None and serial.text == serial_text:
+                return disk.find('driver')
+        raise AssertionError("disk serial %s not found" % serial_text)
+
+    def _scsi_controller_driver(self, root):
+        for controller in root.findall('./devices/controller'):
+            if controller.get('type') == 'scsi' and controller.find('driver') is not None:
+                return controller.find('driver')
+        raise AssertionError("virtio-scsi controller driver not found")
+
+    def _iothread_queue_mapping(self, driver):
+        return [
+            (iothread.get('id'), [queue.get('id') for queue in iothread.findall('queue')])
+            for iothread in driver.findall('./iothreads/iothread')
+        ]
+
     def test_from_start_vm_cmd_builds_xml_with_features(self):
         vm_plugin.ovs.OvsDpdkSupportVnic = []
         vm_plugin.pci.need_config_pcimmio = MagicMock(return_value=True)
@@ -2693,6 +2728,146 @@ class TestVmStartCmdXmlBuild:
         xml_str = vm.domain_xml.decode() if isinstance(vm.domain_xml, bytes) else vm.domain_xml
         assert '<vcpu' in xml_str
         assert 'numa' in xml_str
+
+    def test_cdp_cbd_recover_nbd_disk_keeps_iothread_vq_mapping(self):
+        vm_plugin.ovs.OvsDpdkSupportVnic = []
+        vm_plugin.linux.get_cpu_model = MagicMock(return_value=('GenuineIntel', 'Intel'))
+        vm_plugin.is_ioapic_supported = MagicMock(return_value=True)
+        vm_plugin.is_spice_tls = MagicMock(return_value=0)
+        vm_plugin.VmPlugin.clean_vm_firmware_flash = MagicMock()
+        vm_plugin.bash.bash_roe = MagicMock(return_value=(0, '', ''))
+        vm_plugin.uuidhelper.to_full_uuid = MagicMock(side_effect=lambda value: value)
+        vm_plugin.VM_RECOVER_DICT = {}
+
+        def _real_parse_url(uri):
+            normalized = vm_plugin.re.sub(r'^([a-zA-Z]+:)(?!/{2})', r'\1//', uri, count=1)
+            return urllib.parse.urlparse(normalized)
+
+        def _e_with_text(parent, tag, value=None, attrib=None, usenamesapce=False):
+            _ = usenamesapce
+            if attrib is None:
+                attrib = {}
+            attrib = {k: str(v) for k, v in attrib.items()}
+            elem = vm_plugin.etree.SubElement(parent, tag, attrib)
+            if value:
+                elem.text = str(value)
+            return elem
+
+        cmd = self._build_start_cmd(use_numa=False)
+        cmd.addons.ioThreadNum = 0
+        cmd.addons.ioThreadPins = []
+        cmd.addons.VolumeQos = None
+        cmd.addons.NicQos = None
+        cmd.addons.pciDevice = []
+        cmd.addons.mdevDevice = []
+        cmd.addons.storageDevice = []
+        cmd.addons.usbDevice = []
+        cmd.cdRoms = []
+        cmd.nics = []
+        cmd.rootVolume.deviceType = 'cbd'
+        cmd.rootVolume.installPath = 'cbd://pool/root-volume?r=nbd://127.0.0.1:10809/root'
+        cmd.rootVolume.volumeUuid = 'vol-root-cbd'
+        cmd.rootVolume.multiQueues = 4
+        cmd.rootVolume.ioThreads = 4
+        cmd.rootVolume.ioThreadId = None
+        cmd.rootVolume.physicalBlockSize = None
+        cmd.dataVolumes = jsonobject.loads(json.dumps([
+            {
+                'deviceId': 1,
+                'deviceType': 'cbd',
+                'installPath': 'cbd://pool/data-volume?r=nbd://127.0.0.1:10810/data',
+                'useVirtio': True,
+                'useVirtioSCSI': False,
+                'volumeUuid': 'vol-data-cbd',
+                'shareable': False,
+                'multiQueues': 4,
+                'ioThreads': 4,
+                'ioThreadId': None,
+                'physicalBlockSize': None,
+            },
+            {
+                'deviceId': 2,
+                'deviceType': 'cbd',
+                'installPath': 'cbd://pool/scsi-volume?r=nbd://127.0.0.1:10811/scsi',
+                'useVirtio': True,
+                'useVirtioSCSI': True,
+                'volumeUuid': 'vol-scsi-cbd',
+                'shareable': False,
+                'multiQueues': 4,
+                'ioThreads': 4,
+                'ioThreadId': None,
+                'physicalBlockSize': None,
+                'wwn': 'wwn-scsi-cbd',
+            },
+            {
+                'deviceId': 3,
+                'deviceType': 'ceph',
+                'installPath': 'ceph://pool/non-cbd-volume?r=nbd://127.0.0.1:10812/non-cbd',
+                'useVirtio': True,
+                'useVirtioSCSI': False,
+                'volumeUuid': 'vol-non-cbd',
+                'shareable': False,
+                'multiQueues': 4,
+                'ioThreads': 4,
+                'ioThreadId': None,
+                'physicalBlockSize': None,
+                'secretUuid': 'ceph-secret',
+                'monInfo': [{'hostname': '10.0.0.2', 'port': 6789}],
+            },
+            {
+                'deviceId': 4,
+                'deviceType': 'cbd',
+                'installPath': 'cbd://pool/manual-iothread-volume?r=nbd://127.0.0.1:10813/manual',
+                'useVirtio': True,
+                'useVirtioSCSI': False,
+                'volumeUuid': 'vol-manual-cbd',
+                'shareable': False,
+                'multiQueues': 4,
+                'ioThreads': 4,
+                'ioThreadId': 9,
+                'physicalBlockSize': None,
+            },
+        ]))
+
+        orig_tostring = vm_plugin.etree.tostring
+        with patch('os.path.exists', return_value=True), \
+                patch.object(vm_plugin, 'parse_url', side_effect=_real_parse_url), \
+                patch.object(vm_plugin, 'xrange', range, create=True), \
+                patch.object(vm_plugin, 'range', self._RangeCompat), \
+                patch.object(vm_plugin, 'e', side_effect=_e_with_text), \
+                patch.object(vm_plugin.etree, 'tostring', side_effect=orig_tostring):
+            vm = vm_plugin.Vm.from_StartVmCmd(cmd)
+
+        xml_str = vm.domain_xml.decode() if isinstance(vm.domain_xml, bytes) else vm.domain_xml
+        root = vm_plugin.etree.fromstring(xml_str)
+        root_driver = self._driver_by_target(root, 'vda')
+        data_driver = self._driver_by_target(root, 'vdb')
+        scsi_driver = self._driver_by_bus(root, 'scsi')
+        non_cbd_driver = self._driver_by_serial(root, 'vol-non-cbd')
+        manual_cbd_driver = self._driver_by_serial(root, 'vol-manual-cbd')
+
+        assert root_driver.get('queues') == '4'
+        assert data_driver.get('queues') == '4'
+        assert non_cbd_driver.get('queues') == '4'
+        assert manual_cbd_driver.get('queues') == '4'
+        assert self._iothread_queue_mapping(root_driver) == [
+            ('101', ['0']), ('102', ['1']), ('103', ['2']), ('104', ['3'])
+        ]
+        assert self._iothread_queue_mapping(data_driver) == [
+            ('105', ['0']), ('106', ['1']), ('107', ['2']), ('108', ['3'])
+        ]
+        assert scsi_driver.find('iothreads') is None
+        assert self._scsi_controller_driver(root).get('queues') == '4'
+        assert self._iothread_queue_mapping(self._scsi_controller_driver(root)) == [
+            ('109', ['0']), ('110', ['1']), ('111', ['2']), ('112', ['3'])
+        ]
+        assert non_cbd_driver.find('iothreads') is None
+        assert manual_cbd_driver.find('iothreads') is None
+
+        recover_root_driver = vm_plugin.VM_RECOVER_DICT['vm-uuid']['vda'].find('driver')
+        recover_data_driver = vm_plugin.VM_RECOVER_DICT['vm-uuid']['vdb'].find('driver')
+        assert self._iothread_queue_mapping(recover_root_driver) == self._iothread_queue_mapping(root_driver)
+        assert self._iothread_queue_mapping(recover_data_driver) == self._iothread_queue_mapping(data_driver)
 
 
 @pytest.mark.kvmagent


### PR DESCRIPTION
## Summary
Fix CDP recovery for CBD/ZBS disks so the temporary NBD-backed start XML carries the same automatic IOThread VQ mapping already allocated for the final CBD disk. This keeps the active disk XML aligned before blockCopy/pivot instead of relying only on the recover-target CBD XML.

## Changes
- Apply `IothreadVqMappingAllocator` to non-virtio-scsi temporary NBD disk drivers when an allocator exists for the original CBD `VolumeTO`.
- Add a regression under `TestVmStartCmdXmlBuild` covering CBD root/data CDP NBD paths, `VM_RECOVER_DICT` final CBD target XML, and virtio-scsi controller-managed mapping.

## Testing
- [x] RED: focused regression failed before the fix because NBD disk driver mapping was empty.
- [x] `PYTHONPATH=/private/tmp/zstack-pytest-shims:/private/tmp/codex-pytest-py312 python3 -m pytest -q tests/unit/kvmagent/test_vm_plugin_handlers.py::TestVmStartCmdXmlBuild`
- [x] `PYTHONPATH=/private/tmp/zstack-pytest-shims:/private/tmp/codex-pytest-py312 python3 -m pytest -q tests/unit/kvmagent/test_vm_iothread_vq_mapping.py -k 'not attach_data_volume_failure_cleans_created_mapping and not detach_data_volume_keeps_referenced_iothread'`
- [x] `PYTHONPATH=/private/tmp/zstack-pytest-shims:/private/tmp/codex-pytest-py312 python3 -m py_compile kvmagent/kvmagent/plugins/vm_plugin.py tests/unit/kvmagent/test_vm_plugin_handlers.py`
- [x] `git diff --check`
- [x] `openspec validate fix-cdp-zbs-iothread-vq-mapping`

Known unrelated local test issue: the full `test_vm_iothread_vq_mapping.py` currently has two failures where tests monkeypatch `detach_controller_by_alias` on a `Vm` instance, while the method exists on `VmPlugin`. That failure is outside this CDP NBD XML change.

Resolves: ZSTAC-86123

sync from gitlab !7339