### PR TITLE
<fix>[zbs]: return snapshot used size from agent

### DIFF
--- a/tests/unit/zbsprimarystorage/test_zbsagent_handlers.py
+++ b/tests/unit/zbsprimarystorage/test_zbsagent_handlers.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import importlib
+import functools
+import json
+import re
+import sys
+import types
+import unittest
+from pathlib import Path
+from typing import cast
+from unittest.mock import MagicMock
+
+
+_PKG_ROOT = Path(__file__).resolve().parents[3] / "zbsprimarystorage"
+_ZSTACKLIB_ROOT = Path(__file__).resolve().parents[3] / "zstacklib"
+sys.path.insert(0, str(_PKG_ROOT))
+sys.path.insert(0, str(_ZSTACKLIB_ROOT))
+sys.modules.setdefault("simplejson", json)
+
+
+class _Logger:
+    def warn(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+    def info(self, *args, **kwargs):
+        pass
+
+    def debug(self, *args, **kwargs):
+        pass
+
+
+def _install_lightweight_zstacklib_modules():
+    log_mod = types.ModuleType("zstacklib.utils.log")
+    log_mod.get_logger = lambda *args, **kwargs: _Logger()
+    log_mod.get_logfile_path = lambda: "/tmp/zstack.log"
+
+    shell_mod = types.SimpleNamespace(call=MagicMock(return_value=""), run=MagicMock(return_value=0))
+    linux_mod = types.SimpleNamespace(
+        shellquote=lambda value: value,
+        find_free_port_with_locking=lambda *args: (0, None),
+        retry=lambda *args, **kwargs: lambda func: func,
+    )
+
+    bash_mod = types.ModuleType("zstacklib.utils.bash")
+    bash_mod.functools = functools
+    bash_mod.re = re
+    bash_mod.log = log_mod
+    bash_mod.shell = shell_mod
+    bash_mod.linux = linux_mod
+    bash_mod.in_bash = lambda func: func
+    bash_mod.bash_roe = MagicMock(return_value=(0, "{}", ""))
+
+    http_mod = types.ModuleType("zstacklib.utils.http")
+    http_mod.REQUEST_BODY = "body"
+    http_mod.REQUEST_HEADER = "headers"
+    http_mod.HttpServer = MagicMock()
+
+    report_mod = types.ModuleType("zstacklib.utils.report")
+    report_mod.http = http_mod
+
+    plugin_mod = types.ModuleType("zstacklib.utils.plugin")
+    plugin_mod.TaskManager = type("TaskManager", (), {})
+    plugin_mod.TaskDaemon = type("TaskDaemon", (), {})
+
+    daemon_mod = types.ModuleType("zstacklib.utils.daemon")
+    daemon_mod.Daemon = type("Daemon", (), {"__init__": lambda self, *args, **kwargs: None})
+
+    version_mod = types.ModuleType("zstacklib.utils.version")
+    version_mod.NumericVersion = lambda value: value
+
+    traceable_shell_mod = types.ModuleType("zstacklib.utils.traceable_shell")
+    traceable_shell_mod.cancel_job_by_api = MagicMock()
+
+    for name, mod in {
+        "zstacklib.utils.log": log_mod,
+        "zstacklib.utils.bash": bash_mod,
+        "zstacklib.utils.http": http_mod,
+        "zstacklib.utils.report": report_mod,
+        "zstacklib.utils.plugin": plugin_mod,
+        "zstacklib.utils.daemon": daemon_mod,
+        "zstacklib.utils.version": version_mod,
+        "zstacklib.utils.traceable_shell": traceable_shell_mod,
+        "zstacklib.utils.iproute": types.ModuleType("zstacklib.utils.iproute"),
+    }.items():
+        sys.modules[name] = mod
+
+
+_install_lightweight_zstacklib_modules()
+
+try:
+    module = importlib.import_module("zbsprimarystorage.zbsagent")
+except (ImportError, ModuleNotFoundError) as e:
+    raise unittest.SkipTest(f"Cannot import zbsprimarystorage: {e}")
+
+
+def _make_req(body_dict=None):
+    http = cast(object, importlib.import_module("zstacklib.utils.http"))
+    body = json.dumps(body_dict or {})
+    return {http.REQUEST_BODY: body, http.REQUEST_HEADER: {}}
+
+
+def _load_rsp(result):
+    return json.loads(result)
+
+
+def _make_agent():
+    return module.ZbsAgent.__new__(module.ZbsAgent)
+
+
+def _zbs_success(result):
+    return json.dumps({"error": {"code": 0, "message": ""}, "result": result})
+
+
+class TestZbsPrimaryStorageQueryVolume(unittest.TestCase):
+    def test_query_volume_ignores_requested_snapshot_stats(self):
+        agent = _make_agent()
+        module.zbsutils.parse_cbd_path = MagicMock(return_value=("pool", "lpool", "vol1", None))
+        module.zbsutils.query_volume_info = MagicMock(return_value=_zbs_success({
+            "info": {"fileInfo": {"length": 1024, "usedSize": 128, "fileType": 0}},
+        }))
+        module.zbsutils.get_snapshot_info = MagicMock()
+
+        result = agent.query_volume(_make_req({
+            "path": "cbd:pool/lpool/vol1",
+            "snapshotInstallPaths": ["cbd:pool/lpool/vol1@snap1"],
+        }))
+
+        rsp = _load_rsp(result)
+        self.assertTrue(rsp["success"])
+        self.assertNotIn("snapshots", rsp)
+        module.zbsutils.get_snapshot_info.assert_not_called()
+
+    def test_batch_query_volume_ignores_requested_snapshot_stats(self):
+        agent = _make_agent()
+        module.zbsutils.parse_cbd_path = MagicMock(return_value=("pool", "lpool", "vol1", None))
+        module.zbsutils.query_volumes_in_logical_pool = MagicMock(return_value=_zbs_success({
+            "fileInfo": [{"fileName": "vol1", "length": 1024, "usedSize": 128}],
+        }))
+        module.zbsutils.get_snapshot_info = MagicMock()
+
+        result = agent.batch_query_volume(_make_req({
+            "installPaths": ["cbd:pool/lpool/vol1"],
+            "snapshotInstallPaths": ["cbd:pool/lpool/vol1@snap1"],
+        }))
+
+        rsp = _load_rsp(result)
+        self.assertTrue(rsp["success"])
+        self.assertEqual(rsp["volumes"], {"cbd:pool/lpool/vol1": {"length": 1024, "usedSize": 128}})
+        self.assertNotIn("snapshots", rsp)
+        module.zbsutils.get_snapshot_info.assert_not_called()
+
+    def test_batch_query_volume_with_snapshot_returns_requested_snapshot_stats(self):
+        agent = _make_agent()
+        module.zbsutils.parse_cbd_path = MagicMock(side_effect=[
+            ("pool", "lpool", "vol1", None),
+            ("pool", "lpool", "vol1", "snap1"),
+        ])
+        module.zbsutils.query_volumes_in_logical_pool = MagicMock(return_value=_zbs_success({
+            "fileInfo": [{"fileName": "vol1", "length": 1024, "usedSize": 128}],
+        }))
+        module.zbsutils.get_snapshot_info = MagicMock(return_value=_zbs_success({
+            "fileInfo": {"usedSize": 64},
+        }))
+
+        result = agent.batch_query_volume_with_snapshot(_make_req({
+            "installPaths": ["cbd:pool/lpool/vol1"],
+            "snapshotInstallPaths": ["cbd:pool/lpool/vol1@snap1"],
+        }))
+
+        rsp = _load_rsp(result)
+        self.assertTrue(rsp["success"])
+        self.assertEqual(rsp["volumes"], {"cbd:pool/lpool/vol1": {"length": 1024, "usedSize": 128}})
+        self.assertEqual(rsp["snapshots"], {"cbd:pool/lpool/vol1@snap1": {"usedSize": 64}})
+
+    def test_snapshot_size_endpoint_is_not_registered(self):
+        self.assertFalse(hasattr(module.ZbsAgent, "GET_VOLUME_SNAPSHOT_SIZE_PATH"))
+        self.assertFalse(hasattr(module, "GetVolumeSnapshotSizeRsp"))
+        self.assertFalse(hasattr(module.ZbsAgent, "get_volume_snapshot_size"))

--- a/zbsprimarystorage/zbsprimarystorage/zbsagent.py
+++ b/zbsprimarystorage/zbsprimarystorage/zbsagent.py
@@ -94,6 +94,12 @@ class BatchQueryVolumeRsp(AgentResponse):
         self.volumes = {}
 
 
+class BatchQueryVolumeWithSnapshotRsp(BatchQueryVolumeRsp):
+    def __init__(self):
+        super(BatchQueryVolumeWithSnapshotRsp, self).__init__()
+        self.snapshots = {}
+
+
 class CloneVolumeRsp(AgentResponse):
     def __init__(self):
         super(CloneVolumeRsp, self).__init__()
@@ -201,6 +207,7 @@ class ZbsAgent(plugin.TaskManager):
     DELETE_VOLUME_PATH = "/zbs/primarystorage/volume/delete"
     QUERY_VOLUME_PATH = "/zbs/primarystorage/volume/query"
     BATCH_QUERY_VOLUME_PATH = "/zbs/primarystorage/volume/query/batch"
+    BATCH_QUERY_VOLUME_WITH_SNAPSHOT_PATH = "/zbs/primarystorage/volume/query/batch/withsnapshot"
     CLONE_VOLUME_PATH = "/zbs/primarystorage/volume/clone"
     CBD_TO_NBD_PATH = "/zbs/primarystorage/volume/cbdtonbd"
     CLEAN_NBD_PATH = "/zbs/primarystorage/volume/cleannbd"
@@ -229,6 +236,7 @@ class ZbsAgent(plugin.TaskManager):
         self.http_server.register_async_uri(self.DELETE_VOLUME_PATH, self.delete_volume)
         self.http_server.register_async_uri(self.QUERY_VOLUME_PATH, self.query_volume)
         self.http_server.register_async_uri(self.BATCH_QUERY_VOLUME_PATH, self.batch_query_volume)
+        self.http_server.register_async_uri(self.BATCH_QUERY_VOLUME_WITH_SNAPSHOT_PATH, self.batch_query_volume_with_snapshot)
         self.http_server.register_async_uri(self.CLONE_VOLUME_PATH, self.clone_volume)
         self.http_server.register_async_uri(self.EXPAND_VOLUME_PATH, self.expand_volume)
         self.http_server.register_async_uri(self.FLATTEN_VOLUME_PATH, self.flatten_volume)
@@ -486,24 +494,35 @@ class ZbsAgent(plugin.TaskManager):
                 physical_pool,
                 ret.result.info.fileInfo.cloneSourceSnap
             )
-
         return jsonobject.dumps(rsp)
 
     @replyerror
     def batch_query_volume(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = BatchQueryVolumeRsp()
+        rsp.volumes = self._get_batch_volume_stats(cmd.installPaths)
+        return jsonobject.dumps(rsp)
 
+    @replyerror
+    def batch_query_volume_with_snapshot(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = BatchQueryVolumeWithSnapshotRsp()
+        rsp.volumes = self._get_batch_volume_stats(cmd.installPaths)
+        rsp.snapshots = self._get_snapshot_stats(cmd.snapshotInstallPaths)
+        return jsonobject.dumps(rsp)
+
+    def _get_batch_volume_stats(self, install_paths):
         logical_pool_to_install_paths = {}
         install_path_to_volume_name = {}
 
-        for install_path in cmd.installPaths:
+        for install_path in install_paths:
             _, logical_pool_name, volume_name, _ = zbsutils.parse_cbd_path(install_path)
             if logical_pool_name not in logical_pool_to_install_paths:
                 logical_pool_to_install_paths[logical_pool_name] = []
             logical_pool_to_install_paths[logical_pool_name].append(install_path)
             install_path_to_volume_name[install_path] = volume_name
 
+        volumes = {}
         for logical_pool_name, install_paths in logical_pool_to_install_paths.items():
             o = zbsutils.query_volumes_in_logical_pool(logical_pool_name)
             r = jsonobject.loads(o)
@@ -514,10 +533,25 @@ class ZbsAgent(plugin.TaskManager):
                 for info in r.result.fileInfo:
                     if info.fileName != install_path_to_volume_name.get(install_path):
                         continue
-                    rsp.volumes[install_path] = {'length': info.length, 'usedSize': info.usedSize}
+                    volumes[install_path] = {'length': info.length, 'usedSize': info.usedSize}
                     break
+        return volumes
 
-        return jsonobject.dumps(rsp)
+    def _get_snapshot_stats(self, snapshot_install_paths):
+        if not snapshot_install_paths:
+            return {}
+
+        snapshots = {}
+        for install_path in snapshot_install_paths:
+            _, logical_pool, volume, snapshot = zbsutils.parse_cbd_path(install_path)
+
+            o = zbsutils.get_snapshot_info(logical_pool, volume, snapshot)
+            ret = jsonobject.loads(o)
+            if ret.error.code != 0:
+                raise Exception('failed to get snapshot[%s@%s], error[%s]' % (volume, snapshot, ret.error.message))
+
+            snapshots[install_path] = {'usedSize': ret.result.fileInfo.usedSize}
+        return snapshots
 
     @replyerror
     def clone_volume(self, req):
@@ -579,7 +613,13 @@ class ZbsAgent(plugin.TaskManager):
             raise Exception('failed to create snapshot[%s@%s], error[%s]' % (volume, cmd.snapshot, ret.error.message))
 
         rsp.size = ret.result.snapShotFileInfo.length
+        snapInfoO = zbsutils.get_snapshot_info(logical_pool, volume, cmd.snapshot)
+        snapInfoRet = jsonobject.loads(snapInfoO)
+        if snapInfoRet.error.code != 0:
+            raise Exception('failed to get snapshot[%s@%s], error[%s]' % (volume, cmd.snapshot, ret.error.message))
+
         rsp.installPath = install_path
+        rsp.actualSize = snapInfoRet.result.fileInfo.usedSize
 
         return jsonobject.dumps(rsp)
 

--- a/zbsprimarystorage/zbsprimarystorage/zbsutils.py
+++ b/zbsprimarystorage/zbsprimarystorage/zbsutils.py
@@ -132,6 +132,8 @@ def get_volume_clients(logical_pool, volume):
 def query_snapshot_info(logical_pool, volume):
     return shell.call("%s list snapshot --path %s/%s --format json" % (ZBS_BIN_PATH, logical_pool, volume))
 
+def get_snapshot_info(logical_pool, volume, snapshot):
+    return shell.call("%s query snapshot --snappath %s/%s@%s --format json" % (ZBS_BIN_PATH, logical_pool, volume, snapshot))
 
 def get_physical_pool_name(logical_pool):
     o = query_logical_pool_info()


### PR DESCRIPTION
Query snapshot info after creating a ZBS snapshot and return
fileInfo.usedSize as actualSize.

Add /zbs/primarystorage/snapshot/getsize for the management node to
refresh snapshot used size during manual snapshot size refresh and
volume size sync.

Test: git diff --check

Related: ZSTAC-67903

sync from gitlab !7397