### PR TITLE
<fix>[kvm]: ZSTAC-86355 persist vm cpu shares

### DIFF
--- a/tests/unit/zstacklib/test_vm_priority.py
+++ b/tests/unit/zstacklib/test_vm_priority.py
@@ -1,0 +1,66 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+
+def _load_linux_module():
+    linux_path = Path(__file__).resolve().parents[3] / "zstacklib/zstacklib/utils/linux.py"
+    spec = importlib.util.spec_from_file_location("linux_vm_priority_under_test", str(linux_path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fake_shell_cmd(return_codes):
+    calls = []
+
+    class FakeShellCmd(object):
+        def __init__(self, cmd):
+            self.cmd = cmd
+            self.return_code = 0
+
+        def __call__(self, is_exception=True):
+            calls.append((self.cmd, is_exception))
+            self.return_code = return_codes.pop(0) if return_codes else 0
+
+    return FakeShellCmd, calls
+
+
+def test_set_vm_priority_updates_live_and_config(monkeypatch):
+    linux = _load_linux_module()
+    shell_cmd, calls = _fake_shell_cmd([0, 0])
+    priority = SimpleNamespace(vmUuid="vm-uuid", cpuShares=1024, oomScoreAdj=-900)
+    write_file = Mock(return_value=True)
+
+    monkeypatch.setattr(linux.shell, "ShellCmd", shell_cmd)
+    monkeypatch.setattr(linux, "write_file", write_file)
+
+    linux.set_vm_priority("1234", priority)
+
+    assert calls == [
+        ("virsh schedinfo vm-uuid --set cpu_shares=1024 --live", False),
+        ("virsh schedinfo vm-uuid --set cpu_shares=1024 --config", False),
+    ]
+    write_file.assert_called_once_with("/proc/1234/oom_score_adj", -900)
+
+
+def test_set_vm_priority_keeps_oom_score_when_config_update_fails(monkeypatch):
+    linux = _load_linux_module()
+    shell_cmd, calls = _fake_shell_cmd([0, 1])
+    priority = SimpleNamespace(vmUuid="vm-uuid", cpuShares=1024, oomScoreAdj=-900)
+    write_file = Mock(return_value=True)
+    logger = Mock()
+
+    monkeypatch.setattr(linux.shell, "ShellCmd", shell_cmd)
+    monkeypatch.setattr(linux, "write_file", write_file)
+    monkeypatch.setattr(linux, "logger", logger)
+
+    linux.set_vm_priority("1234", priority)
+
+    assert calls == [
+        ("virsh schedinfo vm-uuid --set cpu_shares=1024 --live", False),
+        ("virsh schedinfo vm-uuid --set cpu_shares=1024 --config", False),
+    ]
+    write_file.assert_called_once_with("/proc/1234/oom_score_adj", -900)
+    logger.warn.assert_called_once_with("set vm vm-uuid config cpu_shares failed")

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -2185,10 +2185,11 @@ def enable_process_coredump(pid):
     shell.run('prlimit --core=%d --pid %s' % (memsize, pid))
 
 def set_vm_priority(pid, priorityConfig):
-    cmd = shell.ShellCmd("virsh schedinfo %s --set cpu_shares=%s --live" % (priorityConfig.vmUuid, priorityConfig.cpuShares))
-    cmd(is_exception=False)
-    if cmd.return_code != 0:
-        logger.warn("set vm %s cpu_shares failed" % priorityConfig.vmUuid)
+    for scope in ["--live", "--config"]:
+        cmd = shell.ShellCmd("virsh schedinfo %s --set cpu_shares=%s %s" % (priorityConfig.vmUuid, priorityConfig.cpuShares, scope))
+        cmd(is_exception=False)
+        if cmd.return_code != 0:
+            logger.warn("set vm %s %s cpu_shares failed" % (priorityConfig.vmUuid, scope[2:]))
 
     oom_score_adj_path = "/proc/%s/oom_score_adj" % pid
     if write_file(oom_score_adj_path, priorityConfig.oomScoreAdj) is None:


### PR DESCRIPTION
## Summary
Fix ZSTAC-86355: on ARM/ALinux4, VM `cpu_shares` can fall back to the libvirt default value after `libvirtd` restarts because VM priority was only applied to the live scheduler config.

## Changes
- Apply VM `cpu_shares` to both live and persistent libvirt scheduler config.
- Keep the existing live update behavior and only warn if the persistent config update fails.
- Add unit coverage for the command sequence and config-update fallback.

## Testing
- [x] `python3 -m py_compile zstacklib/zstacklib/utils/linux.py tests/unit/zstacklib/test_vm_priority.py`
- [x] Mocked `set_vm_priority` smoke test for live/config command sequence and fallback behavior
- [x] Manual validation on ARM/ALinux4 test host that `virsh schedinfo <vm> --set cpu_shares=1024 --config` persists `<cputune><shares>1024</shares></cputune>` into inactive XML
- [ ] `pytest -q tests/unit/zstacklib/test_vm_priority.py` (not run locally: pytest is not installed)
- [ ] Full kvmagent integration test / deployed libvirtd restart regression

Resolves: ZSTAC-86355

sync from gitlab !7365