### PR TITLE
<feature>[zbs]: ZBS vhost SPDK target + kvmagent multi-protocol

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -51,6 +51,7 @@ from kvmagent.plugins.baremetal_v2_gateway_agent import \
 from kvmagent.plugins.bmv2_gateway_agent import utils as bm_utils
 from kvmagent.plugins import host_pushgateway
 from kvmagent.plugins import vm_artifact
+from kvmagent.plugins import zbs_vhost_target
 from kvmagent.plugins.imagestore import ImageStoreClient
 from kvmagent.plugins.shared_block_plugin import MAX_ACTUAL_SIZE_FACTOR
 from kvmagent.plugins.volume_cache.command_wrapper.virsh import VirshCommandWrapper as CacheVirshWrapper
@@ -3630,6 +3631,7 @@ class Vm(object):
         flag = (0, libvirt.VIR_DOMAIN_START_PAUSED)[create_paused]
         domain = define_xml()
         self.domain = domain
+        zbs_vhost_target.ensure_hugepages_for_domain(self.domain_xml)
         self.domain.createWithFlags(flag)
         if create_paused:
             self._wait_for_vm_paused(timeout)

--- a/kvmagent/kvmagent/plugins/zbs_storage_plugin.py
+++ b/kvmagent/kvmagent/plugins/zbs_storage_plugin.py
@@ -1,4 +1,8 @@
+import os.path
+
 from kvmagent import kvmagent
+from kvmagent.plugins import zbs_vhost_target
+from kvmagent.plugins.zbs_vhost_rpc import ZbsVhostRpc
 from zstacklib.utils import http
 from zstacklib.utils import jsonobject
 from zstacklib.utils import log
@@ -16,14 +20,38 @@ class CheckHostStorageConnectionRsp(kvmagent.AgentResponse):
         super(CheckHostStorageConnectionRsp, self).__init__()
 
 
+class VhostActivateRsp(kvmagent.AgentResponse):
+    def __init__(self):
+        super(VhostActivateRsp, self).__init__()
+        self.socketPath = None
+
+
+class VhostTargetHealthRsp(kvmagent.AgentResponse):
+    def __init__(self):
+        super(VhostTargetHealthRsp, self).__init__()
+        self.targetRunning = False
+
+
 class ZbsStoragePlugin(kvmagent.KvmAgent):
     CHECK_HOST_STORAGE_CONNECTION_PATH = "/zbs/primarystorage/check/host/connection"
     UPDATE_HOST_DEPENDENCY_PATH = "/zbs/primarystorage/host/updatedependency"
+    VHOST_TARGET_ENSURE_PATH = "/zbs/primarystorage/vhost/target/ensure"
+    VHOST_ACTIVATE_PATH = "/zbs/primarystorage/vhost/activate"
+    VHOST_DEACTIVATE_PATH = "/zbs/primarystorage/vhost/deactivate"
+    VHOST_RESIZE_PATH = "/zbs/primarystorage/vhost/resize"
+    VHOST_TARGET_HEALTH_PATH = "/zbs/primarystorage/vhost/target/health"
+    PREPARE_VHOST_TARGET_ENV_PATH = "/zbs/primarystorage/vhost/target/prepareenv"
 
     def start(self):
         http_server = kvmagent.get_http_server()
         http_server.register_async_uri(self.CHECK_HOST_STORAGE_CONNECTION_PATH, self.check_host_storage_connection)
         http_server.register_async_uri(self.UPDATE_HOST_DEPENDENCY_PATH, self.update_host_dependency)
+        http_server.register_async_uri(self.VHOST_TARGET_ENSURE_PATH, self.vhost_target_ensure)
+        http_server.register_async_uri(self.VHOST_ACTIVATE_PATH, self.vhost_activate)
+        http_server.register_async_uri(self.VHOST_DEACTIVATE_PATH, self.vhost_deactivate)
+        http_server.register_async_uri(self.VHOST_RESIZE_PATH, self.vhost_resize)
+        http_server.register_async_uri(self.VHOST_TARGET_HEALTH_PATH, self.vhost_target_health)
+        http_server.register_async_uri(self.PREPARE_VHOST_TARGET_ENV_PATH, self.prepare_vhost_target_env)
 
     @kvmagent.replyerror
     @bash.in_bash
@@ -61,6 +89,96 @@ class ZbsStoragePlugin(kvmagent.KvmAgent):
             else:
                 logger.debug("successfully run: %s" % yum_cmd)
 
+        return jsonobject.dumps(rsp)
+
+    @staticmethod
+    def _control_sock(cmd):
+        return cmd.controlSock if cmd.controlSock else zbs_vhost_target.DEFAULT_CONTROL_SOCK
+
+    @staticmethod
+    def _socket_dir(cmd):
+        return cmd.socketDir if cmd.socketDir else zbs_vhost_target.DEFAULT_SOCKET_DIR
+
+    @staticmethod
+    def _bdev_file(cmd):
+        return "%s_zbs_" % cmd.installPath
+
+    def _ensure_target(self, cmd):
+        zbs_vhost_target.ensure_target(
+            image=cmd.image,
+            cores=cmd.cores,
+            socket_dir=self._socket_dir(cmd),
+            control_sock=self._control_sock(cmd),
+            client_conf=cmd.clientConf if cmd.clientConf else zbs_vhost_target.DEFAULT_CLIENT_CONF,
+            hugepage_nr=cmd.hugepageNr if cmd.hugepageNr else zbs_vhost_target.DEFAULT_HUGEPAGE_NR,
+            image_tar=cmd.imageTar,
+            image_url=cmd.imageUrl,
+            core_count=cmd.coreCount if cmd.coreCount else zbs_vhost_target.DEFAULT_CORE_COUNT)
+
+    @kvmagent.replyerror
+    def vhost_target_ensure(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = CheckHostStorageConnectionRsp()
+        self._ensure_target(cmd)
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def vhost_activate(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = VhostActivateRsp()
+
+        self._ensure_target(cmd)
+        rpc = ZbsVhostRpc(self._control_sock(cmd))
+
+        if rpc.get_bdev(cmd.bdevName) is None:
+            rpc.bdev_zbs_create(self._bdev_file(cmd), cmd.bdevName)
+
+        if rpc.get_controller(cmd.controllerName) is None:
+            rpc.vhost_create_blk_controller(cmd.controllerName, cmd.bdevName)
+
+        rsp.socketPath = os.path.join(self._socket_dir(cmd), cmd.controllerName)
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def vhost_deactivate(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = CheckHostStorageConnectionRsp()
+
+        if not zbs_vhost_target.is_running():
+            return jsonobject.dumps(rsp)
+
+        rpc = ZbsVhostRpc(self._control_sock(cmd))
+        if rpc.get_controller(cmd.controllerName) is not None:
+            rpc.vhost_delete_controller(cmd.controllerName)
+        if rpc.get_bdev(cmd.bdevName) is not None:
+            rpc.bdev_zbs_delete(cmd.bdevName)
+
+        zbs_vhost_target.reclaim_hugepages()
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def vhost_resize(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = CheckHostStorageConnectionRsp()
+        rpc = ZbsVhostRpc(self._control_sock(cmd))
+        rpc.bdev_zbs_resize(cmd.bdevName, cmd.sizeMib)
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def vhost_target_health(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = VhostTargetHealthRsp()
+        rsp.targetRunning = zbs_vhost_target.target_running(self._control_sock(cmd), cmd.containerName)
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    @bash.in_bash
+    def prepare_vhost_target_env(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = kvmagent.AgentResponse()
+        zbs_vhost_target.ensure_docker()
+        zbs_vhost_target.ensure_free_hugepages(
+            cmd.hugepageNr if cmd.hugepageNr else zbs_vhost_target.DEFAULT_VHOST_TARGET_HUGEPAGE_NR)
         return jsonobject.dumps(rsp)
 
 

--- a/kvmagent/kvmagent/plugins/zbs_vhost_rpc.py
+++ b/kvmagent/kvmagent/plugins/zbs_vhost_rpc.py
@@ -1,0 +1,97 @@
+import json
+import socket
+
+from zstacklib.utils import log
+
+logger = log.get_logger(__name__)
+
+DEFAULT_RPC_TIMEOUT = 60
+
+
+class ZbsVhostRpcError(Exception):
+    def __init__(self, method, code, message):
+        self.code = code
+        self.message = message
+        super(ZbsVhostRpcError, self).__init__(
+            "zbs vhost rpc[%s] failed: code=%s, message=%s" % (method, code, message))
+
+
+class ZbsVhostRpc(object):
+    def __init__(self, control_sock, timeout=DEFAULT_RPC_TIMEOUT):
+        self.control_sock = control_sock
+        self.timeout = timeout
+        self._id = 0
+
+    def _call(self, method, params=None):
+        self._id += 1
+        req = {"jsonrpc": "2.0", "id": self._id, "method": method}
+        if params:
+            req["params"] = params
+
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.settimeout(self.timeout)
+        try:
+            s.connect(self.control_sock)
+            s.sendall(json.dumps(req).encode())
+            rsp = self._recv_json(s)
+        finally:
+            s.close()
+
+        if "error" in rsp:
+            err = rsp["error"]
+            raise ZbsVhostRpcError(method, err.get("code"), err.get("message"))
+        return rsp.get("result")
+
+    def _recv_json(self, s):
+        buf = b""
+        while True:
+            chunk = s.recv(65536)
+            if not chunk:
+                break
+            buf += chunk
+            try:
+                return json.loads(buf.decode())
+            except ValueError:
+                continue
+        raise ZbsVhostRpcError("recv", None, "incomplete json response: %s" % buf.decode("utf-8", "replace"))
+
+    def bdev_zbs_create(self, zbs_file, name):
+        return self._call("bdev_zbs_create", {"file": zbs_file, "name": name})
+
+    def bdev_zbs_delete(self, name):
+        return self._call("bdev_zbs_delete", {"name": name})
+
+    def bdev_zbs_resize(self, name, new_size_mib):
+        return self._call("bdev_zbs_resize", {"name": name, "new_size": new_size_mib})
+
+    def bdev_get_bdevs(self, name=None):
+        params = {"name": name} if name else None
+        return self._call("bdev_get_bdevs", params)
+
+    def get_bdev(self, name):
+        try:
+            bdevs = self.bdev_get_bdevs(name)
+        except ZbsVhostRpcError as e:
+            if e.code == -19:
+                return None
+            raise
+        return bdevs[0] if bdevs else None
+
+    def vhost_create_blk_controller(self, ctrlr, bdev):
+        return self._call("vhost_create_blk_controller", {"ctrlr": ctrlr, "dev_name": bdev})
+
+    def vhost_delete_controller(self, ctrlr):
+        return self._call("vhost_delete_controller", {"ctrlr": ctrlr})
+
+    def vhost_get_controllers(self, name=None):
+        params = {"name": name} if name else None
+        return self._call("vhost_get_controllers", params)
+
+    def get_controller(self, ctrlr):
+        try:
+            ctrls = self.vhost_get_controllers(ctrlr)
+        except ZbsVhostRpcError as e:
+            if e.code in (-19, -32602, -32603):
+                return None
+            raise
+        return ctrls[0] if ctrls else None

--- a/kvmagent/kvmagent/plugins/zbs_vhost_target.py
+++ b/kvmagent/kvmagent/plugins/zbs_vhost_target.py
@@ -1,0 +1,297 @@
+import functools
+import json
+import os
+import shlex
+import socket
+import threading
+import xml.etree.ElementTree as ET
+
+from zstacklib.utils import bash
+from zstacklib.utils import log
+
+logger = log.get_logger(__name__)
+
+_TARGET_LOCK = threading.RLock()
+
+
+def _locked(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        with _TARGET_LOCK:
+            return fn(*args, **kwargs)
+    return wrapper
+
+HUGEPAGE_NR_PATH = "/sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages"
+DEFAULT_SOCKET_DIR = "/var/tmp/vhost-sockets"
+DEFAULT_CONTROL_SOCK = "/var/tmp/vhost-sockets/vhost.sock"
+DEFAULT_CLIENT_CONF = "/etc/zbs/client.conf"
+DEFAULT_CONTAINER_NAME = "zbs-vhost"
+DEFAULT_HUGEPAGE_NR = 256
+DEFAULT_VHOST_TARGET_HUGEPAGE_NR = 1024
+HUGEPAGE_SIZE_BYTES = 2 * 1024 * 1024
+DEFAULT_CORE_COUNT = 2
+
+
+def host_cpu_num():
+    return int(bash.bash_o("nproc").strip() or "1")
+
+
+def compute_cores(count=DEFAULT_CORE_COUNT):
+    total = host_cpu_num()
+    count = max(1, min(count, total))
+    cores = list(range(total - count, total))
+    return "[%s]" % ",".join(str(c) for c in cores)
+
+
+def download_image(url, dest_tar):
+    bash.bash_errorout(
+        "curl -fSL --connect-timeout 10 --retry 3 --retry-delay 2 -o %s %s"
+        % (shlex.quote(dest_tar), shlex.quote(url)))
+    return dest_tar
+
+
+def image_registry(image):
+    if "/" not in image:
+        return None
+    head = image.split("/", 1)[0]
+    if "." in head or ":" in head or head == "localhost":
+        return head
+    return None
+
+
+def ensure_insecure_registry(registry):
+    path = "/etc/docker/daemon.json"
+    cfg = {}
+    if os.path.exists(path):
+        try:
+            with open(path) as f:
+                cfg = json.load(f) or {}
+        except ValueError:
+            cfg = {}
+    regs = cfg.get("insecure-registries", [])
+    if registry in regs:
+        return
+    regs.append(registry)
+    cfg["insecure-registries"] = regs
+    with open(path, "w") as f:
+        json.dump(cfg, f, indent=2)
+    bash.bash_errorout("systemctl reload docker")
+
+
+_INSECURE_REGISTRY_MARKERS = ("server gave http response", "tls", "x509", "certificate")
+
+
+def pull_image(image):
+    registry = image_registry(image)
+    try:
+        bash.bash_errorout("docker pull %s" % shlex.quote(image))
+        return
+    except Exception as e:
+        err = str(e).lower()
+        if not registry or not any(m in err for m in _INSECURE_REGISTRY_MARKERS):
+            raise
+        logger.warn("docker pull %s failed with tls/protocol error, retrying registry[%s] as insecure: %s"
+                    % (image, registry, e))
+    ensure_insecure_registry(registry)
+    bash.bash_errorout("docker pull %s" % shlex.quote(image))
+
+
+def mem_to_pages(nbytes):
+    return (int(nbytes) + HUGEPAGE_SIZE_BYTES - 1) // HUGEPAGE_SIZE_BYTES
+
+
+_MEM_UNIT_BYTES = {
+    "b": 1, "bytes": 1,
+    "k": 1024, "kib": 1024, "kb": 1024,
+    "m": 1024 ** 2, "mib": 1024 ** 2, "mb": 1024 ** 2,
+    "g": 1024 ** 3, "gib": 1024 ** 3, "gb": 1024 ** 3,
+    "t": 1024 ** 4, "tib": 1024 ** 4, "tb": 1024 ** 4,
+}
+
+
+def domain_vhostuser_present(domain_xml):
+    try:
+        root = ET.fromstring(domain_xml)
+    except ET.ParseError:
+        return False
+    return any(d.get("type") == "vhostuser" for d in root.iter("disk"))
+
+
+def domain_memory_bytes(domain_xml):
+    mem = ET.fromstring(domain_xml).find("memory")
+    if mem is None or not (mem.text or "").strip():
+        return 0
+    unit = (mem.get("unit") or "k").lower()
+    return int(mem.text.strip()) * _MEM_UNIT_BYTES.get(unit, 1024)
+
+
+def _read_hugepage_nr():
+    if not os.path.exists(HUGEPAGE_NR_PATH):
+        raise Exception("hugepage sysfs not found: %s" % HUGEPAGE_NR_PATH)
+    return int(bash.bash_o("cat %s" % HUGEPAGE_NR_PATH).strip() or "0")
+
+
+def _read_hugepage_free():
+    out = bash.bash_o("grep HugePages_Free /proc/meminfo")
+    return int(out.split(":")[1].strip()) if ":" in out else 0
+
+
+def _compact_memory():
+    bash.bash_o("sync; echo 3 > /proc/sys/vm/drop_caches; echo 1 > /proc/sys/vm/compact_memory")
+
+
+@_locked
+def ensure_free_hugepages(need_pages):
+    free = _read_hugepage_free()
+    if free >= need_pages:
+        return
+    total = _read_hugepage_nr()
+    target = total + (need_pages - free)
+    _compact_memory()
+    bash.bash_o("echo %d > %s" % (target, HUGEPAGE_NR_PATH))
+    got = _read_hugepage_free()
+    if got < need_pages:
+        raise Exception("failed to free %d hugepages, only %d free after growing to %d; "
+                        "free up memory on the host" % (need_pages, got, target))
+
+
+def ensure_hugepages_for_domain(domain_xml):
+    if not domain_vhostuser_present(domain_xml):
+        return
+    ensure_free_hugepages(mem_to_pages(domain_memory_bytes(domain_xml)))
+
+
+@_locked
+def reclaim_hugepages(slack=0):
+    free = _read_hugepage_free()
+    total = _read_hugepage_nr()
+    keep = (total - free) + slack
+    if keep < total:
+        bash.bash_o("echo %d > %s" % (keep, HUGEPAGE_NR_PATH))
+
+
+def image_present(image):
+    return bash.bash_r("docker image inspect %s >/dev/null 2>&1" % shlex.quote(image)) == 0
+
+
+def docker_ready():
+    return bash.bash_r("command -v docker >/dev/null 2>&1") == 0 and \
+           bash.bash_r("systemctl is-active --quiet docker") == 0
+
+
+def ensure_docker():
+    if docker_ready():
+        return
+    bash.bash_errorout("yum install -y docker-ce docker-ce-cli containerd.io")
+    bash.bash_errorout("systemctl enable --now docker")
+    if not docker_ready():
+        raise Exception("docker still not running after install on this host")
+
+
+def load_image(image, image_tar=None, image_url=None):
+    if image_present(image):
+        return
+    errors = []
+    if image_registry(image):
+        try:
+            pull_image(image)
+            return
+        except Exception as e:
+            logger.warn("registry pull of %s failed, trying offline sources: %s" % (image, e))
+            errors.append("registry pull: %s" % e)
+    if image_tar and os.path.exists(image_tar):
+        try:
+            bash.bash_errorout("docker load -i %s" % shlex.quote(image_tar))
+            return
+        except Exception as e:
+            logger.warn("docker load of local tar %s failed: %s" % (image_tar, e))
+            errors.append("local tar[%s]: %s" % (image_tar, e))
+    if image_url:
+        tmp_tar = image_tar if image_tar else "/var/lib/zstack/zbs-vhost-image.tar"
+        try:
+            download_image(image_url, tmp_tar)
+            bash.bash_errorout("docker load -i %s" % shlex.quote(tmp_tar))
+            return
+        except Exception as e:
+            logger.warn("fetch/load of image url %s failed: %s" % (image_url, e))
+            errors.append("url[%s]: %s" % (image_url, e))
+    if errors:
+        raise Exception("zbs-vhost image[%s] unavailable from all sources: %s" % (image, "; ".join(errors)))
+    raise Exception("zbs-vhost image[%s] absent: no registry in ref, no local tar[%s], no image url" % (image, image_tar))
+
+
+def is_running(name=DEFAULT_CONTAINER_NAME):
+    out = bash.bash_o("docker ps --filter name=^/%s$ --filter status=running -q" % name).strip()
+    return out != ""
+
+
+@_locked
+def ensure_target(image, cores=None, socket_dir=DEFAULT_SOCKET_DIR, control_sock=DEFAULT_CONTROL_SOCK,
+                  client_conf=DEFAULT_CLIENT_CONF, name=DEFAULT_CONTAINER_NAME,
+                  hugepage_nr=DEFAULT_HUGEPAGE_NR, image_tar=None, image_url=None, core_count=DEFAULT_CORE_COUNT):
+    if is_running(name):
+        return
+
+    if not cores:
+        cores = compute_cores(core_count)
+
+    load_image(image, image_tar, image_url)
+    ensure_free_hugepages(hugepage_nr)
+    if not os.path.exists(socket_dir):
+        os.makedirs(socket_dir)
+
+    bash.bash_r("docker rm -f %s >/dev/null 2>&1" % name)
+    _clean_sockets(socket_dir)
+
+    cmd = ("docker run -d --name {name} --privileged --network host --restart always"
+           " -v {sock_dir}:{sock_dir}"
+           " -v /dev/hugepages:/dev/hugepages"
+           " -v {conf}:{conf}"
+           " {image}"
+           " /usr/local/bin/vhost -m '{cores}' -S {sock_dir} -r {ctrl} -z {conf}").format(
+        name=name, sock_dir=socket_dir, conf=client_conf, image=image, cores=cores, ctrl=control_sock)
+    bash.bash_errorout(cmd)
+
+    if not _wait_control_sock(control_sock):
+        log_tail = bash.bash_o("docker logs --tail 20 %s 2>&1" % name)
+        raise Exception("zbs-vhost target started but control sock[%s] not ready; logs:\n%s" % (control_sock, log_tail))
+
+
+def _clean_sockets(socket_dir):
+    if os.path.isdir(socket_dir):
+        bash.bash_r("rm -f %s/*" % socket_dir)
+
+
+def _wait_control_sock(control_sock, retries=40):
+    for _ in range(retries):
+        if _control_sock_ready(control_sock):
+            return True
+        bash.bash_o("sleep 0.5")
+    return _control_sock_ready(control_sock)
+
+
+def _control_sock_ready(control_sock):
+    if not os.path.exists(control_sock):
+        return False
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.settimeout(1)
+    try:
+        s.connect(control_sock)
+        return True
+    except (socket.error, OSError):
+        return False
+    finally:
+        s.close()
+
+
+def stop_target(name=DEFAULT_CONTAINER_NAME):
+    bash.bash_r("docker rm -f %s >/dev/null 2>&1" % name)
+
+
+def container_exists(name=DEFAULT_CONTAINER_NAME):
+    out = bash.bash_o("docker ps -a --filter name=^/%s$ -q" % name).strip()
+    return out != ""
+
+
+def target_running(control_sock, name):
+    return container_exists(name) and is_running(name) and _control_sock_ready(control_sock)

--- a/tests/unit/kvmagent/test_zbs_vhost_deploy.py
+++ b/tests/unit/kvmagent/test_zbs_vhost_deploy.py
@@ -1,0 +1,145 @@
+"""
+Unit tests for the lazy-deploy path in kvmagent.plugins.zbs_vhost_target:
+image source fallback ordering, conditional insecure-registry downgrade,
+target health semantics, and shell quoting of request-supplied values.
+"""
+import pytest
+from unittest.mock import patch
+
+from kvmagent.plugins import zbs_vhost_target as t
+
+
+class TestPullImage:
+    def test_plain_pull_success_leaves_docker_config_alone(self):
+        with patch.object(t.bash, 'bash_errorout') as be, \
+             patch.object(t, 'ensure_insecure_registry') as ir:
+            t.pull_image("172.26.208.212:5000/zbs-vhost:x")
+            ir.assert_not_called()
+            assert be.call_count == 1
+
+    def test_tls_error_downgrades_registry_and_retries(self):
+        calls = {'n': 0}
+
+        def be(cmd):
+            calls['n'] += 1
+            if calls['n'] == 1:
+                raise Exception("Get https://172.26.208.212:5000/v2/: "
+                                "http: server gave HTTP response to HTTPS client")
+
+        with patch.object(t.bash, 'bash_errorout', side_effect=be), \
+             patch.object(t, 'ensure_insecure_registry') as ir:
+            t.pull_image("172.26.208.212:5000/zbs-vhost:x")
+            ir.assert_called_once_with("172.26.208.212:5000")
+            assert calls['n'] == 2
+
+    def test_non_tls_error_propagates_without_downgrade(self):
+        with patch.object(t.bash, 'bash_errorout', side_effect=Exception("manifest unknown")), \
+             patch.object(t, 'ensure_insecure_registry') as ir:
+            with pytest.raises(Exception):
+                t.pull_image("172.26.208.212:5000/zbs-vhost:x")
+            ir.assert_not_called()
+
+
+class TestLoadImageFallback:
+    def _absent(self):
+        return patch.object(t, 'image_present', return_value=False)
+
+    def test_pull_failure_falls_back_to_local_tar(self):
+        with self._absent(), \
+             patch.object(t, 'pull_image', side_effect=Exception("pull boom")), \
+             patch.object(t.os.path, 'exists', return_value=True), \
+             patch.object(t.bash, 'bash_errorout') as be:
+            t.load_image("reg.io:5000/zbs-vhost:x", image_tar="/x/img.tar")
+            assert any('docker load' in str(c) for c in be.call_args_list)
+
+    def test_pull_and_tar_failures_fall_back_to_url(self):
+        with self._absent(), \
+             patch.object(t, 'pull_image', side_effect=Exception("pull boom")), \
+             patch.object(t.os.path, 'exists', return_value=False), \
+             patch.object(t, 'download_image') as dl, \
+             patch.object(t.bash, 'bash_errorout') as be:
+            t.load_image("reg.io:5000/zbs-vhost:x", image_url="http://x/img.tar")
+            dl.assert_called_once()
+            assert any('docker load' in str(c) for c in be.call_args_list)
+
+    def test_all_sources_failing_raises_aggregate(self):
+        with self._absent(), \
+             patch.object(t, 'pull_image', side_effect=Exception("pull boom")), \
+             patch.object(t.os.path, 'exists', return_value=False):
+            with pytest.raises(Exception) as ei:
+                t.load_image("reg.io:5000/zbs-vhost:x")
+            assert 'pull boom' in str(ei.value)
+
+    def test_present_image_skips_all_sources(self):
+        with patch.object(t, 'image_present', return_value=True), \
+             patch.object(t, 'pull_image') as pi, \
+             patch.object(t.bash, 'bash_errorout') as be:
+            t.load_image("reg.io:5000/zbs-vhost:x", image_tar="/x/img.tar")
+            pi.assert_not_called()
+            be.assert_not_called()
+
+
+class TestTargetRunning:
+    _SOCK = "/var/zbsvhost/sockets/admin.sock"
+    _NAME = "zbsvhost-10.0.0.9"
+
+    def test_never_deployed_is_not_running(self):
+        with patch.object(t, 'container_exists', return_value=False):
+            assert t.target_running(self._SOCK, self._NAME) is False
+
+    def test_deployed_but_exited_is_not_running(self):
+        with patch.object(t, 'container_exists', return_value=True), \
+             patch.object(t, 'is_running', return_value=False):
+            assert t.target_running(self._SOCK, self._NAME) is False
+
+    def test_running_with_ready_sock_is_running(self):
+        with patch.object(t, 'container_exists', return_value=True), \
+             patch.object(t, 'is_running', return_value=True), \
+             patch.object(t, '_control_sock_ready', return_value=True):
+            assert t.target_running(self._SOCK, self._NAME) is True
+
+    def test_running_with_dead_sock_is_not_running(self):
+        with patch.object(t, 'container_exists', return_value=True), \
+             patch.object(t, 'is_running', return_value=True), \
+             patch.object(t, '_control_sock_ready', return_value=False):
+            assert t.target_running(self._SOCK, self._NAME) is False
+
+
+class TestShellQuoting:
+    def test_download_image_quotes_url_and_dest(self):
+        with patch.object(t.bash, 'bash_errorout') as be:
+            t.download_image("http://x/a;rm -rf /", "/tmp/a b.tar")
+            cmd = be.call_args[0][0]
+            assert "'http://x/a;rm -rf /'" in cmd
+            assert "'/tmp/a b.tar'" in cmd
+
+    def test_docker_load_quotes_tar_path(self):
+        with patch.object(t, 'image_present', return_value=False), \
+             patch.object(t.os.path, 'exists', return_value=True), \
+             patch.object(t.bash, 'bash_errorout') as be:
+            t.load_image("zbs-vhost-local", image_tar="/x/evil;touch pwn.tar")
+            cmd = be.call_args[0][0]
+            assert "'/x/evil;touch pwn.tar'" in cmd
+
+
+class TestEnsureDocker:
+    def test_skips_install_when_docker_ready(self):
+        with patch.object(t, 'docker_ready', return_value=True), \
+             patch.object(t.bash, 'bash_errorout') as be:
+            t.ensure_docker()
+            be.assert_not_called()
+
+    def test_installs_and_starts_when_missing(self):
+        states = iter([False, True])
+        with patch.object(t, 'docker_ready', side_effect=lambda: next(states)), \
+             patch.object(t.bash, 'bash_errorout') as be:
+            t.ensure_docker()
+            cmds = " ".join(str(c) for c in be.call_args_list)
+            assert 'yum install' in cmds and 'docker-ce' in cmds
+            assert 'systemctl enable --now docker' in cmds
+
+    def test_raises_when_docker_unavailable_after_install(self):
+        with patch.object(t, 'docker_ready', return_value=False), \
+             patch.object(t.bash, 'bash_errorout'):
+            with pytest.raises(Exception):
+                t.ensure_docker()

--- a/tests/unit/kvmagent/test_zbs_vhost_hugepage.py
+++ b/tests/unit/kvmagent/test_zbs_vhost_hugepage.py
@@ -1,0 +1,120 @@
+"""
+Unit tests for on-demand hugepage sizing in kvmagent.plugins.zbs_vhost_target.
+
+vhost-user-blk forces the guest RAM onto preallocated shared hugepages, so every
+vhost VM consumes hugepages = its memory. These tests cover the pure sizing math,
+the domain-XML gating/parsing, and the free-based grow/shrink logic (sysfs + bash
+mocked).
+"""
+import pytest
+from unittest.mock import patch
+
+from kvmagent.plugins import zbs_vhost_target as t
+
+
+HP = t.HUGEPAGE_SIZE_BYTES
+
+
+class TestMemToPages:
+    def test_exact_multiple(self):
+        assert t.mem_to_pages(300 * 1024 * 1024) == 150
+
+    def test_rounds_up_partial_page(self):
+        assert t.mem_to_pages(HP + 1) == 2
+
+    def test_zero(self):
+        assert t.mem_to_pages(0) == 0
+
+
+class TestDomainVhostuserPresent:
+    def test_detects_vhostuser_disk(self):
+        xml = """<domain><devices>
+          <disk type='vhostuser' device='disk'>
+            <source type='unix' path='/var/tmp/vhost-sockets/zbs-vhost-x'/>
+          </disk></devices></domain>"""
+        assert t.domain_vhostuser_present(xml) is True
+
+    def test_ignores_plain_disk(self):
+        xml = """<domain><devices>
+          <disk type='network' device='disk'><source name='cbd:pool/vol'/></disk>
+          </devices></domain>"""
+        assert t.domain_vhostuser_present(xml) is False
+
+    def test_malformed_xml_is_not_vhost(self):
+        assert t.domain_vhostuser_present("not xml <<<") is False
+
+
+class TestDomainMemoryBytes:
+    def test_unit_kib_default_zstack(self):
+        xml = "<domain><memory unit='k'>307200</memory></domain>"
+        assert t.domain_memory_bytes(xml) == 300 * 1024 * 1024
+
+    def test_unit_mib(self):
+        xml = "<domain><memory unit='MiB'>512</memory></domain>"
+        assert t.domain_memory_bytes(xml) == 512 * 1024 * 1024
+
+    def test_unit_bytes(self):
+        xml = "<domain><memory unit='b'>1048576</memory></domain>"
+        assert t.domain_memory_bytes(xml) == 1048576
+
+    def test_no_unit_defaults_kib(self):
+        xml = "<domain><memory>1024</memory></domain>"
+        assert t.domain_memory_bytes(xml) == 1024 * 1024
+
+
+class TestEnsureFreeHugepages:
+    def test_noop_when_free_sufficient(self):
+        with patch.object(t, '_read_hugepage_nr', return_value=768), \
+             patch.object(t, '_read_hugepage_free', return_value=200), \
+             patch.object(t.bash, 'bash_o') as bo:
+            t.ensure_free_hugepages(150)
+            assert not any('nr_hugepages' in str(c) for c in bo.call_args_list)
+
+    def test_grows_total_by_deficit(self):
+        reads = {'free': [71, 150]}
+        with patch.object(t, '_read_hugepage_nr', return_value=256), \
+             patch.object(t, '_read_hugepage_free', side_effect=lambda: reads['free'].pop(0)), \
+             patch.object(t.bash, 'bash_o') as bo:
+            t.ensure_free_hugepages(150)
+            writes = [str(c) for c in bo.call_args_list if 'nr_hugepages' in str(c)]
+            assert any('335' in w for w in writes), writes
+
+    def test_raises_when_cannot_satisfy(self):
+        with patch.object(t, '_read_hugepage_nr', return_value=256), \
+             patch.object(t, '_read_hugepage_free', side_effect=[71, 90]), \
+             patch.object(t.bash, 'bash_o'):
+            with pytest.raises(Exception):
+                t.ensure_free_hugepages(150)
+
+
+class TestEnsureHugepagesForDomain:
+    def test_vhost_domain_triggers_ensure(self):
+        xml = """<domain><memory unit='k'>307200</memory><devices>
+          <disk type='vhostuser'><source type='unix' path='/x'/></disk>
+          </devices></domain>"""
+        with patch.object(t, 'ensure_free_hugepages') as ef:
+            t.ensure_hugepages_for_domain(xml)
+            ef.assert_called_once_with(150)
+
+    def test_non_vhost_domain_is_noop(self):
+        xml = "<domain><memory unit='k'>307200</memory><devices></devices></domain>"
+        with patch.object(t, 'ensure_free_hugepages') as ef:
+            t.ensure_hugepages_for_domain(xml)
+            ef.assert_not_called()
+
+
+class TestReclaimHugepages:
+    def test_shrinks_to_used_plus_slack(self):
+        with patch.object(t, '_read_hugepage_nr', return_value=768), \
+             patch.object(t, '_read_hugepage_free', return_value=433), \
+             patch.object(t.bash, 'bash_o') as bo:
+            t.reclaim_hugepages(slack=0)
+            writes = [str(c) for c in bo.call_args_list if 'nr_hugepages' in str(c)]
+            assert any('335' in w for w in writes), writes
+
+    def test_noop_when_nothing_free_to_reclaim(self):
+        with patch.object(t, '_read_hugepage_nr', return_value=335), \
+             patch.object(t, '_read_hugepage_free', return_value=0), \
+             patch.object(t.bash, 'bash_o') as bo:
+            t.reclaim_hugepages(slack=0)
+            assert not any('nr_hugepages' in str(c) for c in bo.call_args_list)

--- a/tests/unit/zbsprimarystorage/test_vhost.py
+++ b/tests/unit/zbsprimarystorage/test_vhost.py
@@ -1,0 +1,170 @@
+"""
+Unit tests for the zbsadm-vhost shell-out wrappers in zbsprimarystorage.zbsutils.
+
+Key contract: `zbsadm vhost create-bdev --volume <pool>/<file>_zbs_` strips the
+`_zbs_` marker before libcbd opens the file, so the argument carries the suffix
+while the real ZBS file name has none.
+"""
+from unittest.mock import patch, MagicMock
+
+from zbsprimarystorage import zbsutils
+from zbsprimarystorage import zbsagent
+
+
+def _real_quote(s):
+    return "'" + s.replace("'", "'\\''") + "'"
+
+
+def _last_cmd():
+    return zbsutils.shell.call.call_args[0][0]
+
+
+class TestCreateVhostBdev:
+    def test_appends_zbs_suffix_to_volume_arg(self):
+        with patch.object(zbsutils.shell, 'call'):
+            zbsutils.create_vhost_bdev("10.0.0.9", 22, "root", "pwd",
+                                       "lpool1", "vol-uuid-1", "vhost-blk-1")
+            cmd = _last_cmd()
+            assert "--volume lpool1/vol-uuid-1_zbs_ " in cmd
+            assert "--volume lpool1/vol-uuid-1 " not in cmd
+
+    def test_targets_host_and_names_bdev(self):
+        with patch.object(zbsutils.shell, 'call'):
+            zbsutils.create_vhost_bdev("10.0.0.9", 2222, "admin", "pwd",
+                                       "lpool1", "vol-uuid-1", "vhost-blk-1")
+            cmd = _last_cmd()
+            assert cmd.startswith(zbsutils.ZBSADM_BIN_PATH + " vhost create-bdev")
+            assert "--host 10.0.0.9" in cmd
+            assert "--port 2222" in cmd
+            assert "-u admin" in cmd
+            assert "--name vhost-blk-1" in cmd
+
+    def test_shellquotes_password(self):
+        with patch.object(zbsutils.shell, 'call'), \
+             patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote):
+            zbsutils.create_vhost_bdev("10.0.0.9", 22, "root", "p@ss w'rd",
+                                       "lpool1", "vol-uuid-1", "vhost-blk-1")
+            cmd = _last_cmd()
+            assert "-p 'p@ss w'\\''rd'" in cmd
+
+
+class TestDeleteVhostBdev:
+    def test_deletes_by_name_on_host(self):
+        with patch.object(zbsutils.shell, 'call'):
+            zbsutils.delete_vhost_bdev("10.0.0.9", 22, "root", "pwd", "vhost-blk-1")
+            cmd = _last_cmd()
+            assert cmd.startswith(zbsutils.ZBSADM_BIN_PATH + " vhost delete-bdev")
+            assert "--host 10.0.0.9" in cmd
+            assert "--name vhost-blk-1" in cmd
+
+
+class TestDeployVhost:
+    def test_auto_cpuset_pins_last_core_from_target_host_cpu_count(self):
+        with patch.object(zbsutils.shell, 'call'), \
+             patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
+             patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, "8\n", "")):
+            zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd")
+            cmd = _last_cmd()
+            assert cmd.startswith(zbsutils.ZBSADM_BIN_PATH + " vhost deploy")
+            assert "--host 10.0.0.9" in cmd
+            assert "--cpuset '[7]'" in cmd
+
+    def test_cpuset_is_inferred_on_target_not_local(self):
+        with patch.object(zbsutils.shell, 'call'), \
+             patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
+             patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, "8\n", "")) as ssh:
+            zbsutils.deploy_vhost("10.0.0.9", 2222, "root", "pwd")
+            ssh.assert_called_once_with("10.0.0.9", "pwd", "grep -c processor /proc/cpuinfo",
+                                        user="root", port=2222)
+
+    def test_single_cpu_host_falls_back_to_core0(self):
+        with patch.object(zbsutils.shell, 'call'), \
+             patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
+             patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, "1\n", "")):
+            zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd")
+            assert "--cpuset '[0]'" in _last_cmd()
+
+    def test_omits_hugepage_args_so_zbsadm_defaults_apply(self):
+        with patch.object(zbsutils.shell, 'call'), \
+             patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
+             patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, "8\n", "")):
+            zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd")
+            cmd = _last_cmd()
+            assert "--hugepage-size" not in cmd
+            assert "--hugepage-dir" not in cmd
+
+    def test_explicit_cpuset_overrides_auto(self):
+        with patch.object(zbsutils.shell, 'call'), \
+             patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
+             patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, "8\n", "")):
+            zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd", cpuset="[1-4]")
+            cmd = _last_cmd()
+            assert "--cpuset '[1-4]'" in cmd
+            assert "'[7]'" not in cmd
+
+    def test_includes_hugepage_args_when_explicitly_set(self):
+        with patch.object(zbsutils.shell, 'call'), \
+             patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
+             patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, "8\n", "")):
+            zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd",
+                                  hugepage_size=2048, hugepage_dir="/dev/hugepages2m")
+            cmd = _last_cmd()
+            assert "--hugepage-size 2048" in cmd
+            assert "--hugepage-dir /dev/hugepages2m" in cmd
+
+
+class TestDestroyVhost:
+    def test_targets_host(self):
+        with patch.object(zbsutils.shell, 'call'):
+            zbsutils.destroy_vhost("10.0.0.9", 22, "root", "pwd")
+            cmd = _last_cmd()
+            assert cmd.startswith(zbsutils.ZBSADM_BIN_PATH + " vhost destroy")
+            assert "--host 10.0.0.9" in cmd
+
+
+class TestVhostSocketPath:
+    def test_socket_path_is_dir_slash_bdev_name(self):
+        assert zbsutils.vhost_socket_path("vhost-blk-1") == \
+            zbsutils.VHOST_SOCKET_DIR + "/vhost-blk-1"
+
+
+_OK = '{"success": true, "error": {"code": 0, "message": ""}}'
+_FAIL = '{"success": false, "error": {"code": 410032, "message": "boom"}}'
+
+
+def _req(body):
+    return {zbsagent.http.REQUEST_BODY: body}
+
+
+class TestCreateVhostBdevHandler:
+    def test_creates_bdev_and_returns_socket_path(self):
+        body = ('{"hostIp": "10.0.0.9", "sshPort": 22, "sshUsername": "root", '
+                '"sshPassword": "pwd", "logicalPool": "lpool1", "volume": "vol-uuid-1", '
+                '"bdevName": "vhost-blk-1"}')
+        with patch.object(zbsagent.zbsutils, 'create_vhost_bdev', return_value=_OK) as cb:
+            out = zbsagent.ZbsAgent.create_vhost_bdev(MagicMock(), _req(body))
+            cb.assert_called_once_with("10.0.0.9", 22, "root", "pwd",
+                                       "lpool1", "vol-uuid-1", "vhost-blk-1")
+            r = zbsagent.jsonobject.loads(out)
+            assert r.success is True
+            assert r.socketPath == zbsutils.VHOST_SOCKET_DIR + "/vhost-blk-1"
+
+    def test_failure_is_reported_not_swallowed(self):
+        body = ('{"hostIp": "10.0.0.9", "sshPort": 22, "sshUsername": "root", '
+                '"sshPassword": "pwd", "logicalPool": "lpool1", "volume": "vol-uuid-1", '
+                '"bdevName": "vhost-blk-1"}')
+        with patch.object(zbsagent.zbsutils, 'create_vhost_bdev', return_value=_FAIL):
+            out = zbsagent.ZbsAgent.create_vhost_bdev(MagicMock(), _req(body))
+            r = zbsagent.jsonobject.loads(out)
+            assert r.success is False
+            assert "boom" in r.error
+
+
+class TestDeleteVhostBdevHandler:
+    def test_deletes_named_bdev(self):
+        body = ('{"hostIp": "10.0.0.9", "sshPort": 22, "sshUsername": "root", '
+                '"sshPassword": "pwd", "bdevName": "vhost-blk-1"}')
+        with patch.object(zbsagent.zbsutils, 'delete_vhost_bdev', return_value=_OK) as db:
+            out = zbsagent.ZbsAgent.delete_vhost_bdev(MagicMock(), _req(body))
+            db.assert_called_once_with("10.0.0.9", 22, "root", "pwd", "vhost-blk-1")
+            assert zbsagent.jsonobject.loads(out).success is True

--- a/zbsprimarystorage/zbsprimarystorage/zbsagent.py
+++ b/zbsprimarystorage/zbsprimarystorage/zbsagent.py
@@ -46,6 +46,12 @@ class CbdToNbdRsp(AgentResponse):
         self.port = 0
 
 
+class CreateVhostBdevRsp(AgentResponse):
+    def __init__(self):
+        super(CreateVhostBdevRsp, self).__init__()
+        self.socketPath = None
+
+
 class ExpandVolumeRsp(AgentResponse):
     def __init__(self):
         super(ExpandVolumeRsp, self).__init__()
@@ -210,6 +216,10 @@ class ZbsAgent(plugin.TaskManager):
     EXPAND_VOLUME_PATH = "/zbs/primarystorage/volume/expand"
     FLATTEN_VOLUME_PATH = "/zbs/primarystorage/volume/flatten"
     GET_VOLUME_CLIENTS_PATH = "/zbs/primarystorage/volume/clients"
+    DEPLOY_VHOST_PATH = "/zbs/primarystorage/vhost/deploy"
+    DESTROY_VHOST_PATH = "/zbs/primarystorage/vhost/destroy"
+    CREATE_VHOST_BDEV_PATH = "/zbs/primarystorage/vhost/bdev/create"
+    DELETE_VHOST_BDEV_PATH = "/zbs/primarystorage/vhost/bdev/delete"
 
     http_server = http.HttpServer(port=7763)
     http_server.logfile_path = log.get_logfile_path()
@@ -238,6 +248,10 @@ class ZbsAgent(plugin.TaskManager):
         self.http_server.register_async_uri(self.DELETE_SNAPSHOT_PATH, self.delete_snapshot)
         self.http_server.register_async_uri(self.ROLLBACK_SNAPSHOT_PATH, self.rollback_snapshot)
         self.http_server.register_sync_uri(self.GET_VOLUME_CLIENTS_PATH, self.get_volume_clients)
+        self.http_server.register_async_uri(self.DEPLOY_VHOST_PATH, self.deploy_vhost)
+        self.http_server.register_async_uri(self.DESTROY_VHOST_PATH, self.destroy_vhost)
+        self.http_server.register_async_uri(self.CREATE_VHOST_BDEV_PATH, self.create_vhost_bdev)
+        self.http_server.register_async_uri(self.DELETE_VHOST_BDEV_PATH, self.delete_vhost_bdev)
 
         self.agent_version = None
 
@@ -700,6 +714,61 @@ class ZbsAgent(plugin.TaskManager):
         if r.error.code != 0:
             rsp.success = False
             rsp.error = 'failed to deploy client, error[%s]' % r.error.message
+
+        return jsonobject.dumps(rsp)
+
+    @replyerror
+    def deploy_vhost(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = AgentResponse()
+
+        o = zbsutils.deploy_vhost(cmd.hostIp, cmd.sshPort, cmd.sshUsername, cmd.sshPassword)
+        r = jsonobject.loads(o)
+        if not r.success:
+            raise Exception('failed to deploy vhost target on host[%s], error[%s]' % (
+                cmd.hostIp, r.error.message))
+
+        return jsonobject.dumps(rsp)
+
+    @replyerror
+    def destroy_vhost(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = AgentResponse()
+
+        o = zbsutils.destroy_vhost(cmd.hostIp, cmd.sshPort, cmd.sshUsername, cmd.sshPassword)
+        r = jsonobject.loads(o)
+        if not r.success:
+            raise Exception('failed to destroy vhost target on host[%s], error[%s]' % (
+                cmd.hostIp, r.error.message))
+
+        return jsonobject.dumps(rsp)
+
+    @replyerror
+    def create_vhost_bdev(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = CreateVhostBdevRsp()
+
+        o = zbsutils.create_vhost_bdev(cmd.hostIp, cmd.sshPort, cmd.sshUsername, cmd.sshPassword,
+                                       cmd.logicalPool, cmd.volume, cmd.bdevName)
+        r = jsonobject.loads(o)
+        if not r.success:
+            raise Exception('failed to create vhost bdev[%s] for volume[%s/%s] on host[%s], error[%s]' % (
+                cmd.bdevName, cmd.logicalPool, cmd.volume, cmd.hostIp, r.error.message))
+
+        rsp.socketPath = zbsutils.vhost_socket_path(cmd.bdevName)
+        return jsonobject.dumps(rsp)
+
+    @replyerror
+    def delete_vhost_bdev(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = AgentResponse()
+
+        o = zbsutils.delete_vhost_bdev(cmd.hostIp, cmd.sshPort, cmd.sshUsername, cmd.sshPassword,
+                                       cmd.bdevName)
+        r = jsonobject.loads(o)
+        if not r.success:
+            raise Exception('failed to delete vhost bdev[%s] on host[%s], error[%s]' % (
+                cmd.bdevName, cmd.hostIp, r.error.message))
 
         return jsonobject.dumps(rsp)
 

--- a/zbsprimarystorage/zbsprimarystorage/zbsutils.py
+++ b/zbsprimarystorage/zbsprimarystorage/zbsutils.py
@@ -20,6 +20,8 @@ CBD_PREFIX = "cbd"
 CBD_VOLUME_PATH = CBD_PREFIX + ":{}/{}/{}"
 CBD_SNAPSHOT_PATH = CBD_VOLUME_PATH + "@{}"
 CLUSTER_UUID_SUPPORTED_VERSION = "1.5.1"
+VHOST_SOCKET_DIR = "/var/zbsvhost/sockets"
+VHOST_VOLUME_SUFFIX = "_zbs_"
 
 
 class ClientInfo(object):
@@ -75,6 +77,47 @@ def get_version():
 def deploy_client(ip, port, username, password):
     return shell.call("%s client deploy --host %s --port %s -u %s -p %s --silent" % (
         ZBSADM_BIN_PATH, ip, port, username, linux.shellquote(password)))
+
+
+def vhost_auto_cpuset(ip, port, username, password):
+    _, o, _ = linux.sshpass_run(ip, password, "grep -c processor /proc/cpuinfo", user=username, port=int(port))
+    n = int(o.strip()) if o and o.strip().isdigit() else 0
+    core = n - 1 if n > 1 else 0
+    return "[%d]" % core
+
+
+def deploy_vhost(ip, port, username, password, cpuset=None, hugepage_size=None, hugepage_dir=None):
+    if not cpuset:
+        cpuset = vhost_auto_cpuset(ip, port, username, password)
+    cmd = "%s vhost deploy --host %s --port %s -u %s -p %s --cpuset %s --silent" % (
+        ZBSADM_BIN_PATH, ip, port, username, linux.shellquote(password),
+        linux.shellquote(cpuset))
+    if hugepage_size:
+        cmd += " --hugepage-size %s" % hugepage_size
+    if hugepage_dir:
+        cmd += " --hugepage-dir %s" % hugepage_dir
+    return shell.call(cmd)
+
+
+def destroy_vhost(ip, port, username, password):
+    return shell.call("%s vhost destroy --host %s --port %s -u %s -p %s --silent" % (
+        ZBSADM_BIN_PATH, ip, port, username, linux.shellquote(password)))
+
+
+def create_vhost_bdev(ip, port, username, password, logical_pool, volume, bdev_name):
+    return shell.call(
+        "%s vhost create-bdev --host %s --port %s -u %s -p %s --volume %s/%s%s --name %s --silent" % (
+            ZBSADM_BIN_PATH, ip, port, username, linux.shellquote(password),
+            logical_pool, volume, VHOST_VOLUME_SUFFIX, bdev_name))
+
+
+def delete_vhost_bdev(ip, port, username, password, bdev_name):
+    return shell.call("%s vhost delete-bdev --host %s --port %s -u %s -p %s --name %s --silent" % (
+        ZBSADM_BIN_PATH, ip, port, username, linux.shellquote(password), bdev_name))
+
+
+def vhost_socket_path(bdev_name):
+    return VHOST_SOCKET_DIR + "/" + bdev_name
 
 
 def query_mds_status_info():


### PR DESCRIPTION
## Summary

kvmagent / zbs-PS-agent side of the ZBS vhost output-protocol feature, rebased from `feature-zbs-vhost` directly onto the current `5.5.28` tip (6 commits, merge-noise dropped, zero rebase conflicts — purely additive +1123 lines).

Companion MR in **zstack** (zstackio/zstack !10400) provides the `ZbsStorageController` / volume multi-protocol side.

## Commits (6)

- `<feature>[zbs]` vhost SPDK target + JSON-RPC — `zbs_vhost_target.py` (SPDK docker target), `zbs_vhost_rpc.py` (bdev_zbs + vhost controller over control socket), 4 vhost endpoints in `zbs_storage_plugin`
- `<feature>[zbs]` vhost target lazy deploy + hugepage sizing — `ensure_target` (registry pull w/ tar+url fallback), guest hugepages sized on demand at VM start, hardening (shlex quoting, insecure-registry fallback, lock serialization)
- `<feature>[zbs]` zbs vhost PS-agent ops + kvmagent health — zbsadm vhost shell-outs on the zbs PS agent, host-local `vhost_target_health` probe
- `<fix>[zbs]` resolve vhost MR review findings (round-1) — drop dead code paths
- `<feature>[zbs]` vhost target host env prep — `ensure_docker` + reserve hugepages, `prepare_vhost_target_env` handler
- `<fix>[zbs]` infer vhost cpuset on target host — probe target host CPU count over SSH

## Notes

- New files: `zbs_vhost_target.py`, `zbs_vhost_rpc.py`, unit tests under `tests/unit/kvmagent` and `tests/unit/zbsprimarystorage`.
- Only shared-file edit is a 2-line insertion into `vm_plugin.py` (`ensure_hugepages_for_domain` before `createWithFlags`).

Resolves: ZSTAC-85515

🤖 Generated with [Claude Code](https://claude.com/claude-code)

sync from gitlab !7424