### PR TITLE
ZSTAC-86553 Fix IPv6 NBD URL formatting in kvmagent

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -185,6 +185,11 @@ def build_libvirt_tcp_uri(host):
     return 'tcp://%s' % network_ipv6.format_url_host(host)
 
 
+def build_nbd_url(host, port, export_name=None):
+    url = 'nbd://%s:%s' % (network_ipv6.format_url_host(host), port)
+    return '%s/%s' % (url, export_name) if export_name else url
+
+
 def build_migration_hostname(host_ip):
     host = host_ip.strip(network_ipv6.IPV6_BRACKET_PREFIX + network_ipv6.IPV6_BRACKET_SUFFIX)
     hostname = host.replace(IPV4_SEPARATOR, HOSTNAME_LABEL_SEPARATOR).replace(
@@ -11060,8 +11065,7 @@ host side snapshot files chian:
                     raw_result = qemu.get_rbd_data_bitmap(raw_path, MAX_NBD_READ_SIZE)
                     bitmap_map = _merge_json_data(raw_result, qcow2_result)
                 else:
-                    path = "nbd://%s:%s/%s" % (
-                        volume_info.nbdServer, volume_info.nbdPort, volume_info.scratchNodeName)
+                    path = build_nbd_url(volume_info.nbdServer, volume_info.nbdPort, volume_info.scratchNodeName)
                     bitmap_map = qemu.get_data_bitmap(path, MAX_NBD_READ_SIZE, False, True, "-f raw")
             else:
                 path = "driver=nbd,export=%s,server.type=inet,server.host=%s,server.port=%s,x-dirty-bitmap=qemu:dirty-bitmap:%s" % (
@@ -12636,7 +12640,7 @@ host side snapshot files chian:
             if cmd.fullSync:
                 qmp.execute_qmp_command(cmd.vmInstanceUuid, "drive-mirror", raise_exception=False,
                                     device=alias_name, job_id="zs-ft-resync",
-                                    target="nbd://%s:%s/parent%s" % (cmd.secondaryVmHostIp, cmd.nbdServerPort, count),
+                                    target=build_nbd_url(cmd.secondaryVmHostIp, cmd.nbdServerPort, "parent%s" % count),
                                     mode="existing", format="nbd", sync="full"
                                     )
                 while True:

--- a/tests/unit/kvmagent/test_vm_plugin_handlers.py
+++ b/tests/unit/kvmagent/test_vm_plugin_handlers.py
@@ -54,6 +54,13 @@ def test_build_migration_hostname_supports_bracketed_ipv6():
         'fd00-5-5-28--62-d0e5.zstack.org'
 
 
+def test_build_nbd_url_wraps_ipv6_host():
+    assert vm_plugin.build_nbd_url('192.168.10.10', 10401) == 'nbd://192.168.10.10:10401'
+    assert vm_plugin.build_nbd_url('fd00:5:5:28::5e:508b', 10401) == 'nbd://[fd00:5:5:28::5e:508b]:10401'
+    assert vm_plugin.build_nbd_url('fd00:5:5:28::5e:508b', 10401, 'parent0') == \
+        'nbd://[fd00:5:5:28::5e:508b]:10401/parent0'
+
+
 def _make_vm_plugin():
     plugin = vm_plugin.VmPlugin.__new__(vm_plugin.VmPlugin)
     plugin.config = {}


### PR DESCRIPTION
## Summary
- Build NBD URLs with bracketed IPv6 hosts in kvmagent before qemu-img/QMP URL consumers use them.
- Add unit coverage for IPv4 and IPv6 NBD URL construction.

## Verification
- `python3 -m pytest tests/unit/kvmagent/test_vm_plugin_handlers.py -q`

Jira: ZSTAC-86553

sync from gitlab !7409