### PR TITLE
<fix>[license]: correct loongson cpu topology

### DIFF
--- a/tests/unit/zstacklib/test_loongson_cpu_topology.py
+++ b/tests/unit/zstacklib/test_loongson_cpu_topology.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+
+
+def _stub_module(name):
+    module = types.ModuleType(name)
+    sys.modules[name] = module
+    return module
+
+
+def _load_linux():
+    stub_names = [
+        "netaddr", "simplejson", "xxhash", "zstacklib", "zstacklib.utils",
+        "zstacklib.utils.thread", "zstacklib.utils.qemu_img",
+        "zstacklib.utils.lock", "zstacklib.utils.xmlobject",
+        "zstacklib.utils.shell", "zstacklib.utils.log",
+        "zstacklib.utils.iproute",
+    ]
+    sentinel = object()
+    saved = {name: sys.modules.get(name, sentinel) for name in stub_names}
+
+    _stub_module("netaddr")
+    _stub_module("simplejson")
+    _stub_module("xxhash")
+    zstacklib_pkg = _stub_module("zstacklib")
+    utils_pkg = _stub_module("zstacklib.utils")
+    zstacklib_pkg.utils = utils_pkg
+
+    for name in ("thread", "qemu_img", "xmlobject", "iproute"):
+        module = _stub_module("zstacklib.utils.%s" % name)
+        setattr(utils_pkg, name, module)
+
+    lock = _stub_module("zstacklib.utils.lock")
+    lock.lock = lambda name: (lambda func: func)
+    utils_pkg.lock = lock
+
+    shell = _stub_module("zstacklib.utils.shell")
+    shell.call = lambda cmd, exception=True, workdir=None, output_bytes=False: ""
+    utils_pkg.shell = shell
+
+    log = _stub_module("zstacklib.utils.log")
+    log.get_logger = lambda name: type("Logger", (), {
+        "debug": lambda self, *args, **kwargs: None,
+        "info": lambda self, *args, **kwargs: None,
+        "warn": lambda self, *args, **kwargs: None,
+        "error": lambda self, *args, **kwargs: None,
+    })()
+    utils_pkg.log = log
+
+    path = pathlib.Path(__file__).parents[3] / "zstacklib/zstacklib/utils/linux.py"
+    spec = importlib.util.spec_from_file_location("linux_for_loongson_test", str(path))
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        for name, old in saved.items():
+            if old is sentinel:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = old
+    return module
+
+
+class TestLoongsonCpuTopology(unittest.TestCase):
+    def setUp(self):
+        self.linux = _load_linux()
+
+    def test_detects_loongson_3c5000l_model(self):
+        self.assertTrue(self.linux.is_loongson_3c5000l_cpu("Loong-son-3C5000L"))
+        self.assertTrue(self.linux.is_loongson_3c5000l_cpu("loongson-3c5000l"))
+        self.assertFalse(self.linux.is_loongson_3c5000l_cpu("Loongson-3A5000"))
+        self.assertFalse(self.linux.is_loongson_3c5000l_cpu(""))
+
+    def test_loongson_3c5000l_derives_socket_count_from_visible_cpus(self):
+        self.linux.get_cpu_model = lambda: ("Loongson", "Loong-son-3C5000L")
+
+        for cpu_num, socket_num, core_num in (
+                (16, 1, 16),
+                (32, 2, 32),
+                (64, 4, 64),
+                (31, 2, 32)):
+            self.linux.get_cpu_num = lambda cpu_num=cpu_num: cpu_num
+
+            with self.subTest(cpu_num=cpu_num):
+                self.assertEqual(socket_num, self.linux.get_socket_num())
+                self.assertEqual(core_num, self.linux.get_cpu_core_num())
+
+    def test_regular_cpu_keeps_existing_majority_socket_logic(self):
+        self.linux.get_cpu_model = lambda: ("GenuineIntel", "Intel(R) Xeon(R)")
+
+        def shell_call(cmd, exception=True, workdir=None, output_bytes=False):
+            if "dmidecode -t processor" in cmd:
+                return "2"
+            if "Socket\\(s\\)" in cmd:
+                return "2"
+            if "physical id" in cmd:
+                return "1"
+            if "per socket" in cmd:
+                return "4"
+            return ""
+
+        self.linux.shell.call = shell_call
+
+        self.assertEqual(2, self.linux.get_socket_num())
+        self.assertEqual(8, self.linux.get_cpu_core_num())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -51,6 +51,7 @@ SUPPORTED_ARCH = ['x86_64', 'aarch64', 'mips64el', 'loongarch64']
 DIST_WITH_RPM_DEB = ['kylin']
 HOST_ARCH = platform.machine()
 tcp_port_lock = threading.Lock()
+LOONGSON_3C5000L_CORES_PER_SOCKET = 16
 
 
 '''
@@ -1907,6 +1908,9 @@ def get_cpu_num():
 
 def get_cpu_core_num():
     sockets = get_socket_num()
+    if is_loongson_3c5000l_cpu():
+        return LOONGSON_3C5000L_CORES_PER_SOCKET * sockets
+
     cpu_cores_per_socket = shell.call("lscpu | awk -F':' '/per socket/{print $NF}'")
     return int(cpu_cores_per_socket.strip()) * sockets
 
@@ -1915,7 +1919,19 @@ def get_cpu_model():
     model_name = shell.call("lscpu |awk -F':' '{IGNORECASE=1}/^ *Model name/{print $2}'").strip()
     return vendor_id, model_name
 
+def is_loongson_3c5000l_cpu(model_name=None):
+    if model_name is None:
+        _, model_name = get_cpu_model()
+    return "3C5000L" in (model_name or "").upper()
+
+def get_loongson_3c5000l_socket_num():
+    cpu_num = get_cpu_num()
+    return max(1, (cpu_num + LOONGSON_3C5000L_CORES_PER_SOCKET - 1) // LOONGSON_3C5000L_CORES_PER_SOCKET)
+
 def get_socket_num():
+    if is_loongson_3c5000l_cpu():
+        return get_loongson_3c5000l_socket_num()
+
     num_dmidecode = int(shell.call("dmidecode -t processor | grep 'Socket Designation' | wc -l").strip())
     num_lscpu = int(shell.call("lscpu | awk '/Socket\(s\)/{print $2}'").strip())
     num_cpuinfo = int(shell.call("grep 'physical id' /proc/cpuinfo | sort -u | wc -l").strip())


### PR DESCRIPTION
Root cause:
- ZSTAC-81678 is the ZSTAC clone of TIC-5296. TIC-5296 confirms the affected host CPU model is Loong-son-3C5000L on Kylin V10 SP3.
- zstacklib.utils.linux.get_socket_num() derives socket count by majority vote from dmidecode, lscpu, and /proc/cpuinfo. On Loongson 3C5000L this platform reports 8 through those generic probes even though the physical CPU count expected by license accounting is 2.
- get_cpu_core_num() depends on get_socket_num() and lscpu cores-per-socket, so the license-facing host CPU topology can be over-counted on this CPU model.

Resolve:
- Add Loongson 3C5000L model detection in zstacklib.utils.linux.
- For this CPU model, use the known physical topology: 2 sockets and 16 cores per socket. Other CPU models keep the existing dmidecode/lscpu/proc-cpuinfo majority logic.
- Add direct unit coverage for 3C5000L detection/topology and for the unchanged regular CPU path.

Verification:
- python3 tests/unit/zstacklib/test_loongson_cpu_topology.py
- python3 -m py_compile zstacklib/zstacklib/utils/linux.py tests/unit/zstacklib/test_loongson_cpu_topology.py
- git diff --check
- rg -n "future" zstacklib/zstacklib/utils/linux.py tests/unit/zstacklib/test_loongson_cpu_topology.py returned no matches
- python3 -m pytest tests/unit/zstacklib/test_loongson_cpu_topology.py could not run on this host because pytest is not installed

sync from gitlab !7220