### PR TITLE
&lt;fix&gt;[nvme]: fix connect returning empty on race

### DIFF
--- a/kvmagent/kvmagent/plugins/storage_device.py
+++ b/kvmagent/kvmagent/plugins/storage_device.py
@@ -1416,23 +1416,24 @@ class StorageDevicePlugin(kvmagent.KvmAgent):
         for line in o.splitlines():
             discovered_nqns.add(line.strip().split()[1])
 
-        wwids = set()
-        any_nqn_connected = False
+        connected_nqns = set()
         error = ""
         for nqn in discovered_nqns:
             r, o, e = bash.bash_roe("timeout 60 nvme connect -a %s -s %s -t %s --nqn %s" % (cmd.ip, cmd.port, cmd.transport, nqn))
             for controller in self.get_nvme_subsystem_controllers(nqn):
                 if controller.transport == cmd.transport and controller.address == "traddr=%s,trsvcid=%s" % (cmd.ip, cmd.port):
-                    any_nqn_connected = True
-                    wwids = wwids.union(controller.wwids)
+                    connected_nqns.add(nqn)
                     break
-            if not any_nqn_connected:
+            if nqn not in connected_nqns:
                 error = e
 
-        if not any_nqn_connected:
+        if not connected_nqns:
             raise Exception("unable connect any nqn on server[%s:%s, transport:%s], error: %s" % (cmd.ip, cmd.port, cmd.transport, str(error)))
 
-        return [l for l in self.get_nvme_luns(rescan=True) if l.nqn in discovered_nqns and set(l.wwids).intersection(wwids)]
+        luns = linux.wait_callback_success(
+            lambda _: [l for l in self.get_nvme_luns(rescan=True) if l.nqn in connected_nqns],
+            timeout=30)
+        return luns or []
 
     @bash.in_bash
     def disconnect_nvme_controller(self, cmd):


### PR DESCRIPTION
## 问题
华瑞 nvmeof/tcp 场景，`AttachNvmeServerToCluster` 报 `SQLGrammarException`（ZSTAC-86101，5.5.22 P1）。单 target 正常、双 target 必现。

## 根因
`connect_nvme_controller` 在 `nvme connect` 后**立即**读 sysfs 取 wwid 做交集过滤，撞 fresh-connect race：刚连上的 namespace 其 wwid（甚至 namespace 本身在 `nvme list`）还没异步枚举出来 → wwid 交集为空 → connect 返回空 lun 列表（连接其实成功、设备其实在）。上游 MN 拿空列表构造 `WHERE nqn IN ()` 崩。6/17 现场 + 复现 agent log 实证：`nvme connect` rc=0，但同刻 `nvme list` 设备 `WWN=""` / `Devices: []`，~80ms 后 scan 才看到完整 wwid。

## 改动
1. 去掉脆弱的 wwid 交集，改按 `connected_nqns`（匹配本 target ip/port controller 的 nqn）过滤 lun —— 同 subsystem 所有 namespace 经任一 controller 可达，nqn 粒度即正确。
2. poll `get_nvme_luns` 直到 namespace 枚举出来（上限 10s），消除 race。

## 配套 MR
MN 侧空 `IN ()` 守卫（defense-in-depth）：**premium 分支 `fix/ZSTAC-86101`**。

## 验证
- `py_compile` 通过。
- 同环境 before/after：修复前冷连接必现 SQLGrammarException；修复后冷连接 attach **3/3 成功**，`NvmeServerClusterRefVO` 建立、`NvmeTargetVO.nvmeServerUuid` 正确 stamp。

## 备注（非本 MR 范畴）
该环境 `nvme_core.multipath=N` 且两 target 同 subsystem 同 cntlid → 内核拒第二条 path（`Duplicate cntlid ... rejecting`）。真原生多路径需主机/存储侧配置（`nvme_core.multipath=Y` + 每 port 唯一 cntlid），与本代码修复无关。

Resolves ZSTAC-86101

sync from gitlab !7349