### PR TITLE
ZSTAC-70407 fix qga pushgateway auth

### DIFF
--- a/kvmagent/kvmagent/plugins/host_pushgateway.py
+++ b/kvmagent/kvmagent/plugins/host_pushgateway.py
@@ -1,0 +1,48 @@
+import glob
+import re
+
+
+DEFAULT_HOST_PUSHGATEWAY_AUTH_HEADER = "Basic YWRtaW46enN0YWNrQDEyMw=="
+LIGHTTPD_CONF_GLOBS = [
+    "/var/lib/zstack/userdata/*/lighttpd.conf",
+    "/var/lib/zstack/tf_userdata/lighttpd.conf",
+]
+AUTH_HEADER_PATTERN = re.compile(r'Authorization"\s*=>\s*"([^"]+)"')
+
+
+def get_auth_header(conf_paths=None):
+    if conf_paths is None:
+        conf_paths = []
+        for pattern in LIGHTTPD_CONF_GLOBS:
+            conf_paths.extend(glob.glob(pattern))
+
+    for conf_path in conf_paths:
+        try:
+            with open(conf_path, "r") as fd:
+                match = AUTH_HEADER_PATTERN.search(fd.read())
+                if match:
+                    return match.group(1)
+        except Exception:
+            pass
+
+    return DEFAULT_HOST_PUSHGATEWAY_AUTH_HEADER
+
+
+def make_push_metrics_headers():
+    return {
+        "Content-Type": "application/json",
+        "Authorization": get_auth_header()
+    }
+
+
+def make_get_metrics_headers():
+    return {
+        "Content-Type": "text/plain",
+        "Authorization": get_auth_header()
+    }
+
+
+def make_delete_metric_headers():
+    return {
+        "Authorization": get_auth_header()
+    }

--- a/kvmagent/kvmagent/plugins/qga_zwatch.py
+++ b/kvmagent/kvmagent/plugins/qga_zwatch.py
@@ -11,6 +11,7 @@ from zstacklib.utils import lock
 from zstacklib.utils import log
 from zstacklib.utils import thread
 from zstacklib.utils.qga import VmQga
+from kvmagent.plugins import host_pushgateway
 from kvmagent.plugins import vm_plugin
 
 log.configure_log('/var/log/zstack/zstack-kvmagent.log')
@@ -321,9 +322,7 @@ def get_guest_tools_states(domains):
 def push_metrics_to_gateway(url, uuid, metrics):
     url = url + uuid
     metrics += "\n\n"
-    headers = {
-        "Content-Type": "application/json"
-    }
+    headers = host_pushgateway.make_push_metrics_headers()
     rsp = http.json_post(url, body=metrics, headers=headers)
     logger.debug('vm[%s] push metric with rsp[%s]' % (uuid, rsp))
 
@@ -372,4 +371,3 @@ def get_nic_info_for_windows_2008(uuid, qga):
     mac_to_ip_json = json.dumps(mac_to_ip, indent=4)
     logger.debug('vm[%s] get nic info all: [%s]' % (uuid, mac_to_ip_json))
     return mac_to_ip_json
-

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -49,12 +49,14 @@ from kvmagent import kvmagent
 from kvmagent.plugins.baremetal_v2_gateway_agent import \
     BaremetalV2GatewayAgentPlugin as BmV2GwAgent
 from kvmagent.plugins.bmv2_gateway_agent import utils as bm_utils
+from kvmagent.plugins import host_pushgateway
 from kvmagent.plugins.imagestore import ImageStoreClient
 from kvmagent.plugins.shared_block_plugin import MAX_ACTUAL_SIZE_FACTOR
 from kvmagent.plugins.volume_cache.command_wrapper.virsh import VirshCommandWrapper as CacheVirshWrapper
 from kvmagent.plugins.volume_cache.command_wrapper.qemu_img import BackingVolumeDeviceType, supported_backing_volume_classes
 from zstacklib.utils import bash, plugin, iscsi, gpu
 from zstacklib.utils.bash import in_bash
+from zstacklib.utils import http
 from zstacklib.utils import lvm
 from zstacklib.utils import ft
 from zstacklib.utils import shell
@@ -11775,7 +11777,7 @@ host side snapshot files chian:
             if bind_addresses:
                 port = bind_addresses[0].split(':')[-1]
                 url = 'http://localhost:%s/metrics' % port
-                result = http.json_post(url, body=None, headers={'Content-Type':'text/plain'}, method='GET')
+                result = http.json_post(url, body=None, headers=host_pushgateway.make_get_metrics_headers(), method='GET')
                 lines = [line for line in result.split('\n') if line.startswith('push_time_seconds') and line.find(vm_uuid) >= 0]
                 if lines:
                     push_time_seconds = float(lines[0].split(' ')[-1])
@@ -13713,7 +13715,7 @@ host side snapshot files chian:
                     break
             vm_uuid = dom.name()
             url = "http://localhost:%s/metrics/job/zwatch_vm_agent/vmUuid/%s" % (port, vm_uuid)
-            shell.run('curl -X DELETE ' + url)
+            http.json_post(url, body=None, headers=host_pushgateway.make_delete_metric_headers(), method='DELETE')
         except Exception as e:
             logger.warn("delete pushgateway metric when vm stoped failed: %s" % str(e))
 

--- a/kvmagent/kvmagent/test/test_host_pushgateway.py
+++ b/kvmagent/kvmagent/test/test_host_pushgateway.py
@@ -1,0 +1,49 @@
+import os
+import tempfile
+import unittest
+
+from kvmagent.plugins import host_pushgateway
+
+
+class TestHostPushgateway(unittest.TestCase):
+    def test_get_auth_header_reads_lighttpd_config(self):
+        fd, path = tempfile.mkstemp()
+        try:
+            os.write(fd, b'setenv.add-request-header = ( "Authorization" => "Basic custom" )')
+            os.close(fd)
+
+            self.assertEqual("Basic custom", host_pushgateway.get_auth_header([path]))
+        finally:
+            if fd:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            os.remove(path)
+
+    def test_get_auth_header_falls_back_to_product_default(self):
+        self.assertEqual(
+            host_pushgateway.DEFAULT_HOST_PUSHGATEWAY_AUTH_HEADER,
+            host_pushgateway.get_auth_header([])
+        )
+
+    def test_make_push_metrics_headers_adds_basic_auth(self):
+        headers = host_pushgateway.make_push_metrics_headers()
+
+        self.assertEqual("application/json", headers["Content-Type"])
+        self.assertEqual(host_pushgateway.DEFAULT_HOST_PUSHGATEWAY_AUTH_HEADER, headers["Authorization"])
+
+    def test_make_get_metrics_headers_adds_basic_auth(self):
+        headers = host_pushgateway.make_get_metrics_headers()
+
+        self.assertEqual("text/plain", headers["Content-Type"])
+        self.assertEqual(host_pushgateway.DEFAULT_HOST_PUSHGATEWAY_AUTH_HEADER, headers["Authorization"])
+
+    def test_make_delete_metric_headers_adds_basic_auth(self):
+        headers = host_pushgateway.make_delete_metric_headers()
+
+        self.assertEqual(host_pushgateway.DEFAULT_HOST_PUSHGATEWAY_AUTH_HEADER, headers["Authorization"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Root cause:
ZSTAC-70407 enabled Basic Auth for host pushgateway. The DHCP/metadata path is protected by lighttpd, which injects Authorization before proxying to pushgateway, but qga_zwatch pushes metrics directly from host to 127.0.0.1:9092 and did not send auth. VM stop cleanup and metrics status GET also used direct host pushgateway calls without auth.

Fix solution:
- Add host pushgateway auth helper in kvmagent.
- QGA zwatch metrics POST now sends Authorization.
- VM metrics routing status GET now sends Authorization.
- VM stop pushgateway metric cleanup now uses http DELETE with Authorization instead of curl, avoiding credential exposure in shell logs/process list.
- Auth helper reuses Authorization from existing lighttpd.conf when present and falls back to the current product default.

Verification:
- PYTHONPATH=kvmagent:zstacklib python kvmagent/kvmagent/test/test_host_pushgateway.py: PASS, 5 tests.
- python -m py_compile changed files: PASS, only existing vm_plugin.py invalid escape SyntaxWarning.
- git diff --check: PASS.
- Remote Codex review loop: final pass, no actionable correctness issues.

Note:
MR 7355 was closed because it was accidentally created with the upstream project as both source and target. This MR is created from fork project 1312 to upstream project 1233.

sync from gitlab !7356