### PR TITLE
<fix>[zstacklib]: align highmem mmio size

### DIFF
--- a/zstacklib/zstacklib/utils/pci.py
+++ b/zstacklib/zstacklib/utils/pci.py
@@ -118,7 +118,7 @@ def get_bars_max_addressable_memory():
         logger.warn("max_addressable_memory is None, please reconnect host and try again")
 
     if platform.machine() == 'aarch64':
-        return "%sG" % sizeunit.Byte.toGigaByte(max_addressable_memory_64bit)
+        return "%sG" % sizeunit.Byte.toGigaByte(calc_next_power_of_2(max_addressable_memory_64bit))
 
     if max_addressable_memory_64bit < DEFAULT_PCDPCIMMIO64SIZE_MIN_SIZE:
         return DEFAULT_PCDPCIMMIO64SIZE_MIN_SIZE / 1024 / 1024


### PR DESCRIPTION
## ZSTAC-86433

### Summary
Backport the ZSTAC-81398 zstack-utility fix to 5.4.10.

### Source
- Original Jira: ZSTAC-81398
- Source commit: b703040aa2f2

### Verification
- Cherry-pick to upstream/5.4.10 completed cleanly.
- `git diff --check upstream/5.4.10..HEAD` passed.
- Full regression was not run locally.

Related: ZSTAC-86433, ZSTAC-81398

sync from gitlab !7407