### PR TITLE
<fix>[zstacklib]: adapt file upload task protocol

### DIFF
--- a/cephbackupstorage/cephbackupstorage/cephagent.py
+++ b/cephbackupstorage/cephbackupstorage/cephagent.py
@@ -1406,7 +1406,10 @@ class CephAgent(object):
         rsp.completed = task.completed
         rsp.size = task.expectedSize
         rsp.actualSize = task.expectedSize
-        rsp.downloadSize = task.checked_download_size()
+        # File-upload LongJob uses downloadSize == 0 to decide whether the
+        # upload session has started. Report bytes actually received here;
+        # RangeSet still controls completion.
+        rsp.downloadSize = task.downloadSize
         rsp.lastOpTime = long(task.lastOpTime) * 1000
         rsp.supportSuspend = True
         if task.downloadSize == 0:
@@ -1421,6 +1424,8 @@ class CephAgent(object):
                 rsp.error = "Upload completed but file not found or empty"
                 return jsonobject.dumps(rsp)
             rsp.size = actual_size
+            rsp.actualSize = actual_size
+            rsp.downloadSize = actual_size
             rsp.md5sum = linux.get_file_md5sum_hashlib(task.installPath)
             rsp.installPath = task.installPath
             rsp.progress = 100

--- a/zstacklib/zstacklib/test/test_upload_task.py
+++ b/zstacklib/zstacklib/test/test_upload_task.py
@@ -21,7 +21,21 @@ _ORIGINAL_MODULES = dict((name, sys.modules.get(name, _MISSING)) for name in _ST
 
 if "xxhash" not in sys.modules:
     xxhash = types.ModuleType("xxhash")
-    xxhash.xxh3_64 = lambda: None
+
+    class FakeXxh3(object):
+        def __init__(self):
+            self.value = 0
+
+        def update(self, data):
+            for b in data:
+                if not isinstance(b, int):
+                    b = ord(b)
+                self.value = (self.value + b) & 0xffffffffffffffff
+
+        def hexdigest(self):
+            return "%016x" % self.value
+
+    xxhash.xxh3_64 = FakeXxh3
     sys.modules["xxhash"] = xxhash
 
 linux = types.ModuleType("zstacklib.utils.linux")
@@ -140,6 +154,12 @@ def make_upload_param(task_uuid="task-1", total_size=100, slice_offset=0, slice_
     return param
 
 
+def make_hash(algorithm, data):
+    hasher = upload_task_module.get_hasher(algorithm)
+    hasher.update(data)
+    return hasher.hexdigest()
+
+
 class TestEntity(object):
     fp = object()
 
@@ -165,6 +185,18 @@ class TestSizedReader(object):
         self.chunks = [b'ab', b'cd', b'']
 
     def read(self, size):
+        return self.chunks.pop(0)
+
+
+class SequenceSizedReader(object):
+    chunks = []
+
+    def __init__(self, fp, unused, size):
+        self.chunks = list(SequenceSizedReader.chunks)
+
+    def read(self, size):
+        if not self.chunks:
+            return b''
         return self.chunks.pop(0)
 
 
@@ -389,6 +421,89 @@ class TestUploadSliceFailureCounter(unittest.TestCase):
             self.assertEqual([b'abcd'], task.storage_object.contents)
         finally:
             linux.get_current_timestamp = old_get_current_timestamp
+            upload_task_module.Part = old_part
+            upload_task_module.SizedReader = old_sized_reader
+
+    def test_get_upload_param_accepts_file_headers_with_hash(self):
+        param = UploadHandler.get_upload_param({
+            'X-FILE-UUID': 'file-task-1',
+            'X-FILE-SIZE': '8',
+            'X-SLICE-OFFSET': '3',
+            'X-SLICE-SIZE': '5',
+            'X-SLICE-HASH': 'hash-value',
+            'X-HASH-ALGORITHM': 'xxh3',
+        })
+
+        self.assertEqual('file-task-1', param.task_uuid)
+        self.assertEqual(8, param.total_size)
+        self.assertEqual(3, param.slice_offset)
+        self.assertEqual(5, param.slice_size)
+        self.assertEqual('hash-value', param.slice_hash)
+        self.assertEqual('xxh3', param.hash_algorithm)
+
+    def test_file_upload_variable_slices_complete_without_slice_index(self):
+        old_part = upload_task_module.Part
+        old_sized_reader = upload_task_module.SizedReader
+        upload_task_module.Part = TestPart
+        upload_task_module.SizedReader = SequenceSizedReader
+        try:
+            task = StreamUploadTask("file-task-1", "/tmp/file")
+
+            SequenceSizedReader.chunks = [b'abc', b'']
+            param = UploadHandler.get_upload_param({
+                'X-FILE-UUID': 'file-task-1',
+                'X-FILE-SIZE': '8',
+                'X-SLICE-OFFSET': '0',
+                'X-SLICE-SIZE': '3',
+                'X-SLICE-HASH': make_hash('xxh3', b'abc'),
+                'X-HASH-ALGORITHM': 'xxh3',
+            })
+            task.expectedSize = param.total_size
+            UploadHandler.stream_body(TestEntity(), b'--boundary', param, task)
+            self.assertFalse(task.all_slice_uploaded())
+            self.assertEqual(3, task.checked_download_size())
+
+            SequenceSizedReader.chunks = [b'defgh', b'']
+            param = UploadHandler.get_upload_param({
+                'X-FILE-UUID': 'file-task-1',
+                'X-FILE-SIZE': '8',
+                'X-SLICE-OFFSET': '3',
+                'X-SLICE-SIZE': '5',
+                'X-SLICE-HASH': make_hash('xxh3', b'defgh'),
+                'X-HASH-ALGORITHM': 'xxh3',
+            })
+            UploadHandler.stream_body(TestEntity(), b'--boundary', param, task)
+
+            self.assertTrue(task.all_slice_uploaded())
+            self.assertEqual(8, task.checked_download_size())
+        finally:
+            upload_task_module.Part = old_part
+            upload_task_module.SizedReader = old_sized_reader
+
+    def test_file_upload_hash_mismatch_is_retryable(self):
+        old_part = upload_task_module.Part
+        old_sized_reader = upload_task_module.SizedReader
+        upload_task_module.Part = TestPart
+        upload_task_module.SizedReader = SequenceSizedReader
+        try:
+            task = StreamUploadTask("file-task-1", "/tmp/file")
+            task.expectedSize = 4
+            SequenceSizedReader.chunks = [b'abcd', b'']
+            param = UploadHandler.get_upload_param({
+                'X-FILE-UUID': 'file-task-1',
+                'X-FILE-SIZE': '4',
+                'X-SLICE-OFFSET': '0',
+                'X-SLICE-SIZE': '4',
+                'X-SLICE-HASH': 'bad-hash',
+                'X-HASH-ALGORITHM': 'xxh3',
+            })
+
+            with self.assertRaises(RetryableUploadError):
+                UploadHandler.stream_body(TestEntity(), b'--boundary', param, task)
+
+            self.assertFalse(task.completed)
+            self.assertEqual(0, task.downloadSize)
+        finally:
             upload_task_module.Part = old_part
             upload_task_module.SizedReader = old_sized_reader
 

--- a/zstacklib/zstacklib/utils/upload_task.py
+++ b/zstacklib/zstacklib/utils/upload_task.py
@@ -10,6 +10,11 @@ from zstacklib.utils import linux, lock
 from zstacklib.utils.rangeset import RangeSet
 from cherrypy._cpreqbody import Entity, Part, SizedReader
 
+try:
+    long
+except NameError:
+    long = int
+
 logger = logging.getLogger(__name__)
 BUFFER_SIZE = 16 * 1024 ** 2  # 16MB
 # Per-slice retry budget chosen to tolerate repeated weak-network read/EOF/hash
@@ -317,10 +322,23 @@ class UploadHandler(object):
         up.slice_size = get_long_field('X-SLICE-SIZE', default=up.total_size)
         up.slice_hash = headers.get('X-SLICE-HASH', None)
         up.hash_algorithm = headers.get('X-HASH-ALGORITHM', None)
+        if up.slice_hash is None and headers.get('X-SLICE-MD5', None):
+            up.slice_hash = headers.get('X-SLICE-MD5', None)
+            up.hash_algorithm = 'md5'
+
+        if up.total_size <= 0:
+            raise Exception('invalid total size header: %d' % up.total_size)
+
+        if up.slice_size <= 0:
+            raise Exception('invalid slice size header: %d' % up.slice_size)
 
         if up.slice_offset >= up.total_size:
             raise Exception('invalid slice offset header: %s, total_size: %d' %
                             (up.slice_offset, up.total_size))
+
+        if up.slice_size > up.total_size - up.slice_offset:
+            raise Exception('invalid slice range, offset=%d size=%d total_size=%d' %
+                            (up.slice_offset, up.slice_size, up.total_size))
         return up
 
     def get_upload_task(self, param):


### PR DESCRIPTION
Jira: ZSV-12575
Related: ZSV-12575

Adapt software package upload to image upload protocol.
Accept X-SLICE-HASH and X-HASH-ALGORITHM for file upload.
Keep X-SLICE-MD5 compatible for old upload clients.
Validate total size, slice size, and slice range.
Report actual received bytes for software package progress.
Keep RangeSet completion semantics for out-of-order slices.
Add tests for file headers, variable slices, and hash errors.

Test: PYTHONPATH=zstacklib python -m unittest
Test: zstacklib.test.test_upload_task
Test: python -m py_compile upload_task.py test_upload_task.py
Test: python -m py_compile cephagent.py

Change-Id: I657367627a6e766863696e6d62716d6c7a6c7576

sync from gitlab !7382