### PR TITLE
<fix>[kvm]: emit pmu off in vm xml

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -1347,6 +1347,11 @@ def e(parent, tag, value=None, attrib=None, usenamesapce = False):
     return el
 
 
+def make_pmu_feature(cmd, features):
+    if hasattr(cmd, 'pmu') and cmd.pmu is False:
+        e(features, "pmu", attrib={'state': 'off'})
+
+
 def find_namespace_node(root, path, name):
     ns = {'zs': ZS_XML_NAMESPACE}
 
@@ -5424,6 +5429,8 @@ class Vm(object):
 
             if get_gic_version(cmd.cpuNum) == 2:
                 e(features, "gic", attrib={'version': '2'})
+
+            make_pmu_feature(cmd, features)
 
 
         def make_qemu_commandline():

--- a/kvmagent/kvmagent/test/test_vm_pmu.py
+++ b/kvmagent/kvmagent/test/test_vm_pmu.py
@@ -1,0 +1,64 @@
+import unittest
+import xml.etree.ElementTree as etree
+
+from kvmagent.plugins.vm_plugin import e
+from kvmagent.plugins.vm_plugin import make_pmu_feature
+
+
+class TestVmPmuConfig(unittest.TestCase):
+    def test_pmu_off_generates_xml(self):
+        root, features = self._new_domain_with_features()
+        cmd = self._cmd(False)
+
+        make_pmu_feature(cmd, features)
+
+        pmu = root.find('./features/pmu')
+        self.assertIsNotNone(pmu)
+        self.assertEqual('off', pmu.get('state'))
+
+    def test_pmu_true_omits_pmu_element(self):
+        root, features = self._new_domain_with_features()
+        cmd = self._cmd(True)
+
+        make_pmu_feature(cmd, features)
+
+        self.assertIsNone(root.find('./features/pmu'))
+
+    def test_missing_pmu_omits_pmu_element(self):
+        root, features = self._new_domain_with_features()
+
+        make_pmu_feature(object(), features)
+
+        self.assertIsNone(root.find('./features/pmu'))
+
+    def test_pmu_element_stays_under_features(self):
+        root, features = self._new_domain_with_features()
+        cmd = self._cmd(False)
+
+        make_pmu_feature(cmd, features)
+
+        children = [child.tag for child in features]
+        self.assertEqual(['apic', 'pae', 'acpi', 'pmu'], children)
+        self.assertIn('<pmu state="off"', etree.tostring(root).decode('utf-8'))
+
+    @staticmethod
+    def _new_domain_with_features():
+        root = etree.Element('domain')
+        features = e(root, 'features')
+        e(features, 'apic')
+        e(features, 'pae')
+        e(features, 'acpi')
+        return root, features
+
+    @staticmethod
+    def _cmd(pmu):
+        class Cmd(object):
+            pass
+
+        cmd = Cmd()
+        cmd.pmu = pmu
+        return cmd
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Backport the kvmagent PMU XML generation from ZSTAC-76375 to 5.4.10 for ZSTAC-86338.

When `StartVmCmd.pmu` is explicitly `false`, kvmagent now emits:

```xml
<pmu state='off'/>
```

This disables PMU exposure for affected aarch64 guests and avoids the Kunpeng-920/openEuler 24.03 PMMIR_EL1 guest panic path.

## Testing

- `git diff --cached --check` passed before commit
- RED check: confirmed origin/5.4.10 had no PMU XML generation path before this backport
- Added `kvmagent/kvmagent/test/test_vm_pmu.py`
- PMU helper extraction smoke test passed: `pmu=false` emits `state=off`, `pmu=true` omits PMU XML

Local environment blocker:
- Full `env PYTHONPATH=kvmagent:zstacklib python3 kvmagent/kvmagent/test/test_vm_pmu.py` is blocked because this branch's `vm_plugin.py` still contains Python 2 long literals such as `0L`, which fail under Python 3 import

sync from gitlab !7414