### PR TITLE
<feature>[zbs]: merge zbs to 5.5.28

### DIFF
--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -1838,14 +1838,15 @@ class HostPlugin(kvmagent.KvmAgent):
                 rsp.powerSupplyMaxPowerCapacity = ''.join(re.findall(r'\d+', power_supply_max_power_capacity.strip()))
 
         rsp.qemuImgVersion = qemu_img_version
+        qemu_package_name = "qemu" if IS_AARCH64 else "qemu-kvm"
         if self.IS_YUM:
             try:
-                rsp.qemuKvmPackageVersion = linux.get_rpm_version("qemu-kvm")
+                rsp.qemuKvmPackageVersion = linux.get_rpm_version(qemu_package_name)
             except Exception as e:
-                logger.error("failed to get qemu-kvm rpm version for host[uuid:%s]: %s" % (self.host_uuid, str(e)))
+                logger.error("failed to get %s rpm version for host[uuid:%s]: %s" % (qemu_package_name, self.host_uuid, str(e)))
                 rsp.qemuKvmPackageVersion = None
         else:
-            logger.debug("qemu-kvm package version is only reported on RPM-based host[uuid:%s]; automatic IOThread VQ mapping capability will not be enabled" % self.host_uuid)
+            logger.debug("%s package version is only reported on RPM-based host[uuid:%s]; automatic IOThread VQ mapping capability will not be enabled" % (qemu_package_name, self.host_uuid))
         rsp.libvirtVersion = self.libvirt_version
         rsp.libvirtPackageVersion = linux.get_libvirt_package_version()
         rsp.ipAddresses = ip_addrs

--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -134,6 +134,7 @@ class HostFactResponse(kvmagent.AgentResponse):
         self.osVersion = None
         self.osRelease = None
         self.qemuImgVersion = None
+        self.qemuKvmPackageVersion = None
         self.libvirtVersion = None
         self.hvmCpuFlag = None
         self.cpuModelName = None
@@ -1837,6 +1838,14 @@ class HostPlugin(kvmagent.KvmAgent):
                 rsp.powerSupplyMaxPowerCapacity = ''.join(re.findall(r'\d+', power_supply_max_power_capacity.strip()))
 
         rsp.qemuImgVersion = qemu_img_version
+        if self.IS_YUM:
+            try:
+                rsp.qemuKvmPackageVersion = linux.get_rpm_version("qemu-kvm")
+            except Exception as e:
+                logger.error("failed to get qemu-kvm rpm version for host[uuid:%s]: %s" % (self.host_uuid, str(e)))
+                rsp.qemuKvmPackageVersion = None
+        else:
+            logger.debug("qemu-kvm package version is only reported on RPM-based host[uuid:%s]; automatic IOThread VQ mapping capability will not be enabled" % self.host_uuid)
         rsp.libvirtVersion = self.libvirt_version
         rsp.libvirtPackageVersion = linux.get_libvirt_package_version()
         rsp.ipAddresses = ip_addrs

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -3285,30 +3285,68 @@ class Vm(object):
 
         target = disk_element.find('target')
         bus = target.get('bus') if target is not None else None
+        persisted_address = vol.deviceAddress
 
-        if vol.deviceAddress and vol.deviceAddress.type == 'pci' and Vm._get_disk_address_type(bus) == 'pci':
-            attributes = {}
-            if vol.deviceAddress.domain:
-                attributes['domain'] = vol.deviceAddress.domain
-            if vol.deviceAddress.bus:
-                attributes['bus'] = vol.deviceAddress.bus
-            if vol.deviceAddress.slot:
-                attributes['slot'] = vol.deviceAddress.slot
-            if vol.deviceAddress.function:
-                attributes['function'] = vol.deviceAddress.function
+        def has_persisted_address_type(address_type):
+            return bool(persisted_address and persisted_address.type == address_type)
 
-            attributes['type'] = vol.deviceAddress.type
-            e(disk_element, 'address', None, attributes)
-        elif vol.deviceAddress and vol.deviceAddress.type == 'drive' and Vm._get_disk_address_type(bus) == 'drive':
-            e(disk_element, 'address', None, {'type': 'drive', 'controller': vol.deviceAddress.controller, 'unit': str(vol.deviceAddress.unit)})
-        elif bus == 'scsi':
-            occupied_units = vm_to_attach.get_occupied_disk_address_units(bus='scsi', controller=0) if vm_to_attach else []
-            default_unit = Vm.get_device_unit(vol.deviceId)
-            unit = default_unit if default_unit not in occupied_units else max(occupied_units) + 1
-            controller = '0'
-            if vol.useVirtioSCSI and vol.hasattr("controllerIndex") and vol.controllerIndex:
-               controller = str(vol.controllerIndex)
+        def set_drive_address(controller, unit):
             e(disk_element, 'address', None, {'type': 'drive', 'controller': controller, 'unit': str(unit)})
+
+        match bus:
+            case 'virtio':
+                if not has_persisted_address_type('pci'):
+                    return
+
+                attributes = {}
+                if persisted_address.domain:
+                    attributes['domain'] = persisted_address.domain
+                if persisted_address.bus:
+                    attributes['bus'] = persisted_address.bus
+                if persisted_address.slot:
+                    attributes['slot'] = persisted_address.slot
+                if persisted_address.function:
+                    attributes['function'] = persisted_address.function
+
+                attributes['type'] = persisted_address.type
+                e(disk_element, 'address', None, attributes)
+                return
+
+            case 'scsi':
+                has_persisted_drive_address = has_persisted_address_type('drive')
+                if has_persisted_drive_address and Vm._can_reuse_persisted_scsi_drive_address(vol):
+                    set_drive_address(persisted_address.controller, persisted_address.unit)
+                    return
+
+                if has_persisted_drive_address:
+                    logger.debug('discard stale drive address controller=%s for volume[%s], replan to scsi topology' %
+                                 (persisted_address.controller, vol.volumeUuid))
+                controller = Vm._planned_scsi_controller(vol) or 0
+                occupied_units = vm_to_attach.get_occupied_disk_address_units(bus='scsi', controller=controller) if vm_to_attach else []
+                default_unit = Vm.get_device_unit(vol.deviceId)
+                unit = default_unit if default_unit not in occupied_units else max(occupied_units) + 1
+                set_drive_address(str(controller), unit)
+
+            case 'sata' | 'ide':
+                if has_persisted_address_type('drive'):
+                    set_drive_address(persisted_address.controller, persisted_address.unit)
+
+    @staticmethod
+    def _can_reuse_persisted_scsi_drive_address(vol):
+        controller = vol.deviceAddress.controller
+        unit = vol.deviceAddress.unit
+
+        if controller in (None, '') or unit in (None, ''):
+            return False
+
+        return IothreadVqMappingAllocator.to_int(controller) == Vm._planned_scsi_controller(vol)
+
+    @staticmethod
+    def _planned_scsi_controller(vol):
+        if not IothreadVqMappingAllocator.needs_dedicated_scsi_controller(vol):
+            return 0
+        controller_index = IothreadVqMappingAllocator.to_int(vol.controllerIndex)
+        return controller_index if controller_index else None
 
     def __init__(self):
         self.uuid = None

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -2215,6 +2215,10 @@ class BlkCeph(object):
         return disk
 
 
+def is_virtio_blk(volume):
+    return bool(volume.useVirtio) and not bool(volume.useVirtioSCSI)
+
+
 class VirtioCeph(object):
     def __init__(self):
         self.volume = None
@@ -2223,7 +2227,7 @@ class VirtioCeph(object):
     def to_xmlobject(self):
         disk = etree.Element('disk', {'type': 'network', 'device': 'disk'})
         driver_elements = {'name': 'qemu', 'type': 'raw', 'cache': 'none', 'discard': 'unmap'}
-        if self.volume.hasattr("multiQueues") and self.volume.multiQueues:
+        if is_virtio_blk(self.volume) and self.volume.multiQueues:
             driver_elements["queues"] = self.volume.multiQueues
         if self.volume.hasattr("ioThreadId") and self.volume.ioThreadId:
             driver_elements["iothread"] = str(self.volume.ioThreadId)
@@ -2871,6 +2875,222 @@ def make_spool_conf(imgfmt, dev_letter, volume):
 
 def make_cbd_conf(install_path):
     return install_path[len(PROTOCOL_CBD_PREFIX):] + "_" + DEFAULT_ZBS_USER_NAME + "_:" + DEFAULT_ZBS_CONF_PATH
+
+
+AUTOMATIC_IOTHREAD_ID_START = 101
+AUTOMATIC_IOTHREAD_ID_LIMIT = 65535
+
+
+class IothreadVqMappingAllocator(object):
+    def __init__(self, volume_uuid, queue_count, iothread_ids):
+        self.volume_uuid = volume_uuid
+        self.iothread_ids = iothread_ids
+        self.queue_ids_by_iothread = self._queue_ids_by_iothread(queue_count, iothread_ids)
+
+    @classmethod
+    def allocate(cls, volume, used_iothread_ids):
+        if not cls.needs_automatic_mapping(volume):
+            return None
+
+        queue_count = cls.to_int(volume.multiQueues)
+        iothread_ids = cls.allocate_iothread_ids(min(queue_count, cls.to_int(volume.ioThreads)), used_iothread_ids)
+        return cls(volume.volumeUuid, queue_count, iothread_ids)
+
+    @classmethod
+    def allocate_all(cls, volumes, used_iothread_ids=None):
+        used_iothread_ids = set(used_iothread_ids or [])
+        allocators = {}
+        for volume in sorted(volumes, key=lambda v: cls.to_int(v.deviceId)):
+            allocator = cls.allocate(volume, used_iothread_ids)
+            if allocator:
+                allocators[allocator.volume_uuid] = allocator
+        return allocators
+
+    @classmethod
+    def prepare_scsi_controller_indexes(cls, volumes):
+        volumes = sorted(volumes, key=lambda v: cls.to_int(v.deviceId))
+        used_indexes = {0}
+        reused_indexes = {}
+        for volume in volumes:
+            controller_index = cls.to_int(volume.controllerIndex)
+            if controller_index:
+                io_thread_id = cls.to_int(volume.ioThreadId)
+                if io_thread_id and io_thread_id in reused_indexes:
+                    volume.controllerIndex = reused_indexes[io_thread_id]
+                    continue
+                used_indexes.add(controller_index)
+                if io_thread_id:
+                    reused_indexes[io_thread_id] = controller_index
+
+        next_index = 1
+        for volume in volumes:
+            if not cls.needs_dedicated_scsi_controller(volume) or cls.to_int(volume.controllerIndex):
+                continue
+            io_thread_id = cls.to_int(volume.ioThreadId)
+            if io_thread_id and io_thread_id in reused_indexes:
+                volume.controllerIndex = reused_indexes[io_thread_id]
+                continue
+            while next_index in used_indexes:
+                next_index += 1
+            volume.controllerIndex = next_index
+            used_indexes.add(next_index)
+            if io_thread_id:
+                reused_indexes[io_thread_id] = next_index
+
+    @classmethod
+    def apply(cls, driver, allocator):
+        if not allocator:
+            return
+        iothreads = e(driver, 'iothreads')
+        for iothread_id in allocator.iothread_ids:
+            iothread = e(iothreads, 'iothread', None, {'id': str(iothread_id)})
+            for queue_id in allocator.queue_ids_by_iothread[iothread_id]:
+                e(iothread, 'queue', None, {'id': str(queue_id)})
+
+    @classmethod
+    def automatic_ids_from_xml(cls, root):
+        ids = set()
+        if root is None:
+            return ids
+        for iothread in root.findall(".//iothreads/iothread"):
+            iothread_id = cls.to_int(iothread.get('id'))
+            if iothread_id >= AUTOMATIC_IOTHREAD_ID_START:
+                ids.add(iothread_id)
+        return ids
+
+    @classmethod
+    def used_ids_from_xml(cls, root):
+        ids = set()
+        if root is None:
+            return ids
+        for iothread in root.findall(".//iothread"):
+            iothread_id = cls.to_int(iothread.get('id'))
+            if iothread_id:
+                ids.add(iothread_id)
+        for element in root.findall(".//*[@iothread]"):
+            iothread_id = cls.to_int(element.get('iothread'))
+            if iothread_id:
+                ids.add(iothread_id)
+        return ids
+
+    @classmethod
+    def from_existing_driver(cls, volume, driver, queue_count):
+        # IOThread IDs are scoped to a libvirt domain, so migration can preserve IDs from the source disk XML.
+        iothread_ids = sorted(cls.automatic_ids_from_xml(driver))
+        queue_count = cls.to_int(queue_count)
+        if not iothread_ids or not queue_count:
+            return None
+        return cls(volume.volumeUuid, queue_count, iothread_ids)
+
+    @classmethod
+    def iothread_ids_from_info(cls, iothread_info):
+        ids = set()
+        for info in iothread_info:
+            iothread_id = cls.to_int(info[0])
+            if iothread_id:
+                ids.add(iothread_id)
+        return ids
+
+    @staticmethod
+    def to_int(value):
+        return int(value or 0)
+
+    @classmethod
+    def needs_automatic_mapping(cls, volume):
+        return volume.deviceType == 'cbd' \
+            and not cls.to_int(volume.ioThreadId) \
+            and (volume.useVirtio or volume.useVirtioSCSI) \
+            and cls.to_int(volume.multiQueues) > 0 \
+            and cls.to_int(volume.ioThreads) > 0
+
+    @classmethod
+    def needs_dedicated_scsi_controller(cls, volume):
+        return bool(volume.useVirtioSCSI) and (
+            cls.to_int(volume.multiQueues) > 0 or cls.to_int(volume.ioThreadId) > 0
+        )
+
+    @classmethod
+    def _queue_ids_by_iothread(cls, queue_count, iothread_ids):
+        iothread_count = len(iothread_ids)
+        base = queue_count // iothread_count
+        remainder = queue_count % iothread_count
+        next_queue_id = 0
+        result = {}
+        for index, iothread_id in enumerate(iothread_ids):
+            owned_queue_count = base + (1 if index >= iothread_count - remainder else 0)
+            result[iothread_id] = list(range(next_queue_id, next_queue_id + owned_queue_count))
+            next_queue_id += owned_queue_count
+        return result
+
+    @staticmethod
+    def allocate_iothread_ids(count, used_iothread_ids):
+        ids = []
+        iothread_id = AUTOMATIC_IOTHREAD_ID_START
+        while len(ids) < count:
+            if iothread_id > AUTOMATIC_IOTHREAD_ID_LIMIT:
+                raise Exception('cannot allocate %s automatic iothreads, no id available below %s' %
+                                (count, AUTOMATIC_IOTHREAD_ID_LIMIT))
+            if iothread_id not in used_iothread_ids:
+                ids.append(iothread_id)
+                used_iothread_ids.add(iothread_id)
+            iothread_id += 1
+        return ids
+
+
+def scsi_controller_xml(root, controller_index):
+    if root is None or controller_index is None:
+        return None
+    for controller in root.findall("./devices/controller"):
+        if controller.get('type') == 'scsi' and controller.get('index') == str(controller_index):
+            return controller
+    return None
+
+
+def scsi_controller_alias(controller):
+    if controller is None:
+        return None
+    alias = controller.find('alias')
+    return alias.get('name') if alias is not None else None
+
+
+def scsi_controller_has_attached_disk(root, controller_index):
+    if root is None or controller_index is None:
+        return False
+    for disk in root.findall("./devices/disk"):
+        target = disk.find('target')
+        address = disk.find('address')
+        if target is None or address is None:
+            continue
+        if target.get('bus') == 'scsi' and address.get('controller') == str(controller_index):
+            return True
+    return False
+
+
+def scsi_controller_is_feature_managed(controller):
+    if controller is None:
+        return False
+    driver = controller.find('driver')
+    return driver is not None and (
+        driver.get('queues') is not None or bool(IothreadVqMappingAllocator.automatic_ids_from_xml(driver))
+    )
+
+
+def make_virtio_scsi_controller_xml(index, alias_id, io_thread_id=None, queues=None, mapping_allocator=None):
+    controller_xml = etree.Element('controller',
+                                   attrib={'type': 'scsi', 'model': 'virtio-scsi', 'index': str(index)})
+    e(controller_xml, 'address', None, {'type': 'pci'})
+
+    driver_elements = {}
+    if queues:
+        driver_elements['queues'] = str(queues)
+    if io_thread_id:
+        driver_elements['iothread'] = str(io_thread_id)
+    if driver_elements or mapping_allocator:
+        driver = e(controller_xml, 'driver', None, driver_elements)
+        IothreadVqMappingAllocator.apply(driver, mapping_allocator)
+
+    e(controller_xml, 'alias', None, {'name': 'scsi{0}'.format(alias_id)})
+    return controller_xml
 
 
 def is_spice_tls():
@@ -3664,7 +3884,7 @@ class Vm(object):
         def filebased_volume():
             disk = etree.Element('disk', attrib={'type': 'file', 'device': 'disk'})
             driver_elements = {'name': 'qemu', 'type': linux.get_img_fmt(volume.installPath), 'cache': volume.cacheMode, 'discard': 'unmap'}
-            if volume.useVirtio and volume.hasattr("multiQueues") and volume.multiQueues:
+            if is_virtio_blk(volume) and volume.multiQueues:
                 driver_elements["queues"] = volume.multiQueues
             if (not volume.useVirtioSCSI) and volume.useVirtio and volume.hasattr("ioThreadId") and volume.ioThreadId:
                 driver_elements["iothread"] = str(volume.ioThreadId)
@@ -3756,7 +3976,7 @@ class Vm(object):
             def blk():
                 disk = etree.Element('disk', {'type': 'block', 'device': 'disk', 'snapshot': 'external'})
                 driver_elements = {'name': 'qemu', 'type': linux.get_img_fmt(volume.installPath), 'cache': 'none', 'io': 'native'}
-                if volume.useVirtio and volume.hasattr("multiQueues") and volume.multiQueues:
+                if is_virtio_blk(volume) and volume.multiQueues:
                     driver_elements["queues"] = volume.multiQueues
                 if (not volume.useVirtioSCSI) and volume.useVirtio and volume.hasattr("ioThreadId") and volume.ioThreadId:
                     driver_elements["iothread"] = str(volume.ioThreadId)
@@ -3800,7 +4020,7 @@ class Vm(object):
             disk = etree.Element('disk', {'type': 'vhostuser', 'device': 'disk', 'snapshot': 'no'})
 
             driver_elements = {'name': 'qemu', 'type': volume.format}
-            if volume.hasattr("multiQueues") and volume.multiQueues:
+            if is_virtio_blk(volume) and volume.multiQueues:
                 driver_elements["queues"] = volume.multiQueues
             e(disk, 'driver', None, driver_elements)
 
@@ -3823,7 +4043,12 @@ class Vm(object):
 
         def cbd_volume():
             disk = etree.Element('disk', {'type': 'network', 'device': 'disk'})
-            e(disk, 'driver', None, {'name': 'qemu', 'type': 'raw', 'cache': 'none', 'discard': 'unmap'})
+            driver_elements = {'name': 'qemu', 'type': 'raw', 'cache': 'none', 'discard': 'unmap'}
+            if is_virtio_blk(volume) and volume.multiQueues:
+                driver_elements["queues"] = volume.multiQueues
+            driver = e(disk, 'driver', None, driver_elements)
+            if not volume.useVirtioSCSI:
+                IothreadVqMappingAllocator.apply(driver, automatic_iothread_vq_mapping_allocator)
             e(disk, 'source', None, {'protocol': 'cbd', 'name': make_cbd_conf(volume.installPath)})
             if volume.useVirtioSCSI:
                 e(disk, 'target', None, {'dev': 'sd%s' % dev_letter, 'bus': 'scsi'})
@@ -3841,12 +4066,56 @@ class Vm(object):
         dev_letter = self._get_device_letter(volume, addons)
         volume = file_volume_check(volume)
 
+        automatic_iothread_vq_mapping_allocator = None
+        created_automatic_iothread_ids = []
+        created_scsi_controller_aliases = []
+        if IothreadVqMappingAllocator.needs_automatic_mapping(volume):
+            used_iothread_ids = IothreadVqMappingAllocator.iothread_ids_from_info(VmPlugin.get_iothread_info(self.uuid))
+            automatic_iothread_vq_mapping_allocator = IothreadVqMappingAllocator.allocate(volume, used_iothread_ids)
+
+        def cleanup_created_iothread_vq_mapping():
+            for created_scsi_controller_alias in created_scsi_controller_aliases:
+                try:
+                    self.detach_controller_by_alias(self.uuid, created_scsi_controller_alias)
+                except Exception as exc:
+                    logger.warn('failed to cleanup scsi controller[%s] on vm[uuid:%s]: %s' %
+                                (created_scsi_controller_alias, self.uuid, str(exc)))
+            for iothread_id in created_automatic_iothread_ids:
+                try:
+                    err_info = VmPlugin.del_io_thread(self.uuid, iothread_id)
+                    if err_info:
+                        logger.warn('failed to cleanup automatic iothread[%s] on vm[uuid:%s]: %s' %
+                                    (iothread_id, self.uuid, err_info))
+                except Exception as exc:
+                    logger.warn('failed to cleanup automatic iothread[%s] on vm[uuid:%s]: %s' %
+                                (iothread_id, self.uuid, str(exc)))
+
         if volume.hasattr("ioThreadId") and volume.ioThreadId:
             err_info = self.create_iothread(self.uuid, volume.ioThreadId, volume.ioThreadPin)
             if err_info:
                 raise kvmagent.KvmError("set iothread[{}:{}] on volume[uuid:{}] err: {}".format(volume.ioThreadId, volume.ioThreadPin, volume.volumeUuid, err_info))
-        if volume.useVirtioSCSI and volume.hasattr("ioThreadId") and volume.ioThreadId:
-            volume.controllerIndex = self.create_scsi_controller(self.uuid, volume.ioThreadId)
+
+        try:
+            if automatic_iothread_vq_mapping_allocator:
+                for iothread_id in automatic_iothread_vq_mapping_allocator.iothread_ids:
+                    err_info = VmPlugin.add_io_thread(self.uuid, iothread_id)
+                    if err_info:
+                        raise kvmagent.KvmError("add automatic iothread[{}] on vm[uuid:{}] failed: {}".format(
+                            iothread_id, self.uuid, err_info))
+                    created_automatic_iothread_ids.append(iothread_id)
+
+            if volume.useVirtioSCSI and IothreadVqMappingAllocator.needs_dedicated_scsi_controller(volume):
+                manual_iothread_id = IothreadVqMappingAllocator.to_int(volume.ioThreadId)
+                volume.controllerIndex = VmPlugin.add_scsi_controller_with_driver(
+                    self.uuid,
+                    io_thread_id=manual_iothread_id,
+                    queues=IothreadVqMappingAllocator.to_int(volume.multiQueues),
+                    mapping_allocator=automatic_iothread_vq_mapping_allocator,
+                    created_aliases=created_scsi_controller_aliases
+                )
+        except Exception:
+            cleanup_created_iothread_vq_mapping()
+            raise
 
         if volume.deviceType == 'iscsi':
             disk_element = iscsibased_volume()
@@ -3875,6 +4144,7 @@ class Vm(object):
         add_caching_store(disk_element, volume)
         xml = etree.tostring(disk_element, encoding="unicode")
         logger.debug('attaching volume[%s] to vm[uuid:%s]:\n%s' % (volume.installPath, self.uuid, xml))
+        attach_succeeded = False
         try:
             # libvirt has a bug that if attaching volume just after vm created, it likely fails. So we retry three time here
             @linux.retry(times=3, sleep_time=5)
@@ -3899,6 +4169,7 @@ class Vm(object):
                         raise
 
             attach()
+            attach_succeeded = True
 
         except libvirt.libvirtError as ex:
             err = str(ex)
@@ -3912,6 +4183,9 @@ class Vm(object):
                 err = 'unable to attach the volume[%s] to vm[uuid: %s], %s.' % (volume.volumeUuid, self.uuid, err)
             logger.warn(linux.get_exception_stacktrace())
             raise kvmagent.KvmError(err)
+        finally:
+            if not attach_succeeded:
+                cleanup_created_iothread_vq_mapping()
 
     def _get_device_letter(self, volume, addons):
         default_letter = Vm.DEVICE_LETTERS[volume.deviceId]
@@ -3973,6 +4247,54 @@ class Vm(object):
 
         target_disk, disk_name = self._get_target_disk(volume)
         xmlstr = target_disk.dump()
+        automatic_iothread_ids_to_cleanup = set()
+        scsi_controller_alias_to_cleanup = None
+        scsi_controller_index_to_cleanup = None
+        try:
+            disk_xml = etree.fromstring(xmlstr)
+            automatic_iothread_ids_to_cleanup.update(IothreadVqMappingAllocator.automatic_ids_from_xml(disk_xml))
+            target = disk_xml.find('target')
+            address = disk_xml.find('address')
+            if target is not None and address is not None and target.get('bus') == 'scsi':
+                controller_index = address.get('controller')
+                domain_root = etree.fromstring(self.domain_xml)
+                controller = scsi_controller_xml(domain_root, controller_index)
+                automatic_iothread_ids_to_cleanup.update(IothreadVqMappingAllocator.automatic_ids_from_xml(controller))
+                if scsi_controller_is_feature_managed(controller):
+                    scsi_controller_index_to_cleanup = controller_index
+                    scsi_controller_alias_to_cleanup = scsi_controller_alias(controller)
+        except Exception as exc:
+            logger.warn('failed to collect iothread-vq-mapping cleanup info before detaching volume[%s] from vm[uuid:%s]: %s' %
+                        (volume.volumeUuid, self.uuid, str(exc)))
+
+        def cleanup_iothread_vq_mapping_after_detach():
+            if not automatic_iothread_ids_to_cleanup and not scsi_controller_alias_to_cleanup:
+                return
+
+            try:
+                current_vm = get_vm_by_uuid(self.uuid)
+                current_root = etree.fromstring(current_vm.domain_xml)
+                if scsi_controller_alias_to_cleanup and not scsi_controller_has_attached_disk(
+                        current_root, scsi_controller_index_to_cleanup):
+                    err_info = self.detach_controller_by_alias(self.uuid, scsi_controller_alias_to_cleanup)
+                    if err_info:
+                        logger.warn('failed to cleanup scsi controller[%s] on vm[uuid:%s]: %s' %
+                                    (scsi_controller_alias_to_cleanup, self.uuid, err_info))
+                    current_vm = get_vm_by_uuid(self.uuid)
+                    current_root = etree.fromstring(current_vm.domain_xml)
+
+                referenced_iothread_ids = IothreadVqMappingAllocator.automatic_ids_from_xml(current_root)
+                for iothread_id in automatic_iothread_ids_to_cleanup:
+                    if iothread_id in referenced_iothread_ids:
+                        continue
+                    err_info = VmPlugin.del_io_thread(self.uuid, iothread_id)
+                    if err_info:
+                        logger.warn('failed to cleanup automatic iothread[%s] on vm[uuid:%s]: %s' %
+                                    (iothread_id, self.uuid, err_info))
+            except Exception as exc:
+                logger.warn('failed to cleanup iothread-vq-mapping after detaching volume[%s] from vm[uuid:%s]: %s' %
+                            (volume.volumeUuid, self.uuid, str(exc)))
+
         logger.debug('detaching volume from vm[uuid:%s]:\n%s' % (self.uuid, xmlstr))
         try:
             # libvirt has a bug that if detaching volume just after vm created, it likely fails. So we retry three time here
@@ -4016,6 +4338,8 @@ class Vm(object):
             if self._volume_detach_timed_out(volume):
                 self._clean_timeout_record(volume)
                 logger.debug("detach success finally, remove record of volume install path: %s" % volume.installPath)
+
+            cleanup_iothread_vq_mapping_after_detach()
 
             def logout_iscsi():
                 BlkIscsi.logout_portal(target_disk.source.dev_)
@@ -5985,6 +6309,24 @@ class Vm(object):
             hd_device_address_deduplicate = True
 
         elements = {}
+        volumes_for_iothread_vq_mapping = [cmd.rootVolume]
+        volumes_for_iothread_vq_mapping.extend(cmd.dataVolumes)
+
+        manual_iothread_ids = set()
+        if cmd.addons and cmd.addons.hasattr("ioThreadPins") and cmd.addons.ioThreadPins:
+            for pin in cmd.addons.ioThreadPins:
+                io_thread_id = IothreadVqMappingAllocator.to_int(pin["ioThreadId"])
+                if io_thread_id:
+                    manual_iothread_ids.add(io_thread_id)
+        for volume in volumes_for_iothread_vq_mapping:
+            io_thread_id = IothreadVqMappingAllocator.to_int(volume.ioThreadId)
+            if io_thread_id:
+                manual_iothread_ids.add(io_thread_id)
+
+        IothreadVqMappingAllocator.prepare_scsi_controller_indexes(volumes_for_iothread_vq_mapping)
+        automatic_iothread_vq_mapping_allocators = IothreadVqMappingAllocator.allocate_all(
+            volumes_for_iothread_vq_mapping, manual_iothread_ids
+        )
 
         def make_root():
             root = etree.Element('domain')
@@ -6648,8 +6990,7 @@ class Vm(object):
         def make_volumes():
             devices = elements['devices']
             #guarantee rootVolume is the first of the set
-            volumes = [cmd.rootVolume]
-            volumes.extend(cmd.dataVolumes)
+            volumes = list(volumes_for_iothread_vq_mapping)
             #When platform=other and default_bus_type=ide, the maximum number of volume is three
             if machine_type == 'q35':
                 volume_hd_configs = [
@@ -6714,10 +7055,10 @@ class Vm(object):
             def filebased_volume(_dev_letter, _v):
                 disk = etree.Element('disk', {'type': 'file', 'device': 'disk', 'snapshot': 'external'})
                 driver_elements = {'name': 'qemu', 'type': linux.get_img_fmt(_v.installPath), 'cache': _v.cacheMode, 'discard': 'unmap'}
-                if cmd.addons and cmd.addons['useDataPlane'] is True:
+                if cmd.addons and cmd.addons['useDataPlane'] is True and is_virtio_blk(_v):
                     driver_elements['dataplane'] = 'on'
                     driver_elements['queues'] = 1
-                if _v.useVirtio and _v.hasattr("multiQueues") and _v.multiQueues:
+                if is_virtio_blk(_v) and _v.multiQueues:
                     driver_elements["queues"] = _v.multiQueues
                 if (not _v.useVirtioSCSI) and _v.useVirtio and _v.hasattr("ioThreadId") and _v.ioThreadId:
                     driver_elements["iothread"] = str(_v.ioThreadId)
@@ -6787,7 +7128,7 @@ class Vm(object):
 
                 disk = etree.Element('disk', {'type': 'network', 'device': 'disk'})
                 driver_elements = {'name': 'qemu', 'type': 'raw', 'cache': 'none', 'discard': 'unmap'}
-                if _v.useVirtio and _v.hasattr("multiQueues") and _v.multiQueues:
+                if is_virtio_blk(_v) and _v.multiQueues:
                     driver_elements["queues"] = _v.multiQueues
                 e(disk, 'driver', None, driver_elements)
 
@@ -6862,7 +7203,7 @@ class Vm(object):
             def block_volume(_dev_letter, _v):
                 disk = etree.Element('disk', {'type': 'block', 'device': 'disk', 'snapshot': 'external'})
                 driver_elements = {'name': 'qemu', 'type': linux.get_img_fmt(_v.installPath), 'cache': 'none', 'io': 'native'}
-                if _v.useVirtio and _v.hasattr("multiQueues") and _v.multiQueues:
+                if is_virtio_blk(_v) and _v.multiQueues:
                     driver_elements["queues"] = _v.multiQueues
                 if (not _v.useVirtioSCSI) and _v.useVirtio and _v.hasattr("ioThreadId") and _v.ioThreadId:
                     driver_elements["iothread"] = str(_v.ioThreadId)
@@ -6892,7 +7233,7 @@ class Vm(object):
                 disk = etree.Element('disk', {'type': 'vhostuser', 'device': 'disk', 'snapshot': 'no'})
 
                 driver_elements = {'name': 'qemu', 'type': _v.format}
-                if _v.hasattr("multiQueues") and _v.multiQueues:
+                if is_virtio_blk(_v) and _v.multiQueues:
                     driver_elements["queues"] = _v.multiQueues
                 e(disk, 'driver', None, driver_elements)
 
@@ -6918,7 +7259,12 @@ class Vm(object):
 
             def cbd_volume(_dev_letter, _v):
                 disk = etree.Element('disk', {'type': 'network', 'device': 'disk'})
-                e(disk, 'driver', None, {'name': 'qemu', 'type': 'raw', 'cache': 'none', 'discard': 'unmap'})
+                driver_elements = {'name': 'qemu', 'type': 'raw', 'cache': 'none', 'discard': 'unmap'}
+                if is_virtio_blk(_v) and _v.multiQueues:
+                    driver_elements["queues"] = _v.multiQueues
+                driver = e(disk, 'driver', None, driver_elements)
+                if not _v.useVirtioSCSI:
+                    IothreadVqMappingAllocator.apply(driver, automatic_iothread_vq_mapping_allocators.get(_v.volumeUuid))
                 e(disk, 'source', None, {'protocol': 'cbd', 'name': make_cbd_conf(_v.installPath)})
                 if _v.useVirtioSCSI:
                     e(disk, 'target', None, {'dev': 'sd%s' % _dev_letter, 'bus': 'scsi'})
@@ -7128,11 +7474,21 @@ class Vm(object):
             io_thread_num = 0
             if cmd.coloPrimary or cmd.coloSecondary:
                 io_thread_num += len(cmd.nics)
+            explicit_iothread_ids = set()
             if cmd.addons and cmd.addons.hasattr("ioThreadNum") and cmd.addons.ioThreadNum:
                 io_thread_num += int(cmd.addons.ioThreadNum)
-                io_thread_ids = e(root, "iothreadids")
                 for pin in cmd.addons.ioThreadPins:
-                    e(io_thread_ids, "iothread", None, {"id": str(pin["ioThreadId"])})
+                    explicit_iothread_ids.add(int(pin["ioThreadId"]))
+            undeclared_manual_iothread_ids = manual_iothread_ids - explicit_iothread_ids
+            io_thread_num += len(undeclared_manual_iothread_ids)
+            explicit_iothread_ids.update(undeclared_manual_iothread_ids)
+            for allocator in automatic_iothread_vq_mapping_allocators.values():
+                io_thread_num += len(allocator.iothread_ids)
+                explicit_iothread_ids.update(allocator.iothread_ids)
+            if explicit_iothread_ids:
+                io_thread_ids = e(root, "iothreadids")
+                for iothread_id in sorted(explicit_iothread_ids):
+                    e(io_thread_ids, "iothread", None, {"id": str(iothread_id)})
             if io_thread_num != 0:
                 e(root, 'iothreads', str(io_thread_num))
 
@@ -7489,14 +7845,21 @@ class Vm(object):
             devices = elements['devices']
             e(devices, 'controller', None, {'type': 'scsi', 'model': 'virtio-scsi'})
 
-            for vol in cmd.dataVolumes:
-                if not vol.useVirtioSCSI:
+            created_dedicated_controllers = set()
+            for vol in volumes_for_iothread_vq_mapping:
+                if not IothreadVqMappingAllocator.needs_dedicated_scsi_controller(vol):
                     continue
-                if vol.hasattr("ioThreadId") and vol.ioThreadId:
-                    controller_xml = e(devices, 'controller', None, {'type': 'scsi', 'model': 'virtio-scsi', 'index': str(vol.controllerIndex)})
-                    e(controller_xml, 'address', None, {'type': 'pci'})
-                    e(controller_xml, 'driver', None, {'iothread': str(vol.ioThreadId)})
-                    e(controller_xml, 'alias', None, {'name': 'scsi{0}'.format(vol.ioThreadId)})
+                alias_id = vol.ioThreadId if vol.ioThreadId else vol.controllerIndex
+                if alias_id in created_dedicated_controllers:
+                    continue
+                created_dedicated_controllers.add(alias_id)
+                devices.append(make_virtio_scsi_controller_xml(
+                    vol.controllerIndex,
+                    alias_id,
+                    io_thread_id=vol.ioThreadId,
+                    queues=IothreadVqMappingAllocator.to_int(vol.multiQueues),
+                    mapping_allocator=automatic_iothread_vq_mapping_allocators.get(vol.volumeUuid)
+                ))
 
             if machine_type in ['q35', 'virt']:
                 if HOST_ARCH != 'loongarch64':
@@ -9518,6 +9881,24 @@ class VmPlugin(kvmagent.KvmAgent):
 
     @staticmethod
     def _get_new_disk(old_disk: etree.Element, volume=None):
+        old_driver = old_disk.find('driver')
+
+        def volume_multi_queues(_v):
+            if _v.multiQueues:
+                return _v.multiQueues
+            if old_driver is not None:
+                return old_driver.get('queues')
+            return None
+
+        def automatic_mapping_allocator(_v, queue_count):
+            allocator = IothreadVqMappingAllocator.from_existing_driver(_v, old_driver, queue_count)
+            if allocator:
+                return allocator
+            if not IothreadVqMappingAllocator.needs_automatic_mapping(_v):
+                return None
+            used_iothread_ids = IothreadVqMappingAllocator.used_ids_from_xml(old_disk.getroottree().getroot())
+            return IothreadVqMappingAllocator.allocate(_v, used_iothread_ids)
+
         def filebased_volume(_v):
             disk = etree.Element('disk', {'type': 'file', 'device': 'disk', 'snapshot': 'external'})
             e(disk, 'driver', None, {'name': 'qemu', 'type': driver_type, 'cache': _v.cacheMode, 'discard': 'unmap'})
@@ -9553,9 +9934,20 @@ class VmPlugin(kvmagent.KvmAgent):
 
         def cbd_volume(_v):
             disk = etree.Element('disk', {'type': 'network', 'device': 'disk'})
-            e(disk, 'driver', None, {'name': 'qemu', 'type': 'raw', 'cache': 'none', 'discard': 'unmap'})
+            driver_elements = {'name': 'qemu', 'type': 'raw', 'cache': 'none', 'discard': 'unmap'}
+            queue_count = volume_multi_queues(_v)
+            if is_virtio_blk(_v) and queue_count:
+                driver_elements["queues"] = str(queue_count)
+            driver = e(disk, 'driver', None, driver_elements)
+            if not _v.useVirtioSCSI:
+                IothreadVqMappingAllocator.apply(driver, automatic_mapping_allocator(_v, queue_count))
             e(disk, 'source', None, {'protocol': 'cbd', 'name': make_cbd_conf(_v.installPath)})
-            e(disk, 'target', None, {'dev': 'vd%s' % _v.dev_letter, 'bus': 'virtio'})
+            if _v.useVirtioSCSI:
+                e(disk, 'target', None, {'dev': 'sd%s' % _v.dev_letter, 'bus': 'scsi'})
+                if _v.wwn:
+                    e(disk, 'wwn', _v.wwn)
+            else:
+                e(disk, 'target', None, {'dev': 'vd%s' % _v.dev_letter, 'bus': 'virtio'})
             if _v.physicalBlockSize:
                 e(disk, 'blockio', None, {'physical_block_size': str(_v.physicalBlockSize)})
             return disk
@@ -14012,18 +14404,26 @@ host side snapshot files chian:
         return jsonobject.dumps(rsp)
 
     @staticmethod
-    def add_scsi_controller(vm_uuid, io_thread_id):
+    def add_scsi_controller_with_driver(vm_uuid, io_thread_id=None, queues=None, mapping_allocator=None,
+                                        created_aliases=None):
         vm_xml_obj = get_vm_by_uuid(vm_uuid)
-        index = vm_xml_obj.find_scsi_controller_by_iothread(io_thread_id)
-        if not index or index == "0":
-            index = VmPlugin.get_next_scsi_controller_index(vm_xml_obj)
-            controller_xml = etree.Element('controller',
-                                           attrib={'type': 'scsi', 'model': 'virtio-scsi', 'index': str(index)})
-            e(controller_xml, 'address', None, {'type': 'pci'})
-            e(controller_xml, 'driver', None, {'iothread': str(io_thread_id)})
-            e(controller_xml, 'alias', None, {'name': 'scsi{0}'.format(io_thread_id)})
-            vm_xml_obj.domain.attachDeviceFlags(etree.tostring(controller_xml, encoding="unicode"), libvirt.VIR_DOMAIN_AFFECT_LIVE)
+        if io_thread_id:
+            index = vm_xml_obj.find_scsi_controller_by_iothread(io_thread_id)
+            if index and index != "0":
+                return index
+
+        index = VmPlugin.get_next_scsi_controller_index(vm_xml_obj)
+        alias_id = io_thread_id if io_thread_id else index
+        alias_name = 'scsi{0}'.format(alias_id)
+        if created_aliases is not None:
+            created_aliases.append(alias_name)
+        controller_xml = make_virtio_scsi_controller_xml(index, alias_id, io_thread_id, queues, mapping_allocator)
+        vm_xml_obj.domain.attachDeviceFlags(etree.tostring(controller_xml, encoding="unicode"), libvirt.VIR_DOMAIN_AFFECT_LIVE)
         return index
+
+    @staticmethod
+    def add_scsi_controller(vm_uuid, io_thread_id):
+        return VmPlugin.add_scsi_controller_with_driver(vm_uuid, io_thread_id=io_thread_id)
 
     @staticmethod
     def get_next_scsi_controller_index(vm_xml_obj):

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -2996,11 +2996,12 @@ class IothreadVqMappingAllocator(object):
         return int(value or 0)
 
     @classmethod
-    def needs_automatic_mapping(cls, volume):
+    def needs_automatic_mapping(cls, volume, queue_count=None):
+        queue_count = volume.multiQueues if queue_count is None else queue_count
         return volume.deviceType == 'cbd' \
             and not cls.to_int(volume.ioThreadId) \
             and (volume.useVirtio or volume.useVirtioSCSI) \
-            and cls.to_int(volume.multiQueues) > 0 \
+            and cls.to_int(queue_count) > 0 \
             and cls.to_int(volume.ioThreads) > 0
 
     @classmethod
@@ -4980,8 +4981,11 @@ class Vm(object):
         devices = tree.getroot().find('devices')
         for disk in tree.iterfind('devices/disk'):
             dev = disk.find('target').attrib['dev']
-            new_disk = VmPlugin._get_new_disk(disk, migrate_disks.get(dev, None))
+            volume = migrate_disks.get(dev, None)
+            new_disk = VmPlugin._get_new_disk(disk, volume)
             if new_disk != disk:
+                if volume:
+                    VmPlugin._apply_migration_iothread_vq_mapping(tree.getroot(), new_disk, volume)
                 parent_index = list(devices).index(disk)
                 devices.remove(disk)
                 devices.insert(parent_index, new_disk)
@@ -9882,24 +9886,51 @@ class VmPlugin(kvmagent.KvmAgent):
 
 
     @staticmethod
+    def _apply_migration_iothread_vq_mapping(root, disk, volume):
+        driver = disk.find('driver')
+        target = disk.find('target')
+
+        if target.get('bus') == 'scsi':
+            address = disk.find('address')
+            controller = scsi_controller_xml(root, address.get('controller') if address is not None else None)
+            driver = controller.find('driver') if controller is not None else None
+            queue_count = driver.get('queues') if driver is not None else None
+        else:
+            queue_count = driver.get('queues')
+
+        queue_count = IothreadVqMappingAllocator.to_int(queue_count)
+        if driver is None or driver.find('iothreads') is not None or queue_count <= 0 \
+                or not IothreadVqMappingAllocator.needs_automatic_mapping(volume, queue_count):
+            return
+
+        iothread_count = min(queue_count, IothreadVqMappingAllocator.to_int(volume.ioThreads))
+        used_iothread_ids = IothreadVqMappingAllocator.used_ids_from_xml(root)
+        iothread_ids = IothreadVqMappingAllocator.allocate_iothread_ids(iothread_count, used_iothread_ids)
+        allocator = IothreadVqMappingAllocator(volume.volumeUuid, queue_count, iothread_ids)
+        IothreadVqMappingAllocator.apply(driver, allocator)
+        VmPlugin._declare_migration_iothreads(root, iothread_ids)
+
+    @staticmethod
+    def _declare_migration_iothreads(root, iothread_ids):
+        devices = root.find('devices')
+        iothreads = root.find('iothreads')
+        iothreadids = root.find('iothreadids')
+        if iothreadids is None:
+            iothreadids = etree.Element('iothreadids')
+            before = iothreads if iothreads is not None else devices
+            root.insert(list(root).index(before), iothreadids)
+        for iothread_id in iothread_ids:
+            e(iothreadids, 'iothread', None, {'id': str(iothread_id)})
+
+        if iothreads is None:
+            iothreads = etree.Element('iothreads')
+            root.insert(list(root).index(devices), iothreads)
+        iothreads.text = str(IothreadVqMappingAllocator.to_int(iothreads.text) + len(iothread_ids))
+
+    @staticmethod
     def _get_new_disk(old_disk: etree.Element, volume=None):
         old_driver = old_disk.find('driver')
-
-        def volume_multi_queues(_v):
-            if _v.multiQueues:
-                return _v.multiQueues
-            if old_driver is not None:
-                return old_driver.get('queues')
-            return None
-
-        def automatic_mapping_allocator(_v, queue_count):
-            allocator = IothreadVqMappingAllocator.from_existing_driver(_v, old_driver, queue_count)
-            if allocator:
-                return allocator
-            if not IothreadVqMappingAllocator.needs_automatic_mapping(_v):
-                return None
-            used_iothread_ids = IothreadVqMappingAllocator.used_ids_from_xml(old_disk.getroottree().getroot())
-            return IothreadVqMappingAllocator.allocate(_v, used_iothread_ids)
+        source_queues = old_driver.get('queues')
 
         def filebased_volume(_v):
             disk = etree.Element('disk', {'type': 'file', 'device': 'disk', 'snapshot': 'external'})
@@ -9937,12 +9968,10 @@ class VmPlugin(kvmagent.KvmAgent):
         def cbd_volume(_v):
             disk = etree.Element('disk', {'type': 'network', 'device': 'disk'})
             driver_elements = {'name': 'qemu', 'type': 'raw', 'cache': 'none', 'discard': 'unmap'}
-            queue_count = volume_multi_queues(_v)
-            if is_virtio_blk(_v) and queue_count:
-                driver_elements["queues"] = str(queue_count)
             driver = e(disk, 'driver', None, driver_elements)
             if not _v.useVirtioSCSI:
-                IothreadVqMappingAllocator.apply(driver, automatic_mapping_allocator(_v, queue_count))
+                IothreadVqMappingAllocator.apply(
+                    driver, IothreadVqMappingAllocator.from_existing_driver(_v, old_driver, source_queues))
             e(disk, 'source', None, {'protocol': 'cbd', 'name': make_cbd_conf(_v.installPath)})
             if _v.useVirtioSCSI:
                 e(disk, 'target', None, {'dev': 'sd%s' % _v.dev_letter, 'bus': 'scsi'})
@@ -9992,6 +10021,11 @@ class VmPlugin(kvmagent.KvmAgent):
         else:
             raise Exception('unsupported volume deviceType[%s]' % volume.deviceType)
 
+        driver = ele.find('driver')
+        driver.attrib.pop('queues', None)
+        if source_queues:
+            driver.set('queues', source_queues)
+
         tags_to_keep = [ 'target', 'boot', 'alias', 'address', 'wwn', 'serial']
         for c in old_disk:  # getchildren
             if c.tag in tags_to_keep:
@@ -10020,6 +10054,7 @@ class VmPlugin(kvmagent.KvmAgent):
             dev = disk.find('target').attrib['dev']
             if dev in migrate_disks:
                 new_disk = VmPlugin._get_new_disk(disk, migrate_disks[dev])
+                VmPlugin._apply_migration_iothread_vq_mapping(tree.getroot(), new_disk, migrate_disks[dev])
                 parent_index = list(devices).index(disk)
                 devices.remove(disk)
                 devices.insert(parent_index, new_disk)

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -7130,7 +7130,9 @@ class Vm(object):
                 driver_elements = {'name': 'qemu', 'type': 'raw', 'cache': 'none', 'discard': 'unmap'}
                 if is_virtio_blk(_v) and _v.multiQueues:
                     driver_elements["queues"] = _v.multiQueues
-                e(disk, 'driver', None, driver_elements)
+                driver = e(disk, 'driver', None, driver_elements)
+                if not _v.useVirtioSCSI:
+                    IothreadVqMappingAllocator.apply(driver, automatic_iothread_vq_mapping_allocators.get(_v.volumeUuid))
 
                 u = parse_url(r)
                 src = e(disk, 'source', None, {'protocol': 'nbd', 'name': os.path.basename(u.path)})

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -4346,15 +4346,14 @@ class Vm(object):
 
             remaining_iothread_ids = set(automatic_iothread_ids_to_cleanup)
 
-            def cleanup_unreferenced_iothreads(_):
+            def wait_for_controller_removed(_):
                 current_vm = get_vm_by_uuid(self.uuid)
                 current_root = etree.fromstring(current_vm.domain_xml)
-                if scsi_controller_cleanup_attempted:
-                    for controller in current_root.findall("./devices/controller"):
-                        if controller.get('type') == 'scsi' and \
-                                scsi_controller_alias(controller) == scsi_controller_alias_to_cleanup:
-                            return False
+                return scsi_controller_xml(current_root, scsi_controller_index_to_cleanup) is None
 
+            def cleanup_unreferenced_iothreads():
+                current_vm = get_vm_by_uuid(self.uuid)
+                current_root = etree.fromstring(current_vm.domain_xml)
                 referenced_iothread_ids = IothreadVqMappingAllocator.automatic_ids_from_xml(current_root)
                 for iothread_id in list(remaining_iothread_ids):
                     if iothread_id in referenced_iothread_ids:
@@ -4365,15 +4364,18 @@ class Vm(object):
                                     (iothread_id, self.uuid, err_info))
                         continue
                     remaining_iothread_ids.remove(iothread_id)
-                return remaining_iothread_ids.issubset(referenced_iothread_ids)
+                return not remaining_iothread_ids
 
             if scsi_controller_cleanup_attempted:
-                if not linux.wait_callback_success(cleanup_unreferenced_iothreads, None, 5, 1):
-                    logger.warn('failed to cleanup automatic iothreads%s after detaching volume[%s] '
-                                'from vm[uuid:%s]: still referenced' %
-                                (sorted(remaining_iothread_ids), volume.volumeUuid, self.uuid))
-            else:
-                cleanup_unreferenced_iothreads(None)
+                if not linux.wait_callback_success(wait_for_controller_removed, None, 15, 1):
+                    logger.warn('failed to cleanup scsi controller[%s] after detaching volume[%s] '
+                                'from vm[uuid:%s]: still present' %
+                                (scsi_controller_alias_to_cleanup, volume.volumeUuid, self.uuid))
+                    return
+            if remaining_iothread_ids and not cleanup_unreferenced_iothreads():
+                logger.warn('failed to cleanup automatic iothreads%s after detaching volume[%s] '
+                            'from vm[uuid:%s]: still referenced' %
+                            (sorted(remaining_iothread_ids), volume.volumeUuid, self.uuid))
 
         logger.debug('detaching volume from vm[uuid:%s]:\n%s' % (self.uuid, xmlstr))
         try:

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -4077,7 +4077,10 @@ class Vm(object):
         def cleanup_created_iothread_vq_mapping():
             for created_scsi_controller_alias in created_scsi_controller_aliases:
                 try:
-                    self.detach_controller_by_alias(self.uuid, created_scsi_controller_alias)
+                    cmd_res = self.detach_controller_by_alias(created_scsi_controller_alias)
+                    if cmd_res:
+                        logger.warn('failed to cleanup scsi controller[%s] on vm[uuid:%s]: %s' %
+                                    (created_scsi_controller_alias, self.uuid, cmd_res))
                 except Exception as exc:
                     logger.warn('failed to cleanup scsi controller[%s] on vm[uuid:%s]: %s' %
                                 (created_scsi_controller_alias, self.uuid, str(exc)))
@@ -4237,6 +4240,26 @@ class Vm(object):
         return VmPlugin.add_scsi_controller(vm_uuid, iothread_id)
 
 
+    @linux.retry(times=3, sleep_time=1)
+    def detach_controller_by_alias(self, controller_alias):
+        exec_cmd = "virsh detach-device-alias %s %s --current" % (self.uuid, controller_alias)
+        cmd_res = shell.call(exec_cmd)
+
+        def controller_detached(_):
+            vm = get_vm_by_uuid(self.uuid)
+            for controller in vm.domain_xmlobject.devices.get_child_node_as_list('controller'):
+                if controller.type_ == 'scsi' and hasattr(controller, 'alias') \
+                        and controller.alias.name_ == controller_alias:
+                    return False
+            return True
+
+        if not linux.wait_callback_success(controller_detached, None, 60, 1):
+            return "failed to detach scsi controller[alias:%s] from vm[uuid:%s]" % (controller_alias, self.uuid)
+        if cmd_res and cmd_res.startswith("error:"):
+            return cmd_res
+        return None
+
+
     def detach_data_volume(self, volume):
         self._wait_vm_run_until_seconds(60)
         self.timeout_object.wait_until_object_timeout('attach-volume-%s' % self.uuid)
@@ -4272,29 +4295,47 @@ class Vm(object):
             if not automatic_iothread_ids_to_cleanup and not scsi_controller_alias_to_cleanup:
                 return
 
-            try:
+            current_vm = get_vm_by_uuid(self.uuid)
+            current_root = etree.fromstring(current_vm.domain_xml)
+            scsi_controller_cleanup_attempted = False
+            if scsi_controller_alias_to_cleanup and not scsi_controller_has_attached_disk(
+                    current_root, scsi_controller_index_to_cleanup):
+                scsi_controller_cleanup_attempted = True
+                err_info = self.detach_controller_by_alias(scsi_controller_alias_to_cleanup)
+                if err_info:
+                    logger.warn('failed to cleanup scsi controller[%s] on vm[uuid:%s]: %s' %
+                                (scsi_controller_alias_to_cleanup, self.uuid, err_info))
+
+            remaining_iothread_ids = set(automatic_iothread_ids_to_cleanup)
+
+            def cleanup_unreferenced_iothreads(_):
                 current_vm = get_vm_by_uuid(self.uuid)
                 current_root = etree.fromstring(current_vm.domain_xml)
-                if scsi_controller_alias_to_cleanup and not scsi_controller_has_attached_disk(
-                        current_root, scsi_controller_index_to_cleanup):
-                    err_info = self.detach_controller_by_alias(self.uuid, scsi_controller_alias_to_cleanup)
-                    if err_info:
-                        logger.warn('failed to cleanup scsi controller[%s] on vm[uuid:%s]: %s' %
-                                    (scsi_controller_alias_to_cleanup, self.uuid, err_info))
-                    current_vm = get_vm_by_uuid(self.uuid)
-                    current_root = etree.fromstring(current_vm.domain_xml)
+                if scsi_controller_cleanup_attempted:
+                    for controller in current_root.findall("./devices/controller"):
+                        if controller.get('type') == 'scsi' and \
+                                scsi_controller_alias(controller) == scsi_controller_alias_to_cleanup:
+                            return False
 
                 referenced_iothread_ids = IothreadVqMappingAllocator.automatic_ids_from_xml(current_root)
-                for iothread_id in automatic_iothread_ids_to_cleanup:
+                for iothread_id in list(remaining_iothread_ids):
                     if iothread_id in referenced_iothread_ids:
                         continue
                     err_info = VmPlugin.del_io_thread(self.uuid, iothread_id)
                     if err_info:
                         logger.warn('failed to cleanup automatic iothread[%s] on vm[uuid:%s]: %s' %
                                     (iothread_id, self.uuid, err_info))
-            except Exception as exc:
-                logger.warn('failed to cleanup iothread-vq-mapping after detaching volume[%s] from vm[uuid:%s]: %s' %
-                            (volume.volumeUuid, self.uuid, str(exc)))
+                        continue
+                    remaining_iothread_ids.remove(iothread_id)
+                return remaining_iothread_ids.issubset(referenced_iothread_ids)
+
+            if scsi_controller_cleanup_attempted:
+                if not linux.wait_callback_success(cleanup_unreferenced_iothreads, None, 5, 1):
+                    logger.warn('failed to cleanup automatic iothreads%s after detaching volume[%s] '
+                                'from vm[uuid:%s]: still referenced' %
+                                (sorted(remaining_iothread_ids), volume.volumeUuid, self.uuid))
+            else:
+                cleanup_unreferenced_iothreads(None)
 
         logger.debug('detaching volume from vm[uuid:%s]:\n%s' % (self.uuid, xmlstr))
         try:
@@ -4340,7 +4381,11 @@ class Vm(object):
                 self._clean_timeout_record(volume)
                 logger.debug("detach success finally, remove record of volume install path: %s" % volume.installPath)
 
-            cleanup_iothread_vq_mapping_after_detach()
+            try:
+                cleanup_iothread_vq_mapping_after_detach()
+            except Exception as exc:
+                logger.warn('failed to cleanup iothread-vq-mapping after detaching volume[%s] from vm[uuid:%s]: %s' %
+                            (volume.volumeUuid, self.uuid, str(exc)))
 
             def logout_iscsi():
                 BlkIscsi.logout_portal(target_disk.source.dev_)
@@ -14429,7 +14474,7 @@ host side snapshot files chian:
         for controller in vm.domain_xmlobject.devices.get_child_node_as_list('controller'):
             if controller.type_ == 'scsi' and hasattr(controller, 'driver') and hasattr(controller.driver, 'iothread_') \
                     and str(controller.driver.iothread_) == str(cmd.ioThreadId):
-                err_info = self.detach_controller_by_alias(cmd.vmUuid, controller.alias.name_)
+                err_info = vm.detach_controller_by_alias(controller.alias.name_)
                 if isinstance(err_info, str) and err_info:
                     rsp.success = False
                     rsp.error = err_info
@@ -14470,26 +14515,6 @@ host side snapshot files chian:
                 old_index_list.append(int(controller.index_))
         new_index_list = [i for i in range(0, len(old_index_list) + 1)]
         return set(new_index_list).difference(set(old_index_list)).pop()
-
-
-    @linux.retry(times=3, sleep_time=1)
-    def detach_controller_by_alias(self, vm_uuid, controller_alias):
-        exec_cmd = "virsh detach-device-alias %s %s --current" % (vm_uuid, controller_alias)
-        cmd_res = shell.call(exec_cmd)
-
-        def controller_detached(_):
-            vm = get_vm_by_uuid(vm_uuid)
-            for controller in vm.domain_xmlobject.devices.get_child_node_as_list('controller'):
-                if controller.type_ == 'scsi' and hasattr(controller, 'alias') \
-                        and controller.alias.name_ == controller_alias:
-                    return False
-            return True
-
-        if not linux.wait_callback_success(controller_detached, None, 60, 1):
-            return "failed to detach scsi controller[alias:%s] from vm[uuid:%s]" % (controller_alias, vm_uuid)
-        if cmd_res and cmd_res.startswith("error:"):
-            return cmd_res
-        return None
 
     @staticmethod
     def has_scsi_controller_using_iothread(vm_uuid, io_thread_id):

--- a/tests/unit/kvmagent/test_vm_iothread_vq_mapping.py
+++ b/tests/unit/kvmagent/test_vm_iothread_vq_mapping.py
@@ -165,6 +165,15 @@ def fake_wait_callback_success(callback, callback_data=None, timeout=60, interva
     return False
 
 
+def record_wait_calls(calls):
+    def wait(callback, callback_data=None, timeout=60, interval=1,
+             ignore_exception_in_callback=False):
+        calls.append((callback.__name__, timeout))
+        return fake_wait_callback_success(callback, callback_data, timeout, interval,
+                                          ignore_exception_in_callback)
+    return wait
+
+
 def stub_detach_volume_dependencies(monkeypatch, vm, disk_xml, current_xmls,
                                     detached_aliases, deleted_iothreads,
                                     wait_callback_success=None,
@@ -813,15 +822,34 @@ def test_detach_data_volume_keeps_controller_with_attached_disk(monkeypatch):
 @pytest.mark.kvmagent
 def test_detach_data_volume_retries_iothread_cleanup_after_stale_reference(monkeypatch):
     controller_xml = scsi_controller_domain_xml([101])
+    wait_calls = []
     ctx = setup_detach_volume_cleanup(
         monkeypatch, controller_xml, scsi_disk_xml([101]),
         [CLEAN_DOMAIN_XML, controller_xml, controller_xml, CLEAN_DOMAIN_XML],
-        fake_wait_callback_success)
+        record_wait_calls(wait_calls))
 
     ctx.vm._detach_data_volume(ctx.volume)
 
     assert ctx.detached_aliases == ['scsi1']
     assert ctx.deleted_iothreads == [101]
+    assert wait_calls == [('wait_for_detach', 5), ('wait_for_controller_removed', 15)]
+
+
+@pytest.mark.kvmagent
+def test_detach_data_volume_does_not_wait_after_controller_removed_while_iothread_is_referenced(monkeypatch):
+    controller_xml = scsi_controller_domain_xml([101])
+    referenced_xml = domain_xml_with_iothread_disk([101])
+    wait_calls = []
+    ctx = setup_detach_volume_cleanup(
+        monkeypatch, controller_xml, scsi_disk_xml([101]),
+        [CLEAN_DOMAIN_XML, controller_xml, CLEAN_DOMAIN_XML, referenced_xml],
+        record_wait_calls(wait_calls))
+
+    ctx.vm._detach_data_volume(ctx.volume)
+
+    assert ctx.detached_aliases == ['scsi1']
+    assert ctx.deleted_iothreads == []
+    assert wait_calls == [('wait_for_detach', 5), ('wait_for_controller_removed', 15)]
 
 
 @pytest.mark.kvmagent

--- a/tests/unit/kvmagent/test_vm_iothread_vq_mapping.py
+++ b/tests/unit/kvmagent/test_vm_iothread_vq_mapping.py
@@ -185,6 +185,69 @@ def test_get_new_cbd_disk_keeps_existing_iothread_vq_mapping_for_migration():
     assert [q.get('id') for q in iothreads[1].findall('queue')] == ['2', '3']
 
 
+def migration_domain_with_virtio_disks(count=1, queues='4'):
+    driver_queues = '' if queues is None else ' queues="%s"' % queues
+    disks = ''.join([
+        '''
+        <disk type="network" device="disk">
+          <driver name="qemu" type="raw" cache="none" discard="unmap"%s/>
+          <source protocol="cbd" name="old-%s"/>
+          <target dev="vd%s" bus="virtio"/>
+        </disk>
+        ''' % (driver_queues, index, chr(ord('a') + index))
+        for index in range(count)
+    ])
+    return vm_plugin.etree.fromstring('<domain><devices>%s</devices></domain>' % disks)
+
+
+@pytest.mark.kvmagent
+def test_migration_cbd_disk_allocates_iothread_vq_mapping_from_driver_queues():
+    root = migration_domain_with_virtio_disks()
+    disk = root.find('./devices/disk')
+    volume = cbd_volume(multiQueues='16', ioThreads=2)
+
+    vm_plugin.VmPlugin._apply_migration_iothread_vq_mapping(root, disk, volume)
+
+    driver = disk.find('driver')
+    assert driver.get('queues') == '4'
+    iothreads = driver.findall('./iothreads/iothread')
+    assert [i.get('id') for i in iothreads] == ['101', '102']
+    assert [q.get('id') for q in iothreads[0].findall('queue')] == ['0', '1']
+    assert [q.get('id') for q in iothreads[1].findall('queue')] == ['2', '3']
+    assert root.find('iothreads').text == '2'
+    assert [i.get('id') for i in root.findall('./iothreadids/iothread')] == ['101', '102']
+
+
+@pytest.mark.kvmagent
+def test_migration_cbd_disk_without_driver_queues_does_not_allocate_iothread_vq_mapping():
+    root = migration_domain_with_virtio_disks(queues=None)
+    disk = root.find('./devices/disk')
+    volume = cbd_volume(multiQueues='16', ioThreads=2)
+
+    vm_plugin.VmPlugin._apply_migration_iothread_vq_mapping(root, disk, volume)
+
+    assert disk.find('./driver/iothreads') is None
+    assert root.find('iothreads') is None
+    assert root.find('iothreadids') is None
+
+
+@pytest.mark.kvmagent
+def test_migration_cbd_disks_allocate_distinct_iothread_ids():
+    root = migration_domain_with_virtio_disks(count=2)
+    volume = cbd_volume(multiQueues='16', ioThreads=2)
+
+    for disk in root.findall('./devices/disk'):
+        vm_plugin.VmPlugin._apply_migration_iothread_vq_mapping(root, disk, volume)
+
+    disk_iothread_ids = [
+        [i.get('id') for i in disk.findall('./driver/iothreads/iothread')]
+        for disk in root.findall('./devices/disk')
+    ]
+    assert disk_iothread_ids == [['101', '102'], ['103', '104']]
+    assert root.find('iothreads').text == '4'
+    assert [i.get('id') for i in root.findall('./iothreadids/iothread')] == ['101', '102', '103', '104']
+
+
 @pytest.mark.kvmagent
 def test_get_new_cbd_scsi_disk_does_not_write_queues_on_disk_driver():
     old_disk = vm_plugin.etree.fromstring('''
@@ -210,6 +273,52 @@ def test_get_new_cbd_scsi_disk_does_not_write_queues_on_disk_driver():
     assert driver.get('queues') is None
     assert driver.find('iothreads') is None
     assert new_disk.find('target').get('bus') == 'scsi'
+
+
+@pytest.mark.kvmagent
+def test_migration_cbd_scsi_controller_allocates_iothread_vq_mapping_from_controller_queues():
+    root = vm_plugin.etree.fromstring('''
+    <domain>
+      <devices>
+        <controller type="scsi" model="virtio-scsi" index="1">
+          <driver queues="4"/>
+          <alias name="scsi1"/>
+        </controller>
+        <disk type="network" device="disk">
+          <driver name="qemu" type="raw" cache="none" discard="unmap"/>
+          <source protocol="cbd" name="old"/>
+          <target dev="sdb" bus="scsi"/>
+          <address type="drive" controller="1"/>
+        </disk>
+      </devices>
+    </domain>
+    ''')
+    old_disk = root.find('./devices/disk')
+    volume = cbd_volume(
+        installPath='cbd:new-volume',
+        dev_letter='b',
+        useVirtio=True,
+        useVirtioSCSI=False,
+        multiQueues='16',
+        ioThreads=2,
+        physicalBlockSize=None,
+        wwn='123456789abcdef0',
+    )
+
+    new_disk = vm_plugin.VmPlugin._get_new_disk(old_disk, volume)
+    vm_plugin.VmPlugin._apply_migration_iothread_vq_mapping(root, new_disk, volume)
+
+    disk_driver = new_disk.find('driver')
+    controller_driver = root.find('./devices/controller/driver')
+    iothreads = controller_driver.findall('./iothreads/iothread')
+    assert disk_driver.get('queues') is None
+    assert disk_driver.find('iothreads') is None
+    assert controller_driver.get('queues') == '4'
+    assert [i.get('id') for i in iothreads] == ['101', '102']
+    assert [q.get('id') for q in iothreads[0].findall('queue')] == ['0', '1']
+    assert [q.get('id') for q in iothreads[1].findall('queue')] == ['2', '3']
+    assert root.find('iothreads').text == '2'
+    assert [i.get('id') for i in root.findall('./iothreadids/iothread')] == ['101', '102']
 
 
 @pytest.mark.kvmagent

--- a/tests/unit/kvmagent/test_vm_iothread_vq_mapping.py
+++ b/tests/unit/kvmagent/test_vm_iothread_vq_mapping.py
@@ -1,0 +1,383 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from kvmagent.plugins import vm_plugin
+
+
+class Volume(object):
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def __getattr__(self, name):
+        return None
+
+    def hasattr(self, name):
+        return name in self.__dict__
+
+
+def cbd_volume(**kwargs):
+    values = {
+        'deviceType': 'cbd',
+        'useVirtio': True,
+        'useVirtioSCSI': False,
+        'multiQueues': '16',
+        'ioThreads': 8,
+        'volumeUuid': 'volume-uuid',
+        'deviceId': 1,
+    }
+    values.update(kwargs)
+    return Volume(**values)
+
+
+class EmptyAddons(object):
+    def __init__(self):
+        self.attachedDataVolumes = []
+
+    def __bool__(self):
+        return False
+
+    __nonzero__ = __bool__
+
+
+def no_retry(*args, **kwargs):
+    def decorator(func):
+        return func
+    return decorator
+
+
+@pytest.mark.kvmagent
+def test_is_virtio_blk_excludes_virtio_scsi():
+    assert vm_plugin.is_virtio_blk(cbd_volume(useVirtio=True, useVirtioSCSI=False))
+    assert not vm_plugin.is_virtio_blk(cbd_volume(useVirtio=True, useVirtioSCSI=True))
+    assert not vm_plugin.is_virtio_blk(cbd_volume(useVirtio=False, useVirtioSCSI=False))
+
+
+@pytest.mark.kvmagent
+def test_iothread_vq_mapping_allocator_distributes_queues_to_larger_iothread_ids_first():
+    volume = cbd_volume(ioThreads=7)
+
+    allocator = vm_plugin.IothreadVqMappingAllocator.allocate(volume, set())
+
+    assert allocator.iothread_ids == [101, 102, 103, 104, 105, 106, 107]
+    assert allocator.queue_ids_by_iothread[101] == [0, 1]
+    assert allocator.queue_ids_by_iothread[102] == [2, 3]
+    assert allocator.queue_ids_by_iothread[103] == [4, 5]
+    assert allocator.queue_ids_by_iothread[104] == [6, 7]
+    assert allocator.queue_ids_by_iothread[105] == [8, 9]
+    assert allocator.queue_ids_by_iothread[106] == [10, 11, 12]
+    assert allocator.queue_ids_by_iothread[107] == [13, 14, 15]
+
+
+@pytest.mark.kvmagent
+def test_iothread_vq_mapping_allocator_uses_one_iothread_per_queue_when_count_matches_queue_count():
+    volume = cbd_volume(multiQueues='8', ioThreads=8)
+
+    allocator = vm_plugin.IothreadVqMappingAllocator.allocate(volume, set())
+
+    assert allocator.iothread_ids == [101, 102, 103, 104, 105, 106, 107, 108]
+    assert allocator.queue_ids_by_iothread[101] == [0]
+    assert allocator.queue_ids_by_iothread[108] == [7]
+
+
+@pytest.mark.kvmagent
+def test_iothread_vq_mapping_allocator_avoids_existing_iothread_ids():
+    volume = cbd_volume(multiQueues='4', ioThreads=4)
+
+    allocator = vm_plugin.IothreadVqMappingAllocator.allocate(volume, set([101, 103]))
+
+    assert allocator.iothread_ids == [102, 104, 105, 106]
+
+
+@pytest.mark.kvmagent
+def test_iothread_vq_mapping_allocator_reports_id_exhaustion():
+    used_ids = set(range(vm_plugin.AUTOMATIC_IOTHREAD_ID_START, vm_plugin.AUTOMATIC_IOTHREAD_ID_LIMIT + 1))
+
+    with pytest.raises(Exception) as exc:
+        vm_plugin.IothreadVqMappingAllocator.allocate_iothread_ids(1, used_ids)
+
+    assert 'no id available' in str(exc.value)
+
+
+@pytest.mark.kvmagent
+def test_prepare_scsi_controller_indexes_reuses_manual_iothread_controller():
+    volume1 = cbd_volume(useVirtio=False, useVirtioSCSI=True, ioThreadId=101, deviceId=1)
+    volume2 = cbd_volume(volumeUuid='volume-uuid-2', useVirtio=False, useVirtioSCSI=True, ioThreadId=101, deviceId=2)
+
+    vm_plugin.IothreadVqMappingAllocator.prepare_scsi_controller_indexes([volume1, volume2])
+
+    assert volume1.controllerIndex == 1
+    assert volume2.controllerIndex == 1
+
+
+@pytest.mark.kvmagent
+def test_manual_iothread_pin_disables_automatic_iothread_vq_mapping():
+    volume = cbd_volume(ioThreadId=3)
+
+    assert vm_plugin.IothreadVqMappingAllocator.allocate(volume, set()) is None
+
+
+@pytest.mark.kvmagent
+def test_missing_iothreads_disables_automatic_iothread_vq_mapping():
+    volume = cbd_volume()
+    delattr(volume, 'ioThreads')
+
+    assert vm_plugin.IothreadVqMappingAllocator.allocate(volume, set()) is None
+
+
+@pytest.mark.kvmagent
+def test_non_cbd_volume_can_use_dedicated_scsi_controller_without_automatic_mapping():
+    volume = cbd_volume(deviceType='ceph', useVirtio=False, useVirtioSCSI=True, multiQueues='4')
+
+    assert vm_plugin.IothreadVqMappingAllocator.needs_automatic_mapping(volume) is False
+    assert vm_plugin.IothreadVqMappingAllocator.needs_dedicated_scsi_controller(volume) is True
+
+
+@pytest.mark.kvmagent
+def test_iothread_vq_mapping_allocator_writes_individual_queues():
+    volume = cbd_volume(ioThreads=7)
+    allocator = vm_plugin.IothreadVqMappingAllocator.allocate(volume, set())
+    driver = vm_plugin.etree.Element('driver')
+
+    vm_plugin.IothreadVqMappingAllocator.apply(driver, allocator)
+
+    iothreads = driver.findall('./iothreads/iothread')
+    assert iothreads[-2].get('id') == '106'
+    assert [q.get('id') for q in iothreads[-2].findall('queue')] == ['10', '11', '12']
+    assert iothreads[-1].get('id') == '107'
+    assert [q.get('id') for q in iothreads[-1].findall('queue')] == ['13', '14', '15']
+
+
+@pytest.mark.kvmagent
+def test_get_new_cbd_disk_keeps_existing_iothread_vq_mapping_for_migration():
+    old_disk = vm_plugin.etree.fromstring('''
+    <disk type="network" device="disk">
+      <driver name="qemu" type="raw" cache="none" discard="unmap" queues="4">
+        <iothreads>
+          <iothread id="101"><queue id="0-1"/></iothread>
+          <iothread id="102"><queue id="2-3"/></iothread>
+        </iothreads>
+      </driver>
+      <source protocol="cbd" name="old"/>
+      <target dev="vdb" bus="virtio"/>
+    </disk>
+    ''')
+    volume = cbd_volume(
+        installPath='cbd:new-volume',
+        dev_letter='b',
+        multiQueues=None,
+        ioThreads=None,
+        physicalBlockSize=None,
+    )
+
+    new_disk = vm_plugin.VmPlugin._get_new_disk(old_disk, volume)
+
+    driver = new_disk.find('driver')
+    assert driver.get('queues') == '4'
+    iothreads = driver.findall('./iothreads/iothread')
+    assert [i.get('id') for i in iothreads] == ['101', '102']
+    assert [q.get('id') for q in iothreads[0].findall('queue')] == ['0', '1']
+    assert [q.get('id') for q in iothreads[1].findall('queue')] == ['2', '3']
+
+
+@pytest.mark.kvmagent
+def test_get_new_cbd_scsi_disk_does_not_write_queues_on_disk_driver():
+    old_disk = vm_plugin.etree.fromstring('''
+    <disk type="network" device="disk">
+      <driver name="qemu" type="raw" cache="none" discard="unmap"/>
+      <source protocol="cbd" name="old"/>
+      <target dev="sdb" bus="scsi"/>
+    </disk>
+    ''')
+    volume = cbd_volume(
+        installPath='cbd:new-volume',
+        dev_letter='b',
+        useVirtio=True,
+        useVirtioSCSI=True,
+        multiQueues='4',
+        physicalBlockSize=None,
+        wwn='123456789abcdef0',
+    )
+
+    new_disk = vm_plugin.VmPlugin._get_new_disk(old_disk, volume)
+
+    driver = new_disk.find('driver')
+    assert driver.get('queues') is None
+    assert driver.find('iothreads') is None
+    assert new_disk.find('target').get('bus') == 'scsi'
+
+
+@pytest.mark.kvmagent
+def test_add_scsi_controller_records_alias_before_attach(monkeypatch):
+    class FakeDomain(object):
+        def attachDeviceFlags(self, xml, flags):
+            raise RuntimeError('attach failed')
+
+    class FakeVm(object):
+        domain = FakeDomain()
+
+        def find_scsi_controller_by_iothread(self, io_thread_id):
+            return "0"
+
+    aliases = []
+    monkeypatch.setattr(vm_plugin, 'get_vm_by_uuid', lambda uuid: FakeVm())
+    monkeypatch.setattr(vm_plugin.VmPlugin, 'get_next_scsi_controller_index', staticmethod(lambda vm: 3))
+
+    with pytest.raises(RuntimeError):
+        vm_plugin.VmPlugin.add_scsi_controller_with_driver('vm-uuid', queues=4, created_aliases=aliases)
+
+    assert aliases == ['scsi3']
+
+
+@pytest.mark.kvmagent
+def test_attach_data_volume_failure_cleans_created_mapping(monkeypatch):
+    class FakeDomain(object):
+        def attachDeviceFlags(self, xml, flags):
+            raise RuntimeError('disk attach failed')
+
+    class FakeCurrentVm(object):
+        def _get_target_disk(self, volume, is_exception=False):
+            return None, None
+
+    vm = vm_plugin.Vm()
+    vm.uuid = 'vm-uuid'
+    vm.domain = FakeDomain()
+    attached_disk_xml = []
+    volume = cbd_volume(
+        useVirtio=True,
+        useVirtioSCSI=True,
+        installPath='cbd:test-volume',
+        wwn='123456789abcdef0',
+        physicalBlockSize=None,
+    )
+    created_iothreads = []
+    deleted_iothreads = []
+    detached_aliases = []
+
+    def fake_attach_device(xml, flags):
+        attached_disk_xml.append(xml)
+        raise RuntimeError('disk attach failed')
+
+    def fake_add_controller(vm_uuid, io_thread_id=None, queues=None, mapping_allocator=None, created_aliases=None):
+        created_aliases.append('scsi5')
+        return 5
+
+    vm.domain.attachDeviceFlags = fake_attach_device
+    monkeypatch.setattr(vm_plugin.linux, 'retry', no_retry)
+    monkeypatch.setattr(vm_plugin.linux, 'wait_callback_success', lambda callback, *args: callback(None))
+    monkeypatch.setattr(vm_plugin, 'file_volume_check', lambda v: v)
+    monkeypatch.setattr(vm_plugin, 'get_vm_by_uuid', lambda uuid: FakeCurrentVm())
+    monkeypatch.setattr(vm_plugin.Vm, 'set_device_address', staticmethod(lambda *args: None))
+    monkeypatch.setattr(vm_plugin.VmPlugin, 'get_iothread_info', staticmethod(lambda uuid: []))
+    monkeypatch.setattr(vm_plugin.VmPlugin, 'add_io_thread',
+                        staticmethod(lambda uuid, iothread_id: created_iothreads.append(iothread_id) or None))
+    monkeypatch.setattr(vm_plugin.VmPlugin, 'del_io_thread',
+                        staticmethod(lambda uuid, iothread_id: deleted_iothreads.append(iothread_id) or None))
+    monkeypatch.setattr(vm_plugin.VmPlugin, 'add_scsi_controller_with_driver', staticmethod(fake_add_controller))
+    monkeypatch.setattr(vm, 'detach_controller_by_alias',
+                        lambda vm_uuid, alias: detached_aliases.append(alias) or None)
+
+    with pytest.raises(RuntimeError):
+        vm._attach_data_volume(volume, EmptyAddons())
+
+    assert created_iothreads == [101, 102, 103, 104, 105, 106, 107, 108]
+    assert deleted_iothreads == created_iothreads
+    assert detached_aliases == ['scsi5']
+    disk = vm_plugin.etree.fromstring(attached_disk_xml[0])
+    assert disk.find('driver').get('queues') is None
+    assert disk.find('driver').find('iothreads') is None
+    assert disk.find('target').get('bus') == 'scsi'
+
+
+@pytest.mark.kvmagent
+def test_detach_data_volume_keeps_referenced_iothread(monkeypatch):
+    class FakeDomain(object):
+        def detachDeviceFlags(self, xml, flags):
+            return None
+
+    class FakeTargetDisk(object):
+        def dump(self):
+            return '''
+            <disk type="network" device="disk">
+              <driver name="qemu" type="raw">
+                <iothreads>
+                  <iothread id="101"><queue id="0"/></iothread>
+                  <iothread id="102"><queue id="1"/></iothread>
+                </iothreads>
+              </driver>
+              <target dev="sdb" bus="scsi"/>
+              <address type="drive" controller="1"/>
+            </disk>
+            '''
+
+    class FakeVm(object):
+        def __init__(self, domain_xml):
+            self.domain_xml = domain_xml
+
+        def _get_target_disk(self, volume, is_exception=False):
+            return None, None
+
+    controller_xml = '''
+    <domain>
+      <devices>
+        <controller type="scsi" model="virtio-scsi" index="1">
+          <driver queues="16">
+            <iothreads>
+              <iothread id="101"><queue id="0"/></iothread>
+              <iothread id="102"><queue id="1"/></iothread>
+            </iothreads>
+          </driver>
+          <alias name="scsi1"/>
+        </controller>
+      </devices>
+    </domain>
+    '''
+    referenced_xml = '''
+    <domain>
+      <devices>
+        <disk type="network" device="disk">
+          <driver name="qemu" type="raw">
+            <iothreads>
+              <iothread id="101"><queue id="0"/></iothread>
+            </iothreads>
+          </driver>
+        </disk>
+      </devices>
+    </domain>
+    '''
+    current_vms = [
+        FakeVm('<domain><devices/></domain>'),
+        FakeVm(controller_xml),
+        FakeVm(referenced_xml),
+    ]
+    vm = vm_plugin.Vm()
+    vm.uuid = 'vm-uuid'
+    vm.domain = FakeDomain()
+    vm.domain_xml = controller_xml
+    volume = cbd_volume(
+        useVirtio=False,
+        useVirtioSCSI=True,
+        installPath='cbd:test-volume',
+        volumeUuid='volume-uuid',
+    )
+    detached_aliases = []
+    deleted_iothreads = []
+
+    def fake_get_vm_by_uuid(uuid):
+        return current_vms.pop(0) if current_vms else FakeVm(referenced_xml)
+
+    monkeypatch.setattr(vm_plugin.linux, 'retry', no_retry)
+    monkeypatch.setattr(vm_plugin.linux, 'wait_callback_success', lambda callback, *args: callback(None))
+    monkeypatch.setattr(vm_plugin, 'get_vm_by_uuid', fake_get_vm_by_uuid)
+    monkeypatch.setattr(vm_plugin, 'is_libvirt_support_blockdev', lambda version: True)
+    monkeypatch.setattr(vm_plugin.VmPlugin, 'del_io_thread',
+                        staticmethod(lambda uuid, iothread_id: deleted_iothreads.append(iothread_id) or None))
+    monkeypatch.setattr(vm, '_get_target_disk', lambda v: (FakeTargetDisk(), 'sdb'))
+    monkeypatch.setattr(vm, 'detach_controller_by_alias',
+                        lambda vm_uuid, alias: detached_aliases.append(alias) or None)
+
+    vm._detach_data_volume(volume)
+
+    assert detached_aliases == ['scsi1']
+    assert deleted_iothreads == [102]

--- a/tests/unit/kvmagent/test_vm_iothread_vq_mapping.py
+++ b/tests/unit/kvmagent/test_vm_iothread_vq_mapping.py
@@ -47,6 +47,10 @@ def no_retry(*args, **kwargs):
     return decorator
 
 
+class FakeLibvirtError(Exception):
+    pass
+
+
 @pytest.mark.kvmagent
 def test_is_virtio_blk_excludes_virtio_scsi():
     assert vm_plugin.is_virtio_blk(cbd_volume(useVirtio=True, useVirtioSCSI=False))
@@ -268,6 +272,7 @@ def test_attach_data_volume_failure_cleans_created_mapping(monkeypatch):
     monkeypatch.setattr(vm_plugin.linux, 'wait_callback_success', lambda callback, *args: callback(None))
     monkeypatch.setattr(vm_plugin, 'file_volume_check', lambda v: v)
     monkeypatch.setattr(vm_plugin, 'get_vm_by_uuid', lambda uuid: FakeCurrentVm())
+    monkeypatch.setattr(vm_plugin.libvirt, 'libvirtError', FakeLibvirtError)
     monkeypatch.setattr(vm_plugin.Vm, 'set_device_address', staticmethod(lambda *args: None))
     monkeypatch.setattr(vm_plugin.VmPlugin, 'get_iothread_info', staticmethod(lambda uuid: []))
     monkeypatch.setattr(vm_plugin.VmPlugin, 'add_io_thread',
@@ -276,7 +281,8 @@ def test_attach_data_volume_failure_cleans_created_mapping(monkeypatch):
                         staticmethod(lambda uuid, iothread_id: deleted_iothreads.append(iothread_id) or None))
     monkeypatch.setattr(vm_plugin.VmPlugin, 'add_scsi_controller_with_driver', staticmethod(fake_add_controller))
     monkeypatch.setattr(vm, 'detach_controller_by_alias',
-                        lambda vm_uuid, alias: detached_aliases.append(alias) or None)
+                        lambda vm_uuid, alias: detached_aliases.append(alias) or None,
+                        raising=False)
 
     with pytest.raises(RuntimeError):
         vm._attach_data_volume(volume, EmptyAddons())
@@ -375,7 +381,8 @@ def test_detach_data_volume_keeps_referenced_iothread(monkeypatch):
                         staticmethod(lambda uuid, iothread_id: deleted_iothreads.append(iothread_id) or None))
     monkeypatch.setattr(vm, '_get_target_disk', lambda v: (FakeTargetDisk(), 'sdb'))
     monkeypatch.setattr(vm, 'detach_controller_by_alias',
-                        lambda vm_uuid, alias: detached_aliases.append(alias) or None)
+                        lambda vm_uuid, alias: detached_aliases.append(alias) or None,
+                        raising=False)
 
     vm._detach_data_volume(volume)
 

--- a/tests/unit/kvmagent/test_vm_iothread_vq_mapping.py
+++ b/tests/unit/kvmagent/test_vm_iothread_vq_mapping.py
@@ -51,6 +51,149 @@ class FakeLibvirtError(Exception):
     pass
 
 
+CLEAN_DOMAIN_XML = '<domain><devices/></domain>'
+
+
+class FakeDetachDomain(object):
+    def detachDeviceFlags(self, xml, flags):
+        return None
+
+
+class FakeTargetDisk(object):
+    def __init__(self, disk_xml):
+        self.disk_xml = disk_xml
+
+    def dump(self):
+        return self.disk_xml
+
+
+class FakeVm(object):
+    def __init__(self, domain_xml):
+        self.domain_xml = domain_xml
+
+    def _get_target_disk(self, volume, is_exception=False):
+        return None, None
+
+
+class DetachVolumeCleanupContext(object):
+    def __init__(self, vm, volume, detached_aliases, deleted_iothreads):
+        self.vm = vm
+        self.volume = volume
+        self.detached_aliases = detached_aliases
+        self.deleted_iothreads = deleted_iothreads
+
+
+def scsi_disk_xml(iothread_ids, dev='sdb', controller='1'):
+    iothreads_xml = '\n'.join(
+        ['                  <iothread id="%s"><queue id="0"/></iothread>' % iothread_id
+         for iothread_id in iothread_ids])
+    iothreads = '''
+                <iothreads>
+%s
+                </iothreads>''' % iothreads_xml if iothread_ids else ''
+    return '''
+            <disk type="network" device="disk">
+              <driver name="qemu" type="raw">
+%s
+              </driver>
+              <target dev="%s" bus="scsi"/>
+              <address type="drive" controller="%s"/>
+            </disk>
+            ''' % (iothreads, dev, controller)
+
+
+def scsi_controller_domain_xml(iothread_ids, queues='4', index='1', alias='scsi1', extra_devices=''):
+    iothreads_xml = '\n'.join(
+        ['              <iothread id="%s"><queue id="0"/></iothread>' % iothread_id
+         for iothread_id in iothread_ids])
+    iothreads = '''
+            <iothreads>
+%s
+            </iothreads>''' % iothreads_xml if iothread_ids else ''
+    return '''
+    <domain>
+      <devices>
+        <controller type="scsi" model="virtio-scsi" index="%s">
+          <driver queues="%s">
+%s
+          </driver>
+          <alias name="%s"/>
+        </controller>
+%s
+      </devices>
+    </domain>
+    ''' % (index, queues, iothreads, alias, extra_devices)
+
+
+def domain_xml_with_iothread_disk(iothread_ids, dev='sdc', controller='1'):
+    return '''
+    <domain>
+      <devices>
+%s
+      </devices>
+    </domain>
+    ''' % scsi_disk_xml(iothread_ids, dev, controller)
+
+
+def fake_wait_callback_success(callback, callback_data=None, timeout=60, interval=1,
+                               ignore_exception_in_callback=False):
+    for _ in range(4):
+        if callback(callback_data):
+            return True
+    return False
+
+
+def stub_detach_volume_dependencies(monkeypatch, vm, disk_xml, current_xmls,
+                                    detached_aliases, deleted_iothreads,
+                                    wait_callback_success=None,
+                                    detach_controller_result=None,
+                                    del_iothread_result=None):
+    current_vms = [FakeVm(domain_xml) for domain_xml in current_xmls]
+
+    def fake_get_vm_by_uuid(uuid):
+        return current_vms.pop(0) if current_vms else FakeVm(current_xmls[-1])
+
+    def fake_detach_controller(alias):
+        detached_aliases.append(alias)
+        return detach_controller_result(vm.uuid, alias) if callable(detach_controller_result) else detach_controller_result
+
+    def fake_del_iothread(uuid, iothread_id):
+        deleted_iothreads.append(iothread_id)
+        return del_iothread_result(uuid, iothread_id) if callable(del_iothread_result) else del_iothread_result
+
+    monkeypatch.setattr(vm_plugin.linux, 'retry', no_retry)
+    monkeypatch.setattr(vm_plugin.linux, 'wait_callback_success',
+                        wait_callback_success or (lambda callback, *args: callback(None)))
+    monkeypatch.setattr(vm_plugin.libvirt, 'libvirtError', RuntimeError)
+    monkeypatch.setattr(vm_plugin, 'get_vm_by_uuid', fake_get_vm_by_uuid)
+    monkeypatch.setattr(vm_plugin, 'is_libvirt_support_blockdev', lambda version: True)
+    monkeypatch.setattr(vm, 'detach_controller_by_alias', fake_detach_controller)
+    monkeypatch.setattr(vm_plugin.VmPlugin, 'del_io_thread', staticmethod(fake_del_iothread))
+    monkeypatch.setattr(vm, '_get_target_disk', lambda v: (FakeTargetDisk(disk_xml), 'sdb'))
+
+
+def setup_detach_volume_cleanup(monkeypatch, controller_xml, disk_xml, current_xmls,
+                                wait_callback_success=None, detach_controller_result=None,
+                                del_iothread_result=None, volume_kwargs=None):
+    vm = vm_plugin.Vm()
+    vm.uuid = 'vm-uuid'
+    vm.domain = FakeDetachDomain()
+    vm.domain_xml = controller_xml
+    volume_args = {
+        'useVirtio': False,
+        'useVirtioSCSI': True,
+        'installPath': 'cbd:test-volume',
+        'volumeUuid': 'volume-uuid',
+    }
+    volume_args.update(volume_kwargs or {})
+    detached_aliases = []
+    deleted_iothreads = []
+    stub_detach_volume_dependencies(
+        monkeypatch, vm, disk_xml, current_xmls, detached_aliases, deleted_iothreads,
+        wait_callback_success, detach_controller_result, del_iothread_result)
+    return DetachVolumeCleanupContext(vm, cbd_volume(**volume_args), detached_aliases, deleted_iothreads)
+
+
 @pytest.mark.kvmagent
 def test_is_virtio_blk_excludes_virtio_scsi():
     assert vm_plugin.is_virtio_blk(cbd_volume(useVirtio=True, useVirtioSCSI=False))
@@ -349,10 +492,6 @@ def test_attach_data_volume_failure_cleans_created_mapping(monkeypatch):
         def attachDeviceFlags(self, xml, flags):
             raise RuntimeError('disk attach failed')
 
-    class FakeCurrentVm(object):
-        def _get_target_disk(self, volume, is_exception=False):
-            return None, None
-
     vm = vm_plugin.Vm()
     vm.uuid = 'vm-uuid'
     vm.domain = FakeDomain()
@@ -379,9 +518,9 @@ def test_attach_data_volume_failure_cleans_created_mapping(monkeypatch):
     vm.domain.attachDeviceFlags = fake_attach_device
     monkeypatch.setattr(vm_plugin.linux, 'retry', no_retry)
     monkeypatch.setattr(vm_plugin.linux, 'wait_callback_success', lambda callback, *args: callback(None))
+    monkeypatch.setattr(vm_plugin.libvirt, 'libvirtError', RuntimeError)
     monkeypatch.setattr(vm_plugin, 'file_volume_check', lambda v: v)
-    monkeypatch.setattr(vm_plugin, 'get_vm_by_uuid', lambda uuid: FakeCurrentVm())
-    monkeypatch.setattr(vm_plugin.libvirt, 'libvirtError', FakeLibvirtError)
+    monkeypatch.setattr(vm_plugin, 'get_vm_by_uuid', lambda uuid: FakeVm(CLEAN_DOMAIN_XML))
     monkeypatch.setattr(vm_plugin.Vm, 'set_device_address', staticmethod(lambda *args: None))
     monkeypatch.setattr(vm_plugin.VmPlugin, 'get_iothread_info', staticmethod(lambda uuid: []))
     monkeypatch.setattr(vm_plugin.VmPlugin, 'add_io_thread',
@@ -390,14 +529,13 @@ def test_attach_data_volume_failure_cleans_created_mapping(monkeypatch):
                         staticmethod(lambda uuid, iothread_id: deleted_iothreads.append(iothread_id) or None))
     monkeypatch.setattr(vm_plugin.VmPlugin, 'add_scsi_controller_with_driver', staticmethod(fake_add_controller))
     monkeypatch.setattr(vm, 'detach_controller_by_alias',
-                        lambda vm_uuid, alias: detached_aliases.append(alias) or None,
-                        raising=False)
+                        lambda alias: detached_aliases.append(alias) or None)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(vm_plugin.kvmagent.KvmError):
         vm._attach_data_volume(volume, EmptyAddons())
 
     assert created_iothreads == [101, 102, 103, 104, 105, 106, 107, 108]
-    assert deleted_iothreads == created_iothreads
+    assert sorted(deleted_iothreads) == created_iothreads
     assert detached_aliases == ['scsi5']
     disk = vm_plugin.etree.fromstring(attached_disk_xml[0])
     assert disk.find('driver').get('queues') is None
@@ -407,93 +545,83 @@ def test_attach_data_volume_failure_cleans_created_mapping(monkeypatch):
 
 @pytest.mark.kvmagent
 def test_detach_data_volume_keeps_referenced_iothread(monkeypatch):
-    class FakeDomain(object):
-        def detachDeviceFlags(self, xml, flags):
-            return None
+    controller_xml = scsi_controller_domain_xml([101, 102], queues='16')
+    referenced_xml = domain_xml_with_iothread_disk([101])
+    ctx = setup_detach_volume_cleanup(
+        monkeypatch, controller_xml, scsi_disk_xml([101, 102]), [CLEAN_DOMAIN_XML, controller_xml, referenced_xml])
 
-    class FakeTargetDisk(object):
-        def dump(self):
-            return '''
-            <disk type="network" device="disk">
-              <driver name="qemu" type="raw">
-                <iothreads>
-                  <iothread id="101"><queue id="0"/></iothread>
-                  <iothread id="102"><queue id="1"/></iothread>
-                </iothreads>
-              </driver>
-              <target dev="sdb" bus="scsi"/>
-              <address type="drive" controller="1"/>
-            </disk>
-            '''
+    ctx.vm._detach_data_volume(ctx.volume)
 
-    class FakeVm(object):
-        def __init__(self, domain_xml):
-            self.domain_xml = domain_xml
+    assert ctx.detached_aliases == ['scsi1']
+    assert ctx.deleted_iothreads == [102]
 
-        def _get_target_disk(self, volume, is_exception=False):
-            return None, None
 
-    controller_xml = '''
-    <domain>
-      <devices>
-        <controller type="scsi" model="virtio-scsi" index="1">
-          <driver queues="16">
-            <iothreads>
-              <iothread id="101"><queue id="0"/></iothread>
-              <iothread id="102"><queue id="1"/></iothread>
-            </iothreads>
-          </driver>
-          <alias name="scsi1"/>
-        </controller>
-      </devices>
-    </domain>
-    '''
-    referenced_xml = '''
-    <domain>
-      <devices>
-        <disk type="network" device="disk">
-          <driver name="qemu" type="raw">
-            <iothreads>
-              <iothread id="101"><queue id="0"/></iothread>
-            </iothreads>
-          </driver>
-        </disk>
-      </devices>
-    </domain>
-    '''
-    current_vms = [
-        FakeVm('<domain><devices/></domain>'),
-        FakeVm(controller_xml),
-        FakeVm(referenced_xml),
-    ]
-    vm = vm_plugin.Vm()
-    vm.uuid = 'vm-uuid'
-    vm.domain = FakeDomain()
-    vm.domain_xml = controller_xml
-    volume = cbd_volume(
-        useVirtio=False,
-        useVirtioSCSI=True,
-        installPath='cbd:test-volume',
-        volumeUuid='volume-uuid',
-    )
-    detached_aliases = []
-    deleted_iothreads = []
+@pytest.mark.kvmagent
+def test_detach_data_volume_keeps_controller_with_attached_disk(monkeypatch):
+    still_attached_disk_xml = scsi_disk_xml([101], dev='sdc')
+    controller_xml = scsi_controller_domain_xml([101])
+    still_attached_xml = scsi_controller_domain_xml([101], extra_devices=still_attached_disk_xml)
+    ctx = setup_detach_volume_cleanup(
+        monkeypatch, controller_xml, scsi_disk_xml([101]), [CLEAN_DOMAIN_XML, still_attached_xml])
 
-    def fake_get_vm_by_uuid(uuid):
-        return current_vms.pop(0) if current_vms else FakeVm(referenced_xml)
+    ctx.vm._detach_data_volume(ctx.volume)
 
-    monkeypatch.setattr(vm_plugin.linux, 'retry', no_retry)
-    monkeypatch.setattr(vm_plugin.linux, 'wait_callback_success', lambda callback, *args: callback(None))
-    monkeypatch.setattr(vm_plugin, 'get_vm_by_uuid', fake_get_vm_by_uuid)
-    monkeypatch.setattr(vm_plugin, 'is_libvirt_support_blockdev', lambda version: True)
-    monkeypatch.setattr(vm_plugin.VmPlugin, 'del_io_thread',
-                        staticmethod(lambda uuid, iothread_id: deleted_iothreads.append(iothread_id) or None))
-    monkeypatch.setattr(vm, '_get_target_disk', lambda v: (FakeTargetDisk(), 'sdb'))
-    monkeypatch.setattr(vm, 'detach_controller_by_alias',
-                        lambda vm_uuid, alias: detached_aliases.append(alias) or None,
-                        raising=False)
+    assert ctx.detached_aliases == []
+    assert ctx.deleted_iothreads == []
 
-    vm._detach_data_volume(volume)
 
-    assert detached_aliases == ['scsi1']
-    assert deleted_iothreads == [102]
+@pytest.mark.kvmagent
+def test_detach_data_volume_retries_iothread_cleanup_after_stale_reference(monkeypatch):
+    controller_xml = scsi_controller_domain_xml([101])
+    ctx = setup_detach_volume_cleanup(
+        monkeypatch, controller_xml, scsi_disk_xml([101]),
+        [CLEAN_DOMAIN_XML, controller_xml, controller_xml, CLEAN_DOMAIN_XML],
+        fake_wait_callback_success)
+
+    ctx.vm._detach_data_volume(ctx.volume)
+
+    assert ctx.detached_aliases == ['scsi1']
+    assert ctx.deleted_iothreads == [101]
+
+
+@pytest.mark.kvmagent
+def test_detach_data_volume_waits_for_controller_cleanup_without_iothreads(monkeypatch):
+    controller_xml = scsi_controller_domain_xml([])
+    ctx = setup_detach_volume_cleanup(
+        monkeypatch, controller_xml, scsi_disk_xml([]),
+        [CLEAN_DOMAIN_XML, controller_xml, controller_xml, CLEAN_DOMAIN_XML],
+        fake_wait_callback_success)
+
+    ctx.vm._detach_data_volume(ctx.volume)
+
+    assert ctx.detached_aliases == ['scsi1']
+    assert ctx.deleted_iothreads == []
+
+
+@pytest.mark.kvmagent
+def test_detach_data_volume_waits_after_controller_cleanup_command_error(monkeypatch):
+    controller_xml = scsi_controller_domain_xml([101])
+    ctx = setup_detach_volume_cleanup(
+        monkeypatch, controller_xml, scsi_disk_xml([101]),
+        [CLEAN_DOMAIN_XML, controller_xml, controller_xml, CLEAN_DOMAIN_XML],
+        fake_wait_callback_success,
+        detach_controller_result='error: detach failed')
+
+    ctx.vm._detach_data_volume(ctx.volume)
+
+    assert ctx.detached_aliases == ['scsi1']
+    assert ctx.deleted_iothreads == [101]
+
+
+@pytest.mark.kvmagent
+def test_detach_data_volume_reports_iothread_cleanup_command_error(monkeypatch):
+    controller_xml = scsi_controller_domain_xml([101])
+    ctx = setup_detach_volume_cleanup(
+        monkeypatch, controller_xml, scsi_disk_xml([101]), [CLEAN_DOMAIN_XML, CLEAN_DOMAIN_XML, CLEAN_DOMAIN_XML],
+        fake_wait_callback_success,
+        del_iothread_result='error: iothreaddel failed')
+
+    ctx.vm._detach_data_volume(ctx.volume)
+
+    assert ctx.detached_aliases == ['scsi1']
+    assert set(ctx.deleted_iothreads) == set([101])

--- a/tests/unit/kvmagent/test_vm_iothread_vq_mapping.py
+++ b/tests/unit/kvmagent/test_vm_iothread_vq_mapping.py
@@ -31,6 +31,28 @@ def cbd_volume(**kwargs):
     return Volume(**values)
 
 
+def drive_address(controller, unit):
+    return Volume(type='drive', controller=str(controller), unit=str(unit))
+
+
+def pci_address(**kwargs):
+    values = {
+        'type': 'pci',
+        'domain': '0x0000',
+        'bus': '0x00',
+        'slot': '0x05',
+        'function': '0x0',
+    }
+    values.update(kwargs)
+    return Volume(**values)
+
+
+def disk_with_target(bus):
+    disk = vm_plugin.etree.Element('disk')
+    vm_plugin.e(disk, 'target', None, {'dev': 'sd%s' % vm_plugin.Vm.DEVICE_LETTERS[1], 'bus': bus})
+    return disk
+
+
 class EmptyAddons(object):
     def __init__(self):
         self.attachedDataVolumes = []
@@ -282,6 +304,227 @@ def test_non_cbd_volume_can_use_dedicated_scsi_controller_without_automatic_mapp
 
 
 @pytest.mark.kvmagent
+def test_set_device_address_ignores_conflicting_virtio_scsi_persisted_controller():
+    disk = disk_with_target('scsi')
+    volume = cbd_volume(
+        useVirtio=True,
+        useVirtioSCSI=True,
+        multiQueues='0',
+        ioThreads=0,
+        ioThreadId=0,
+        controllerIndex=1,
+        deviceAddress=drive_address(1, 1),
+    )
+
+    vm_plugin.Vm.set_device_address(disk, volume)
+
+    address = disk.find('address')
+    assert address.get('type') == 'drive'
+    assert address.get('controller') == '0'
+    assert address.get('unit') == str(vm_plugin.Vm.get_device_unit(volume.deviceId))
+
+
+@pytest.mark.kvmagent
+def test_set_device_address_ignores_non_virtio_scsi_persisted_controller():
+    disk = disk_with_target('scsi')
+    volume = cbd_volume(
+        useVirtio=True,
+        useVirtioSCSI=False,
+        multiQueues='0',
+        ioThreads=0,
+        ioThreadId=0,
+        controllerIndex=1,
+        deviceAddress=drive_address(1, 1),
+    )
+
+    vm_plugin.Vm.set_device_address(disk, volume)
+
+    address = disk.find('address')
+    assert address.get('type') == 'drive'
+    assert address.get('controller') == '0'
+    assert address.get('unit') == str(vm_plugin.Vm.get_device_unit(volume.deviceId))
+
+
+@pytest.mark.kvmagent
+def test_set_device_address_reuses_matching_virtio_scsi_persisted_controller():
+    disk = disk_with_target('scsi')
+    volume = cbd_volume(
+        useVirtio=True,
+        useVirtioSCSI=True,
+        multiQueues='4',
+        ioThreads=4,
+        ioThreadId=0,
+        controllerIndex=1,
+        deviceAddress=drive_address(1, 7),
+    )
+
+    vm_plugin.Vm.set_device_address(disk, volume)
+
+    address = disk.find('address')
+    assert address.get('type') == 'drive'
+    assert address.get('controller') == '1'
+    assert address.get('unit') == '7'
+
+
+@pytest.mark.kvmagent
+def test_set_device_address_ignores_default_controller_when_dedicated_plan_exists():
+    disk = disk_with_target('scsi')
+    volume = cbd_volume(
+        useVirtio=True,
+        useVirtioSCSI=True,
+        multiQueues='4',
+        ioThreads=4,
+        ioThreadId=0,
+        controllerIndex=1,
+        deviceAddress=drive_address(0, 5),
+    )
+
+    vm_plugin.Vm.set_device_address(disk, volume)
+
+    address = disk.find('address')
+    assert address.get('type') == 'drive'
+    assert address.get('controller') == '1'
+    assert address.get('unit') == str(vm_plugin.Vm.get_device_unit(volume.deviceId))
+
+
+@pytest.mark.kvmagent
+def test_set_device_address_ignores_mismatched_dedicated_persisted_controller():
+    disk = disk_with_target('scsi')
+    volume = cbd_volume(
+        useVirtio=True,
+        useVirtioSCSI=True,
+        multiQueues='4',
+        ioThreads=4,
+        ioThreadId=0,
+        controllerIndex=2,
+        deviceAddress=drive_address(1, 7),
+    )
+
+    vm_plugin.Vm.set_device_address(disk, volume)
+
+    address = disk.find('address')
+    assert address.get('type') == 'drive'
+    assert address.get('controller') == '2'
+    assert address.get('unit') == str(vm_plugin.Vm.get_device_unit(volume.deviceId))
+
+
+@pytest.mark.kvmagent
+def test_set_device_address_checks_occupied_units_on_dedicated_controller():
+    class FakeAttachVm(object):
+        def get_occupied_disk_address_units(self, bus, controller):
+            assert bus == 'scsi'
+            assert controller == 2
+            return [vm_plugin.Vm.get_device_unit(1)]
+
+    disk = disk_with_target('scsi')
+    volume = cbd_volume(
+        useVirtio=True,
+        useVirtioSCSI=True,
+        multiQueues='4',
+        ioThreads=4,
+        ioThreadId=0,
+        controllerIndex=2,
+        deviceAddress=drive_address(1, 7),
+    )
+
+    vm_plugin.Vm.set_device_address(disk, volume, FakeAttachVm())
+
+    address = disk.find('address')
+    assert address.get('type') == 'drive'
+    assert address.get('controller') == '2'
+    assert address.get('unit') == str(vm_plugin.Vm.get_device_unit(1) + 1)
+
+
+@pytest.mark.kvmagent
+def test_set_device_address_falls_back_to_default_controller_and_bumps_occupied_unit():
+    class FakeAttachVm(object):
+        def get_occupied_disk_address_units(self, bus, controller):
+            assert bus == 'scsi'
+            assert controller == 0
+            return [vm_plugin.Vm.get_device_unit(1)]
+
+    disk = disk_with_target('scsi')
+    volume = cbd_volume(
+        useVirtio=True,
+        useVirtioSCSI=True,
+        multiQueues='0',
+        ioThreads=0,
+        ioThreadId=0,
+        controllerIndex=1,
+        deviceAddress=drive_address(1, 1),
+    )
+
+    vm_plugin.Vm.set_device_address(disk, volume, FakeAttachVm())
+
+    address = disk.find('address')
+    assert address.get('type') == 'drive'
+    assert address.get('controller') == '0'
+    assert address.get('unit') == str(vm_plugin.Vm.get_device_unit(1) + 1)
+
+
+@pytest.mark.kvmagent
+def test_set_device_address_keeps_default_virtio_scsi_persisted_controller():
+    disk = disk_with_target('scsi')
+    volume = cbd_volume(
+        useVirtio=True,
+        useVirtioSCSI=True,
+        multiQueues='0',
+        ioThreads=0,
+        ioThreadId=0,
+        deviceAddress=drive_address(0, 5),
+    )
+
+    vm_plugin.Vm.set_device_address(disk, volume)
+
+    address = disk.find('address')
+    assert address.get('type') == 'drive'
+    assert address.get('controller') == '0'
+    assert address.get('unit') == '5'
+
+
+@pytest.mark.kvmagent
+@pytest.mark.parametrize('controller, unit', [
+    (None, 5),
+    ('', 5),
+    (0, None),
+    (0, ''),
+])
+def test_set_device_address_replans_incomplete_virtio_scsi_persisted_drive_address(controller, unit):
+    disk = disk_with_target('scsi')
+    volume = cbd_volume(
+        useVirtio=True,
+        useVirtioSCSI=True,
+        multiQueues='0',
+        ioThreads=0,
+        ioThreadId=0,
+        deviceAddress=Volume(type='drive', controller=controller, unit=unit),
+    )
+
+    vm_plugin.Vm.set_device_address(disk, volume)
+
+    address = disk.find('address')
+    assert address.get('type') == 'drive'
+    assert address.get('controller') == '0'
+    assert address.get('unit') == str(vm_plugin.Vm.get_device_unit(volume.deviceId))
+
+
+@pytest.mark.kvmagent
+def test_set_device_address_keeps_virtio_blk_pci_address():
+    disk = disk_with_target('virtio')
+    volume = cbd_volume(
+        useVirtio=True,
+        useVirtioSCSI=False,
+        deviceAddress=pci_address(slot='0x09'),
+    )
+
+    vm_plugin.Vm.set_device_address(disk, volume)
+
+    address = disk.find('address')
+    assert address.get('type') == 'pci'
+    assert address.get('slot') == '0x09'
+
+
+@pytest.mark.kvmagent
 def test_iothread_vq_mapping_allocator_writes_individual_queues():
     volume = cbd_volume(ioThreads=7)
     allocator = vm_plugin.IothreadVqMappingAllocator.allocate(volume, set())
@@ -488,14 +731,16 @@ def test_add_scsi_controller_records_alias_before_attach(monkeypatch):
 
 @pytest.mark.kvmagent
 def test_attach_data_volume_failure_cleans_created_mapping(monkeypatch):
+    attached_disk_xml = []
+
     class FakeDomain(object):
         def attachDeviceFlags(self, xml, flags):
+            attached_disk_xml.append(xml)
             raise RuntimeError('disk attach failed')
 
     vm = vm_plugin.Vm()
     vm.uuid = 'vm-uuid'
     vm.domain = FakeDomain()
-    attached_disk_xml = []
     volume = cbd_volume(
         useVirtio=True,
         useVirtioSCSI=True,
@@ -507,15 +752,10 @@ def test_attach_data_volume_failure_cleans_created_mapping(monkeypatch):
     deleted_iothreads = []
     detached_aliases = []
 
-    def fake_attach_device(xml, flags):
-        attached_disk_xml.append(xml)
-        raise RuntimeError('disk attach failed')
-
     def fake_add_controller(vm_uuid, io_thread_id=None, queues=None, mapping_allocator=None, created_aliases=None):
         created_aliases.append('scsi5')
         return 5
 
-    vm.domain.attachDeviceFlags = fake_attach_device
     monkeypatch.setattr(vm_plugin.linux, 'retry', no_retry)
     monkeypatch.setattr(vm_plugin.linux, 'wait_callback_success', lambda callback, *args: callback(None))
     monkeypatch.setattr(vm_plugin.libvirt, 'libvirtError', RuntimeError)

--- a/tests/unit/kvmagent/test_vm_plugin_handlers.py
+++ b/tests/unit/kvmagent/test_vm_plugin_handlers.py
@@ -347,9 +347,6 @@ class TestGetIothreadPinHandler:
 class TestQueryBlockJobStatusHandler:
     def test_query_block_job_status(self):
         plugin = _make_vm_plugin()
-        # return [] so the empty-result retry loop in query_block_job_status
-        # is actually exercised; bare MagicMock() returns a truthy mock which
-        # would break out of the loop on the first iteration (call_count=1).
         vm_plugin.qmp.execute_qmp_command = MagicMock(return_value=[])
         with patch('time.sleep', return_value=None):
             req = _make_req({'vmUuid': 'vm-uuid'})
@@ -357,6 +354,8 @@ class TestQueryBlockJobStatusHandler:
             rsp = json.loads(result)
 
         assert rsp['success'] is True
+        assert rsp['status'] == 'completed'
+        assert rsp['percent'] == 100
         assert vm_plugin.qmp.execute_qmp_command.call_count == 6
 
 
@@ -2872,6 +2871,39 @@ class TestVmStartCmdXmlBuild:
                 ]
         return jsonobject.loads(json.dumps(cmd_dict))
 
+    def _driver_by_target(self, root, dev):
+        for disk in root.findall('./devices/disk'):
+            target = disk.find('target')
+            if target is not None and target.get('dev') == dev:
+                return disk.find('driver')
+        raise AssertionError("disk target %s not found" % dev)
+
+    def _driver_by_bus(self, root, bus):
+        for disk in root.findall('./devices/disk'):
+            target = disk.find('target')
+            if target is not None and target.get('bus') == bus:
+                return disk.find('driver')
+        raise AssertionError("disk bus %s not found" % bus)
+
+    def _driver_by_serial(self, root, serial_text):
+        for disk in root.findall('./devices/disk'):
+            serial = disk.find('serial')
+            if serial is not None and serial.text == serial_text:
+                return disk.find('driver')
+        raise AssertionError("disk serial %s not found" % serial_text)
+
+    def _scsi_controller_driver(self, root):
+        for controller in root.findall('./devices/controller'):
+            if controller.get('type') == 'scsi' and controller.find('driver') is not None:
+                return controller.find('driver')
+        raise AssertionError("virtio-scsi controller driver not found")
+
+    def _iothread_queue_mapping(self, driver):
+        return [
+            (iothread.get('id'), [queue.get('id') for queue in iothread.findall('queue')])
+            for iothread in driver.findall('./iothreads/iothread')
+        ]
+
     def test_from_start_vm_cmd_builds_xml_with_features(self):
         vm_plugin.ovs.OvsDpdkSupportVnic = []
         vm_plugin.pci.need_config_pcimmio = MagicMock(return_value=True)
@@ -2968,6 +3000,146 @@ class TestVmStartCmdXmlBuild:
         xml_str = vm.domain_xml.decode() if isinstance(vm.domain_xml, bytes) else vm.domain_xml
         assert '<vcpu' in xml_str
         assert 'numa' in xml_str
+
+    def test_cdp_cbd_recover_nbd_disk_keeps_iothread_vq_mapping(self):
+        vm_plugin.ovs.OvsDpdkSupportVnic = []
+        vm_plugin.linux.get_cpu_model = MagicMock(return_value=('GenuineIntel', 'Intel'))
+        vm_plugin.is_ioapic_supported = MagicMock(return_value=True)
+        vm_plugin.is_spice_tls = MagicMock(return_value=0)
+        vm_plugin.VmPlugin.clean_vm_firmware_flash = MagicMock()
+        vm_plugin.bash.bash_roe = MagicMock(return_value=(0, '', ''))
+        vm_plugin.uuidhelper.to_full_uuid = MagicMock(side_effect=lambda value: value)
+        vm_plugin.VM_RECOVER_DICT = {}
+
+        def _real_parse_url(uri):
+            normalized = vm_plugin.re.sub(r'^([a-zA-Z]+:)(?!/{2})', r'\1//', uri, count=1)
+            return urllib.parse.urlparse(normalized)
+
+        def _e_with_text(parent, tag, value=None, attrib=None, usenamesapce=False):
+            _ = usenamesapce
+            if attrib is None:
+                attrib = {}
+            attrib = {k: str(v) for k, v in attrib.items()}
+            elem = vm_plugin.etree.SubElement(parent, tag, attrib)
+            if value:
+                elem.text = str(value)
+            return elem
+
+        cmd = self._build_start_cmd(use_numa=False)
+        cmd.addons.ioThreadNum = 0
+        cmd.addons.ioThreadPins = []
+        cmd.addons.VolumeQos = None
+        cmd.addons.NicQos = None
+        cmd.addons.pciDevice = []
+        cmd.addons.mdevDevice = []
+        cmd.addons.storageDevice = []
+        cmd.addons.usbDevice = []
+        cmd.cdRoms = []
+        cmd.nics = []
+        cmd.rootVolume.deviceType = 'cbd'
+        cmd.rootVolume.installPath = 'cbd://pool/root-volume?r=nbd://127.0.0.1:10809/root'
+        cmd.rootVolume.volumeUuid = 'vol-root-cbd'
+        cmd.rootVolume.multiQueues = 4
+        cmd.rootVolume.ioThreads = 4
+        cmd.rootVolume.ioThreadId = None
+        cmd.rootVolume.physicalBlockSize = None
+        cmd.dataVolumes = jsonobject.loads(json.dumps([
+            {
+                'deviceId': 1,
+                'deviceType': 'cbd',
+                'installPath': 'cbd://pool/data-volume?r=nbd://127.0.0.1:10810/data',
+                'useVirtio': True,
+                'useVirtioSCSI': False,
+                'volumeUuid': 'vol-data-cbd',
+                'shareable': False,
+                'multiQueues': 4,
+                'ioThreads': 4,
+                'ioThreadId': None,
+                'physicalBlockSize': None,
+            },
+            {
+                'deviceId': 2,
+                'deviceType': 'cbd',
+                'installPath': 'cbd://pool/scsi-volume?r=nbd://127.0.0.1:10811/scsi',
+                'useVirtio': True,
+                'useVirtioSCSI': True,
+                'volumeUuid': 'vol-scsi-cbd',
+                'shareable': False,
+                'multiQueues': 4,
+                'ioThreads': 4,
+                'ioThreadId': None,
+                'physicalBlockSize': None,
+                'wwn': 'wwn-scsi-cbd',
+            },
+            {
+                'deviceId': 3,
+                'deviceType': 'ceph',
+                'installPath': 'ceph://pool/non-cbd-volume?r=nbd://127.0.0.1:10812/non-cbd',
+                'useVirtio': True,
+                'useVirtioSCSI': False,
+                'volumeUuid': 'vol-non-cbd',
+                'shareable': False,
+                'multiQueues': 4,
+                'ioThreads': 4,
+                'ioThreadId': None,
+                'physicalBlockSize': None,
+                'secretUuid': 'ceph-secret',
+                'monInfo': [{'hostname': '10.0.0.2', 'port': 6789}],
+            },
+            {
+                'deviceId': 4,
+                'deviceType': 'cbd',
+                'installPath': 'cbd://pool/manual-iothread-volume?r=nbd://127.0.0.1:10813/manual',
+                'useVirtio': True,
+                'useVirtioSCSI': False,
+                'volumeUuid': 'vol-manual-cbd',
+                'shareable': False,
+                'multiQueues': 4,
+                'ioThreads': 4,
+                'ioThreadId': 9,
+                'physicalBlockSize': None,
+            },
+        ]))
+
+        orig_tostring = vm_plugin.etree.tostring
+        with patch('os.path.exists', return_value=True), \
+                patch.object(vm_plugin, 'parse_url', side_effect=_real_parse_url), \
+                patch.object(vm_plugin, 'xrange', range, create=True), \
+                patch.object(vm_plugin, 'range', self._RangeCompat), \
+                patch.object(vm_plugin, 'e', side_effect=_e_with_text), \
+                patch.object(vm_plugin.etree, 'tostring', side_effect=orig_tostring):
+            vm = vm_plugin.Vm.from_StartVmCmd(cmd)
+
+        xml_str = vm.domain_xml.decode() if isinstance(vm.domain_xml, bytes) else vm.domain_xml
+        root = vm_plugin.etree.fromstring(xml_str)
+        root_driver = self._driver_by_target(root, 'vda')
+        data_driver = self._driver_by_target(root, 'vdb')
+        scsi_driver = self._driver_by_bus(root, 'scsi')
+        non_cbd_driver = self._driver_by_serial(root, 'vol-non-cbd')
+        manual_cbd_driver = self._driver_by_serial(root, 'vol-manual-cbd')
+
+        assert root_driver.get('queues') == '4'
+        assert data_driver.get('queues') == '4'
+        assert non_cbd_driver.get('queues') == '4'
+        assert manual_cbd_driver.get('queues') == '4'
+        assert self._iothread_queue_mapping(root_driver) == [
+            ('101', ['0']), ('102', ['1']), ('103', ['2']), ('104', ['3'])
+        ]
+        assert self._iothread_queue_mapping(data_driver) == [
+            ('105', ['0']), ('106', ['1']), ('107', ['2']), ('108', ['3'])
+        ]
+        assert scsi_driver.find('iothreads') is None
+        assert self._scsi_controller_driver(root).get('queues') == '4'
+        assert self._iothread_queue_mapping(self._scsi_controller_driver(root)) == [
+            ('109', ['0']), ('110', ['1']), ('111', ['2']), ('112', ['3'])
+        ]
+        assert non_cbd_driver.find('iothreads') is None
+        assert manual_cbd_driver.find('iothreads') is None
+
+        recover_root_driver = vm_plugin.VM_RECOVER_DICT['vm-uuid']['vda'].find('driver')
+        recover_data_driver = vm_plugin.VM_RECOVER_DICT['vm-uuid']['vdb'].find('driver')
+        assert self._iothread_queue_mapping(recover_root_driver) == self._iothread_queue_mapping(root_driver)
+        assert self._iothread_queue_mapping(recover_data_driver) == self._iothread_queue_mapping(data_driver)
 
 
 @pytest.mark.kvmagent

--- a/tests/unit/kvmagent/test_vm_plugin_handlers.py
+++ b/tests/unit/kvmagent/test_vm_plugin_handlers.py
@@ -1133,14 +1133,13 @@ class TestDelScsiControllerHandler:
         controller.alias.name_ = 'scsi1'
         mock_vm.domain_xmlobject.devices.get_child_node_as_list = MagicMock(return_value=[controller])
         vm_plugin.get_vm_by_uuid = MagicMock(return_value=mock_vm)
-        plugin.detach_controller_by_alias = MagicMock()
 
         req = _make_req({'vmUuid': 'vm-uuid', 'ioThreadId': 1})
         result = plugin.del_scsi_controller(req)
         rsp = json.loads(result)
 
         assert rsp['success'] is True
-        plugin.detach_controller_by_alias.assert_called_once_with('vm-uuid', 'scsi1')
+        mock_vm.detach_controller_by_alias.assert_called_once_with('scsi1')
 
 
 @pytest.mark.kvmagent

--- a/tests/unit/kvmagent/test_vm_plugin_handlers.py
+++ b/tests/unit/kvmagent/test_vm_plugin_handlers.py
@@ -2939,6 +2939,7 @@ class TestVmStartCmdXmlBuild:
                 patch.object(vm_plugin, 'parse_url', side_effect=_real_parse_url), \
                 patch.object(vm_plugin, 'xrange', range, create=True), \
                 patch.object(vm_plugin, 'range', self._RangeCompat), \
+                patch.object(vm_plugin.kvmagent, 'get_host_os_type', return_value='ky10'), \
                 patch.object(vm_plugin, 'e', side_effect=_e_with_text), \
                 patch.object(vm_plugin.etree, 'tostring', side_effect=orig_tostring):
             cmd = self._build_start_cmd(use_numa=False)
@@ -2990,6 +2991,7 @@ class TestVmStartCmdXmlBuild:
                 patch.object(vm_plugin, 'is_hv_freq_supported', return_value=False), \
                 patch.object(vm_plugin, 'is_hv_synic_supported', return_value=False), \
                 patch.object(vm_plugin, 'range', self._RangeCompat), \
+                patch.object(vm_plugin.kvmagent, 'get_host_os_type', return_value='ky10'), \
                 patch.object(vm_plugin, 'e', side_effect=_e_with_text), \
                 patch.object(vm_plugin.etree, 'tostring', side_effect=orig_tostring):
             cmd = self._build_start_cmd(use_numa=True)

--- a/tests/unit/kvmagent/test_vm_plugin_handlers.py
+++ b/tests/unit/kvmagent/test_vm_plugin_handlers.py
@@ -2921,6 +2921,10 @@ class TestVmStartCmdXmlBuild:
         assert 'protocol="rbd"' in xml_str
         assert 'clean-traffic' in xml_str
         assert 'net0-slave1' in xml_str
+        root = vm_plugin.etree.fromstring(xml_str)
+        iothread_ids = {iothread.get('id') for iothread in root.findall('./iothreadids/iothread')}
+        assert iothread_ids == {'1', '2'}
+        assert root.find('iothreads').text == '2'
 
     def test_from_start_vm_cmd_builds_xml_with_numa(self):
         vm_plugin.ovs.OvsDpdkSupportVnic = []


### PR DESCRIPTION
## Summary
Sync `feature-5.5.28-zbs` into `5.5.28` through conflict-resolved branch `feature-5.5.28-zbs@@3`.

## Changes
- Merge KVM agent iothread VQ mapping XML, host capability reporting, migration queue preservation, CDP NBD mapping, and SCSI iothread cleanup fixes into current `5.5.28`.
- Resolve the `test_vm_plugin_handlers.py` conflict by preserving current handler coverage and the new iothread mapping assertions.
- Replay the FV branch as ordinary commits on top of current `5.5.28`, without carrying merge commits into the MR history.

## Testing
- [x] `git diff --check upstream/5.5.28..HEAD`
- [x] bundled Python `py_compile` for touched KVM agent plugin and test files
- [x] conflict marker scan across `zstack`, `premium`, `zstack-utility`
- [x] Change-Id check for all MR commits
- [ ] CI pipeline
- [ ] full agent test suite

sync from gitlab !7375