### PR TITLE
<feature>[zrm_plugin]: kvmagent ZLR/ZR full replication lifecycle support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ develop-eggs
 zstack.log
 *~
 
+# Review worktrees (created by AI reviewer, not source code)
+worktrees/
+
 # Installer logs
 pip-log.txt
 

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -80,6 +80,14 @@ from zstacklib.utils.libvirt_singleton import LibvirtSingleton
 
 logger = log.get_logger(__name__)
 
+# Python 2/3 string-type compatibility for block-graph helpers at module bottom.
+# Python 2: basestring covers both str and unicode (QMP json.loads returns unicode).
+# Python 3: basestring does not exist; str is sufficient.
+try:
+    _str_types = basestring
+except NameError:
+    _str_types = str
+
 HOST_ARCH = platform.machine()
 DIST = platform.dist()
 DIST_NAME = DIST[0]
@@ -2301,6 +2309,274 @@ def get_vm_by_uuid_no_retry(uuid, exception_if_not_existing=True):
 
         err = 'error happened when looking up vm[uuid:%(uuid)s], libvirt error code: %(error_code)s, %(e)s' % locals()
         raise libvirt.libvirtError(err)
+
+
+def _block_struct_contains_volume_uuid(obj, volume_uuid):
+    """
+    Recursively check whether any string value inside a nested dict/list
+    structure contains the given volume_uuid substring.
+
+    **Design trade-off**: A recursive substring scan is deliberately broad --
+    it matches the UUID wherever it appears (file paths, node names, backing
+    chains, etc.). This maximises recall on diverse QEMU/libvirt
+    configurations but may produce false positives when UUIDs overlap or
+    appear in unrelated metadata fields. Callers that need precision should
+    prefer checking ``inserted.file`` first and falling back to this
+    function only when the narrow check misses (see the two-pass strategy in
+    ``get_mirror_device_for_volume_uuid``).
+
+    This mirrors the logic used by the ZR plugin so that mirror device
+    resolution is always based on the QEMU block graph.
+    """
+    if isinstance(obj, _str_types):
+        return volume_uuid in obj
+    if isinstance(obj, dict):
+        for v in obj.values():
+            if _block_struct_contains_volume_uuid(v, volume_uuid):
+                return True
+    elif isinstance(obj, list):
+        for v in obj:
+            if _block_struct_contains_volume_uuid(v, volume_uuid):
+                return True
+    return False
+
+
+# Cached capability flag for ``x-debug-query-block-graph``.
+# This is an experimental (``x-`` prefix) QEMU command available since
+# QEMU 4.0+ for inspecting the internal block driver graph.  It may be
+# removed or renamed in future QEMU releases without notice.
+#
+# The cache avoids repeated QMP round-trips on QEMU versions that do not
+# support the command.  It is a module-global dict keyed by vm_uuid so
+# each running domain is probed at most once.  A ``True`` value means the
+# command succeeded at least once; ``False`` means it returned an error
+# (typically ``CommandNotFound``).  Entries are *not* evicted -- the dict
+# lives for the lifetime of the kvmagent process, and the number of
+# concurrent VMs on a single host is small enough that this is acceptable.
+_BLOCK_GRAPH_CAPABILITY = {}  # type: dict[str, bool]
+
+
+def _block_graph_available(vm_uuid):
+    """Return True if x-debug-query-block-graph is supported on *vm_uuid*.
+
+    On the first call per VM, issues a probe QMP command and caches the
+    result.  Subsequent calls return the cached value without network I/O.
+    """
+    cached = _BLOCK_GRAPH_CAPABILITY.get(vm_uuid)
+    if cached is not None:
+        return cached
+    try:
+        result = qmp.execute_qmp_command(vm_uuid, "x-debug-query-block-graph", raise_exception=False)
+        available = result is not None
+    except Exception:
+        available = False
+    _BLOCK_GRAPH_CAPABILITY[vm_uuid] = available
+    if not available:
+        logger.debug("x-debug-query-block-graph not available on vm %s (QEMU may not support it)" % vm_uuid)
+    return available
+
+
+def _find_root_block_node(vm_uuid, start_node_name):
+    """
+    Use x-debug-query-block-graph to walk upwards from the given node name
+    and find the block-driver node that is directly attached to a block-backend.
+
+    **Note**: ``x-debug-query-block-graph`` is an experimental QEMU command
+    (``x-`` prefix = unstable API, available since QEMU 4.0).  The
+    capability is probed and cached per VM at first use; if the command is
+    unavailable this function returns ``start_node_name`` immediately.
+
+    If the graph is unavailable or cannot be parsed, falls back to
+    ``start_node_name``.
+    """
+    if not vm_uuid or not start_node_name:
+        return start_node_name
+    if not _block_graph_available(vm_uuid):
+        return start_node_name
+    try:
+        graph = qmp.execute_qmp_command(vm_uuid, "x-debug-query-block-graph", raise_exception=False)
+    except Exception:
+        return start_node_name
+    if not graph or not isinstance(graph, dict):
+        return start_node_name
+
+    nodes_list = graph.get("nodes")
+    edges_list = graph.get("edges")
+    if not nodes_list or not edges_list:
+        return start_node_name
+
+    id_to_node = {}
+    name_to_ids = {}
+    for n in nodes_list:
+        if not isinstance(n, dict):
+            continue
+        nid = n.get("id")
+        if nid is None:
+            continue
+        id_to_node[nid] = n
+        nname = n.get("name") or ""
+        name_to_ids.setdefault(nname, []).append(nid)
+
+    parents_by_child = {}
+    children_by_parent = {}
+    for e in edges_list:
+        if not isinstance(e, dict):
+            continue
+        parent_id = e.get("parent")
+        child_id = e.get("child")
+        if parent_id is None or child_id is None:
+            continue
+        parents_by_child.setdefault(child_id, []).append(parent_id)
+        children_by_parent.setdefault(parent_id, []).append(child_id)
+
+    start_ids = name_to_ids.get(start_node_name) or []
+    if not start_ids:
+        return start_node_name
+
+    visited = set()
+    _MAX_ASCEND_DEPTH = 32  # Safety valve: QEMU block graphs are small (<20 nodes).
+
+    def ascend_from(node_id, depth=0):
+        if depth > _MAX_ASCEND_DEPTH or node_id in visited:
+            return None
+        visited.add(node_id)
+        parents = parents_by_child.get(node_id) or []
+        for pid in parents:
+            pnode = id_to_node.get(pid)
+            if not pnode:
+                continue
+            ptype = pnode.get("type") or ""
+            if ptype == "block-backend":
+                node = id_to_node.get(node_id)
+                root_name = (node or {}).get("name")
+                return root_name or start_node_name
+            if ptype == "block-driver":
+                root = ascend_from(pid, depth + 1)
+                if root:
+                    return root
+            if ptype == "block-job":
+                # A block-job (e.g. mirror/backup) sits between the real
+                # block-driver chain and the block-backend. It breaks the
+                # normal parent walk, so we look at the job's *other*
+                # block-driver children (the source side of the job) and
+                # continue ascending from there to reach the block-backend.
+                job_children = children_by_parent.get(pid) or []
+                for cid in job_children:
+                    cnode = id_to_node.get(cid)
+                    if not cnode:
+                        continue
+                    if cnode.get("type") == "block-driver":
+                        root = ascend_from(cid, depth + 1)
+                        if root:
+                            return root
+        return None
+
+    for sid in start_ids:
+        visited.clear()
+        root_name = ascend_from(sid)
+        if root_name:
+            return root_name
+
+    return start_node_name
+
+
+def _extract_device_and_node(block_entry):
+    """Extract (device, node_name) from a single query-block entry.
+
+    Returns (device_str_or_None, node_name_str_or_None).
+    """
+    device = block_entry.get("device") or ""
+    if not (isinstance(device, _str_types) and device.strip()):
+        device = None
+    qdev_path = block_entry.get("qdev") or block_entry.get("Qdev") or ""
+    if not isinstance(qdev_path, _str_types):
+        qdev_path = str(qdev_path) if qdev_path else ""
+    if (not device or not device.strip()) and qdev_path.strip():
+        parts = qdev_path.strip().rstrip("/").split("/")
+        for p in reversed(parts):
+            if p and p not in ("virtio-backend", "machine", "peripheral", "scsi-backend"):
+                device = p
+                break
+    inserted = block_entry.get("inserted") or {}
+    node_name = inserted.get("node-name") if isinstance(inserted, dict) else None
+    return device, node_name
+
+
+def get_mirror_device_for_volume_uuid(vm_uuid, volume_uuid):
+    """
+    Resolve the mirror-capable (node_name, device_name) for a volume from QEMU query-block.
+
+    Uses a **two-pass** matching strategy:
+
+    1. **High-precision pass** -- only check ``inserted.file`` (the image file
+       path reported by QEMU).  This avoids false positives when the UUID
+       substring accidentally appears in unrelated metadata fields.
+    2. **Recursive fallback pass** -- scan the entire block entry dict
+       recursively (via ``_block_struct_contains_volume_uuid``).  This
+       handles unusual QEMU configurations where the file path lives in a
+       nested sub-driver or backing chain.
+
+    If multiple block entries match in either pass, a warning is logged (the
+    first match is returned).
+
+    Uses the actual QEMU block graph: the root block-driver node name (from the graph)
+    is preferred as node_name for drive-mirror/blockdev-mirror. node_name is the BDS
+    node name (reliable under -blockdev); device_name is the qdev-derived alias or empty.
+
+    Returns (node_name, device_name), or (None, None) if the volume is not found.
+    """
+    if not vm_uuid or not volume_uuid:
+        return None, None
+    vol_str = volume_uuid if isinstance(volume_uuid, str) else str(volume_uuid)
+    try:
+        blocks = qmp.execute_qmp_command(vm_uuid, "query-block", raise_exception=False)
+    except Exception:
+        return None, None
+    if not blocks:
+        return None, None
+    # query-block normally returns a list; guard against unusual dict form.
+    if isinstance(blocks, dict):
+        blocks = list(blocks.values())
+
+    def _resolve_from(block_entry):
+        """Build (root_node, device) from a matched block entry."""
+        device, node_name = _extract_device_and_node(block_entry)
+        raw_node = node_name or device
+        if not raw_node:
+            return None, None
+        root_node = _find_root_block_node(vm_uuid, raw_node)
+        return root_node, (device or raw_node)
+
+    # --- Pass 1: high-precision match on inserted.file ---
+    pass1_matches = []
+    for b in (blocks or []):
+        if not isinstance(b, dict):
+            continue
+        inserted = b.get("inserted") or {}
+        file_path = inserted.get("file") if isinstance(inserted, dict) else None
+        if file_path and isinstance(file_path, _str_types) and vol_str in file_path:
+            pass1_matches.append(b)
+    if pass1_matches:
+        if len(pass1_matches) > 1:
+            logger.warn("get_mirror_device_for_volume_uuid: %d blocks matched volume %s by inserted.file (using first)"
+                        % (len(pass1_matches), vol_str))
+        return _resolve_from(pass1_matches[0])
+
+    # --- Pass 2: recursive fallback (full dict scan) ---
+    pass2_matches = []
+    for b in (blocks or []):
+        if not isinstance(b, dict):
+            continue
+        if _block_struct_contains_volume_uuid(b, vol_str):
+            pass2_matches.append(b)
+    if pass2_matches:
+        if len(pass2_matches) > 1:
+            logger.warn("get_mirror_device_for_volume_uuid: %d blocks matched volume %s by recursive scan (using first)"
+                        % (len(pass2_matches), vol_str))
+        return _resolve_from(pass2_matches[0])
+
+    return None, None
+
 
 def get_active_vm_uuids_states():
     @LibvirtAutoReconnect
@@ -7079,8 +7355,8 @@ def iso_check(iso):
 
 
 def execute_qmp_command(domain_id, command, raise_exception=False):
-    warnings.warn("Use qmp.execute_qmp_command instead", DeprecationWarning)
-    return qmp._execute_qmp_command(domain_id, command, raise_exception=raise_exception)
+    warnings.warn("Use qmp.execute_qmp_command or qmp.execute_qmp_command_raw instead", DeprecationWarning)
+    return qmp.execute_qmp_command_raw(domain_id, command, raise_exception=raise_exception)
 
 def get_vm_blocks(domain_id):
     blocks = qmp.execute_qmp_command(domain_id, "query-block")

--- a/kvmagent/kvmagent/plugins/zrm_plugin.py
+++ b/kvmagent/kvmagent/plugins/zrm_plugin.py
@@ -48,6 +48,8 @@ MIRROR_JOB_UUID_TRUNCATE_LEN = 8
 # blocking indefinitely.
 _DEFAULT_MAX_WAIT_TIMEOUT = 3600
 
+_DEFAULT_SHUTDOWN_TIMEOUT = 30
+
 # Interval (seconds) between progress log messages inside _wait_initial_full_sync.
 WAIT_INITIAL_LOG_INTERVAL = 30.0
 
@@ -1409,12 +1411,138 @@ class ZrmPlugin(kvmagent.KvmAgent):
             logger.exception("zrm_checkpoint_create failed")
             return jsonobject.dumps(ZrmAgentRsp(success=False, error=str(e)))
 
+    def _vm_shutdown_and_isolate(self, vm_uuid, shutdown_timeout=_DEFAULT_SHUTDOWN_TIMEOUT, force_isolate=False):
+        import libvirt
+        import xml.etree.ElementTree as ET
+        from kvmagent.plugins.vm_plugin import get_vm_by_uuid
+
+        vm = get_vm_by_uuid(vm_uuid, exception_if_not_existing=False)
+        if not vm or not getattr(vm, "domain", None):
+            logger.info("_vm_shutdown_and_isolate: vm %s not found, treating as stopped" % vm_uuid)
+            return True, None
+
+        domain = vm.domain
+
+        def _is_no_domain_error(ex):
+            try:
+                get_error_code = getattr(ex, "get_error_code", None)
+                return bool(get_error_code) and get_error_code() == libvirt.VIR_ERR_NO_DOMAIN
+            except Exception:
+                return False
+
+        if not force_isolate:
+            try:
+                state, _ = domain.state()
+                if state == libvirt.VIR_DOMAIN_SHUTOFF:
+                    logger.info("_vm_shutdown_and_isolate: vm %s already SHUTOFF" % vm_uuid)
+                    return True, None
+            except Exception as e:
+                if _is_no_domain_error(e):
+                    logger.info("_vm_shutdown_and_isolate: vm %s disappeared while checking state" % vm_uuid)
+                    return True, None
+                return False, "vm state check failed: %s" % e
+
+            try:
+                domain.shutdown()
+            except Exception as e:
+                logger.warn("_vm_shutdown_and_isolate: shutdown() failed for %s: %s, proceeding to poll" % (vm_uuid, e))
+
+            deadline = time.time() + shutdown_timeout
+            while time.time() < deadline:
+                try:
+                    state, _ = domain.state()
+                    if state == libvirt.VIR_DOMAIN_SHUTOFF:
+                        logger.info("_vm_shutdown_and_isolate: vm %s shut down cleanly" % vm_uuid)
+                        return True, None
+                except Exception as e:
+                    if _is_no_domain_error(e):
+                        logger.info("_vm_shutdown_and_isolate: vm %s disappeared while waiting for shutdown" % vm_uuid)
+                        return True, None
+                    return False, "vm state check failed: %s" % e
+                time.sleep(1)
+
+            logger.warn("_vm_shutdown_and_isolate: vm %s did not shut down in %ds, isolating network" %
+                        (vm_uuid, shutdown_timeout))
+
+        try:
+            xml_str = domain.XMLDesc(0)
+            root = ET.fromstring(xml_str)
+            ifaces = root.findall(".//devices/interface")
+            if not ifaces:
+                logger.info("_vm_shutdown_and_isolate: no interfaces to detach on vm %s" % vm_uuid)
+                return True, None
+
+            detached_count = 0
+            detach_errors = []
+            for iface in ifaces:
+                iface_xml = ET.tostring(iface, encoding="unicode")
+                try:
+                    domain.detachDeviceFlags(iface_xml, libvirt.VIR_DOMAIN_AFFECT_LIVE)
+                    detached_count += 1
+                    logger.info("_vm_shutdown_and_isolate: detached vNIC on vm %s" % vm_uuid)
+                except Exception as de:
+                    detach_errors.append(str(de))
+                    logger.warn("_vm_shutdown_and_isolate: detach vNIC failed on vm %s: %s (continuing)" %
+                                (vm_uuid, de))
+            if detach_errors:
+                # Re-read XML to check whether NICs are actually still present.
+                # A detach API error can fire for an NIC that was already absent
+                # (e.g. concurrent removal); in that case isolation is still achieved.
+                try:
+                    remaining_ifaces = ET.fromstring(domain.XMLDesc(0)).findall(".//devices/interface")
+                except Exception:
+                    remaining_ifaces = ifaces  # conservative: assume still present on XML read failure
+                if remaining_ifaces:
+                    return False, "network isolation failed: %d vNIC(s) remain on vm %s; detach errors: %s" % (
+                        len(remaining_ifaces), vm_uuid, "; ".join(detach_errors))
+                logger.info("_vm_shutdown_and_isolate: all vNICs gone on vm %s (detach errors were for already-absent NICs)" % vm_uuid)
+            return True, None
+
+        except Exception as e:
+            return False, "network isolation failed: " + str(e)
+
     @kvmagent.replyerror
     def zrm_recovery_prepare(self, req):
-        logger.info("ZRM recovery/prepare called -- not yet implemented")
-        return jsonobject.dumps(ZrmAgentRsp(
-            success=False,
-            error="ZR_AGENT.NOT_IMPLEMENTED: recovery/prepare is not implemented in this agent version"))
+        try:
+            body = req.get(http.REQUEST_BODY)
+            if not body:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="missing body"))
+            cmd = jsonobject.loads(body)
+
+            vm_uuid          = (getattr(cmd, "vmUuid", None) or "").strip()
+            _timeout_val = getattr(cmd, "shutdownTimeout", None)
+            shutdown_timeout = int(_timeout_val) if _timeout_val is not None else _DEFAULT_SHUTDOWN_TIMEOUT
+            force_isolate    = bool(getattr(cmd, "forceIsolate", False))
+
+            if not vm_uuid:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="vmUuid required"))
+
+            stop_rsp_json = self._replication_stop(req)
+            try:
+                stop_rsp = jsonobject.loads(stop_rsp_json)
+                stop_success = getattr(stop_rsp, "success", True)
+                stale_jobs = getattr(stop_rsp, "staleJobs", None)
+                if not stop_success:
+                    err = getattr(stop_rsp, "error", "unknown error")
+                    return jsonobject.dumps(ZrmAgentRsp(success=False,
+                        error="replication_stop failed: %s" % err))
+                if stale_jobs:
+                    return jsonobject.dumps(ZrmAgentRsp(success=False,
+                        error="replication_stop: stale mirror jobs remain: %s" % stale_jobs))
+            except Exception as e:
+                return jsonobject.dumps(ZrmAgentRsp(success=False,
+                    error="replication_stop response parse error: %s" % e))
+
+            ok, err = self._vm_shutdown_and_isolate(vm_uuid, shutdown_timeout, force_isolate)
+            if not ok:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error=err))
+
+            logger.info("zrm_recovery_prepare: vm %s isolated (mirrors stopped, vm shutdown/isolated)" % vm_uuid)
+            return jsonobject.dumps(ZrmAgentRsp())
+
+        except Exception as e:
+            logger.exception("zrm_recovery_prepare failed")
+            return jsonobject.dumps(ZrmAgentRsp(success=False, error=str(e)))
 
     @kvmagent.replyerror
     def zrm_replication_throttle(self, req):

--- a/kvmagent/kvmagent/plugins/zrm_plugin.py
+++ b/kvmagent/kvmagent/plugins/zrm_plugin.py
@@ -1365,47 +1365,50 @@ class ZrmPlugin(kvmagent.KvmAgent):
             throttle_rsp_json = self._replication_throttle(throttle_req)
             throttle_rsp = jsonobject.loads(throttle_rsp_json)
 
-            if not getattr(throttle_rsp, "success", True):
-                return jsonobject.dumps(ZrmAgentRsp(
-                    success=False,
-                    error="mirror convergence failed: %s" % (getattr(throttle_rsp, "error", "") or "")))
-
-            if not getattr(throttle_rsp, "allReady", False):
-                return jsonobject.dumps(ZrmAgentRsp(
-                    success=False,
-                    error="mirrors not ready after %ds (ready=%s total=%s)" % (
-                        wait_timeout,
-                        getattr(throttle_rsp, "readyCount", "?"),
-                        getattr(throttle_rsp, "totalJobs", "?"))))
-
-            # Step B: POST to ZR Server /zr/checkpoint/create
-            url = zr_server_url.rstrip("/") + "/zr/checkpoint/create"
-            cp_body = json.dumps({"sessionUuid": session_uuid, "checkpointUuid": checkpoint_uuid})
-            zr_rsp_raw = http.json_post(url, body=cp_body, fail_soon=True)
-            zr_rsp = jsonobject.loads(zr_rsp_raw)
-
-            if not getattr(zr_rsp, "success", False):
-                return jsonobject.dumps(ZrmAgentRsp(
-                    success=False,
-                    error="ZR Server checkpoint/create failed: %s" % (getattr(zr_rsp, "error", "") or "")))
-
-            # Step C: restore original mirror speed (best-effort, failure is non-fatal)
+            # Speed may now be 0; use try/finally so original_speed is always restored
+            # regardless of which failure path is taken below.
             try:
-                restore_req = {
-                    http.REQUEST_BODY: json.dumps({
-                        "vmUuid": vm_uuid,
-                        "speed": original_speed,
-                        "waitReadyTimeout": 0
-                    })
-                }
-                self._replication_throttle(restore_req)
-            except Exception as restore_ex:
-                logger.warn("zrm_checkpoint_create: failed to restore mirror speed for vm %s: %s" %
-                            (vm_uuid, restore_ex))
+                if not getattr(throttle_rsp, "success", True):
+                    return jsonobject.dumps(ZrmAgentRsp(
+                        success=False,
+                        error="mirror convergence failed: %s" % (getattr(throttle_rsp, "error", "") or "")))
 
-            logger.info("zrm_checkpoint_create: vm=%s session=%s checkpoint=%s success" %
-                        (vm_uuid, session_uuid, checkpoint_uuid))
-            return jsonobject.dumps(ZrmAgentRsp(checkpointUuid=checkpoint_uuid))
+                if not getattr(throttle_rsp, "allReady", False):
+                    return jsonobject.dumps(ZrmAgentRsp(
+                        success=False,
+                        error="mirrors not ready after %ds (ready=%s total=%s)" % (
+                            wait_timeout,
+                            getattr(throttle_rsp, "readyCount", "?"),
+                            getattr(throttle_rsp, "totalJobs", "?"))))
+
+                # Step B: POST to ZR Server /zr/checkpoint/create
+                url = zr_server_url.rstrip("/") + "/zr/checkpoint/create"
+                cp_body = json.dumps({"sessionUuid": session_uuid, "checkpointUuid": checkpoint_uuid})
+                zr_rsp_raw = http.json_post(url, body=cp_body, fail_soon=True)
+                zr_rsp = jsonobject.loads(zr_rsp_raw)
+
+                if not getattr(zr_rsp, "success", False):
+                    return jsonobject.dumps(ZrmAgentRsp(
+                        success=False,
+                        error="ZR Server checkpoint/create failed: %s" % (getattr(zr_rsp, "error", "") or "")))
+
+                logger.info("zrm_checkpoint_create: vm=%s session=%s checkpoint=%s success" %
+                            (vm_uuid, session_uuid, checkpoint_uuid))
+                return jsonobject.dumps(ZrmAgentRsp(checkpointUuid=checkpoint_uuid))
+            finally:
+                # Step C: restore original mirror speed (best-effort, failure is non-fatal)
+                try:
+                    restore_req = {
+                        http.REQUEST_BODY: json.dumps({
+                            "vmUuid": vm_uuid,
+                            "speed": original_speed,
+                            "waitReadyTimeout": 0
+                        })
+                    }
+                    self._replication_throttle(restore_req)
+                except Exception as restore_ex:
+                    logger.warn("zrm_checkpoint_create: failed to restore mirror speed for vm %s: %s" %
+                                (vm_uuid, restore_ex))
 
         except Exception as e:
             logger.exception("zrm_checkpoint_create failed")

--- a/kvmagent/kvmagent/plugins/zrm_plugin.py
+++ b/kvmagent/kvmagent/plugins/zrm_plugin.py
@@ -1314,10 +1314,100 @@ class ZrmPlugin(kvmagent.KvmAgent):
 
     @kvmagent.replyerror
     def zrm_checkpoint_create(self, req):
-        logger.info("ZRM checkpoint/create called -- not yet implemented")
-        return jsonobject.dumps(ZrmAgentRsp(
-            success=False,
-            error="ZR_AGENT.NOT_IMPLEMENTED: checkpoint/create is not implemented in this agent version"))
+        """
+        Source-side checkpoint gate: ensure mirrors are converged before
+        asking ZR Server to create an atomic checkpoint on the target.
+
+        Sequence:
+          A. Set mirror speed=0 (unlimited) and poll until allReady
+          B. POST /zr/checkpoint/create to ZR Server
+          C. Restore original mirror speed (best-effort)
+
+        Request fields:
+          vmUuid          - source VM UUID (required)
+          sessionUuid     - ZR replication session UUID (required)
+          checkpointUuid  - new checkpoint UUID (required)
+          zrServerUrl     - ZR Server base URL, e.g. http://host:6800 (required)
+          waitReadyTimeout - seconds to wait for mirror convergence (default 30)
+          originalSpeed   - mirror speed (bytes/s) to restore after checkpoint.
+                            0 means unlimited (no throttle); this is also the
+                            default when the field is omitted. Pass the pre-
+                            checkpoint throttle value if mirrors were rate-limited.
+        """
+        try:
+            body = req.get(http.REQUEST_BODY)
+            if not body:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="missing body"))
+            cmd = jsonobject.loads(body)
+
+            vm_uuid = (getattr(cmd, "vmUuid", None) or "").strip()
+            session_uuid = (getattr(cmd, "sessionUuid", None) or "").strip()
+            checkpoint_uuid = (getattr(cmd, "checkpointUuid", None) or "").strip()
+            zr_server_url = (getattr(cmd, "zrServerUrl", None) or "").strip()
+            wait_timeout = int(getattr(cmd, "waitReadyTimeout", None) or 30)
+            original_speed = int(getattr(cmd, "originalSpeed", None) or 0)
+
+            if not all([vm_uuid, session_uuid, checkpoint_uuid, zr_server_url]):
+                return jsonobject.dumps(ZrmAgentRsp(
+                    success=False,
+                    error="vmUuid, sessionUuid, checkpointUuid, zrServerUrl are all required"))
+
+            # Step A: speed=0 (quiesce) + wait allReady via _replication_throttle
+            throttle_req = {
+                http.REQUEST_BODY: json.dumps({
+                    "vmUuid": vm_uuid,
+                    "speed": 0,
+                    "waitReadyTimeout": wait_timeout
+                })
+            }
+            throttle_rsp_json = self._replication_throttle(throttle_req)
+            throttle_rsp = jsonobject.loads(throttle_rsp_json)
+
+            if not getattr(throttle_rsp, "success", True):
+                return jsonobject.dumps(ZrmAgentRsp(
+                    success=False,
+                    error="mirror convergence failed: %s" % (getattr(throttle_rsp, "error", "") or "")))
+
+            if not getattr(throttle_rsp, "allReady", False):
+                return jsonobject.dumps(ZrmAgentRsp(
+                    success=False,
+                    error="mirrors not ready after %ds (ready=%s total=%s)" % (
+                        wait_timeout,
+                        getattr(throttle_rsp, "readyCount", "?"),
+                        getattr(throttle_rsp, "totalJobs", "?"))))
+
+            # Step B: POST to ZR Server /zr/checkpoint/create
+            url = zr_server_url.rstrip("/") + "/zr/checkpoint/create"
+            cp_body = json.dumps({"sessionUuid": session_uuid, "checkpointUuid": checkpoint_uuid})
+            zr_rsp_raw = http.json_post(url, body=cp_body, fail_soon=True)
+            zr_rsp = jsonobject.loads(zr_rsp_raw)
+
+            if not getattr(zr_rsp, "success", False):
+                return jsonobject.dumps(ZrmAgentRsp(
+                    success=False,
+                    error="ZR Server checkpoint/create failed: %s" % (getattr(zr_rsp, "error", "") or "")))
+
+            # Step C: restore original mirror speed (best-effort, failure is non-fatal)
+            try:
+                restore_req = {
+                    http.REQUEST_BODY: json.dumps({
+                        "vmUuid": vm_uuid,
+                        "speed": original_speed,
+                        "waitReadyTimeout": 0
+                    })
+                }
+                self._replication_throttle(restore_req)
+            except Exception as restore_ex:
+                logger.warn("zrm_checkpoint_create: failed to restore mirror speed for vm %s: %s" %
+                            (vm_uuid, restore_ex))
+
+            logger.info("zrm_checkpoint_create: vm=%s session=%s checkpoint=%s success" %
+                        (vm_uuid, session_uuid, checkpoint_uuid))
+            return jsonobject.dumps(ZrmAgentRsp(checkpointUuid=checkpoint_uuid))
+
+        except Exception as e:
+            logger.exception("zrm_checkpoint_create failed")
+            return jsonobject.dumps(ZrmAgentRsp(success=False, error=str(e)))
 
     @kvmagent.replyerror
     def zrm_recovery_prepare(self, req):

--- a/kvmagent/kvmagent/plugins/zrm_plugin.py
+++ b/kvmagent/kvmagent/plugins/zrm_plugin.py
@@ -72,7 +72,9 @@ def execute_qmp_command_raw(domain_id, command, raise_exception=False):
     This wrapper is kept for backward compatibility and to preserve the
     default ``raise_exception=False`` used by ZRM bitmap operations.
     """
-    return qmp.execute_qmp_command_raw(domain_id, command, raise_exception=raise_exception)
+    if hasattr(qmp, 'execute_qmp_command_raw'):
+        return qmp.execute_qmp_command_raw(domain_id, command, raise_exception=raise_exception)
+    return qmp._execute_qmp_command(domain_id, command, raise_exception=raise_exception)
 
 
 class ZrmAgentRsp(object):
@@ -488,6 +490,24 @@ class ZrmPlugin(kvmagent.KvmAgent):
             return {}
         return {k: v for k, v in by_dev.items() if k and (k.startswith("zrm-mirror-"))}
 
+    def _query_zrm_block_jobs(self, vm_uuid):
+        """
+        Query all ZR mirror jobs and preserve observation failures.
+
+        Returns a tuple ``(jobs, error_text)`` so callers that must distinguish
+        "job missing" from "query path temporarily blocked" do not have to
+        infer that from an empty map.
+        """
+        try:
+            by_dev = qmp.query_block_jobs_by_device(vm_uuid)
+        except Exception as e:
+            err = str(e)
+            logger.debug("ZRM query-block-jobs failed for vm %s: %s" % (vm_uuid, err))
+            return {}, err
+        if not by_dev:
+            return {}, None
+        return ({k: v for k, v in by_dev.items() if k and (k.startswith("zrm-mirror-"))}, None)
+
     def _collect_bitmap_status(self, vm_uuid):
         """
         Collect dirty bitmap status for all ZRM bitmaps on this VM.
@@ -528,23 +548,55 @@ class ZrmPlugin(kvmagent.KvmAgent):
         Wait for initial full mirror completion of the specified volumes.
 
         All zrm-mirror-* jobs for the volumes must reach a ready state
-        (job.ready is True or status == "ready"). Returns None on success,
-        or an error string on timeout or when jobs are missing.
+        (job.ready is True or status == "ready"). Returns a ZrmAgentRsp so
+        the caller can distinguish ordinary timeout/not-ready from terminal
+        concluded-job failures and missing-job conditions.
         """
         if isinstance(volume_uuids, (str, bytes)):
             volume_uuids = [volume_uuids] if volume_uuids else []
         vols = [v.strip() for v in (volume_uuids or []) if (v or "").strip()]
         if not vols:
-            return "no volumeUuids specified for initial full sync wait"
+            return ZrmAgentRsp(success=False, error="no volumeUuids specified for initial full sync wait")
         job_ids = ["zrm-mirror-%s" % v[:MIRROR_JOB_UUID_TRUNCATE_LEN] for v in vols]
         # Enforce a deadline to prevent indefinite thread blocking.
         effective_timeout = timeout_seconds if (timeout_seconds and timeout_seconds > 0) else _DEFAULT_MAX_WAIT_TIMEOUT
         deadline = time.time() + effective_timeout
         last_log_ts = 0.0
         while True:
-            jobs = self._get_zrm_block_jobs(vm_uuid)
+            jobs, query_error = self._query_zrm_block_jobs(vm_uuid)
+            if query_error:
+                now = time.time()
+                if now >= deadline:
+                    err = "initial full sync observation failed for vm=%s: query-block-jobs error=%s" % (
+                        vm_uuid, query_error)
+                    logger.warn("ZRM initial full sync wait: %s" % err)
+                    return ZrmAgentRsp(
+                        success=False,
+                        error=err,
+                        queryBlockJobsFailed=True,
+                        queryBlockJobsError=query_error,
+                        queryBlockJobsRetriable=True,
+                        readyJobCount=0,
+                        runningJobCount=0,
+                        concludedJobCount=0,
+                        concludedJobErrors=[],
+                        not_ready=[],
+                        missing=[]
+                    )
+                if now - last_log_ts >= WAIT_INITIAL_LOG_INTERVAL:
+                    logger.info("ZRM initial full sync wait: vm=%s query-block-jobs observation failed: %s" %
+                                (vm_uuid, query_error))
+                    last_log_ts = now
+                time.sleep(1.0)
+                continue
             not_ready = []
             missing = []
+            ready_count = 0
+            running_count = 0
+            concluded_count = 0
+            concluded_errors = []
+            synced_bytes = 0
+            target_bytes = 0
             for job_id in job_ids:
                 job = jobs.get(job_id)
                 if not job:
@@ -552,18 +604,78 @@ class ZrmPlugin(kvmagent.KvmAgent):
                     continue
                 status = (job.get("status") or "").lower()
                 ready = job.get("ready") is True or status == "ready"
+                off = _to_long(job.get("offset"))
+                ln = _to_long(job.get("len"))
+                if off is not None and off > 0:
+                    synced_bytes += off
+                if ln is not None and ln > 0:
+                    target_bytes += ln
                 if not ready:
                     not_ready.append(job_id)
+                    if status == "running":
+                        running_count += 1
+                    elif status == "concluded":
+                        concluded_count += 1
+                        err_text = job.get("error") or "no error detail"
+                        concluded_errors.append({"device": job_id, "error": str(err_text)})
+                        try:
+                            qmp.execute_qmp_command(vm_uuid, "block-job-dismiss",
+                                                    raise_exception=False, id=job_id)
+                        except Exception:
+                            pass
+                else:
+                    ready_count += 1
+            if concluded_count > 0:
+                err = "mirror job concluded during initial full sync for vm=%s: %s" % (
+                    vm_uuid, concluded_errors)
+                logger.warn("ZRM initial full sync wait: %s" % err)
+                return ZrmAgentRsp(
+                    success=False,
+                    error=err,
+                    lastSyncDataBytes=synced_bytes if synced_bytes > 0 else 0,
+                    lastSyncBytes=synced_bytes if synced_bytes > 0 else 0,
+                    totalSyncTargetBytes=target_bytes if target_bytes > 0 else 0,
+                    readyJobCount=ready_count,
+                    runningJobCount=running_count,
+                    concludedJobCount=concluded_count,
+                    concludedJobErrors=concluded_errors,
+                    totalJobs=len(job_ids),
+                    not_ready=not_ready,
+                    missing=missing
+                )
             now = time.time()
             if not not_ready and not missing:
                 logger.info("ZRM initial full sync wait: all jobs ready for vm=%s volumes=%s" %
                             (vm_uuid, ",".join([v[:MIRROR_JOB_UUID_TRUNCATE_LEN] for v in vols])))
-                return None
+                return ZrmAgentRsp(
+                    success=True,
+                    lastSyncDataBytes=synced_bytes if synced_bytes > 0 else 0,
+                    lastSyncBytes=synced_bytes if synced_bytes > 0 else 0,
+                    totalSyncTargetBytes=target_bytes if target_bytes > 0 else 0,
+                    readyJobCount=ready_count,
+                    runningJobCount=running_count,
+                    concludedJobCount=0,
+                    concludedJobErrors=[],
+                    totalJobs=len(job_ids)
+                )
             if now >= deadline:
                 err = "initial full sync timeout for vm=%s, not_ready=%s, missing=%s" % (
                     vm_uuid, ",".join(not_ready), ",".join(missing))
                 logger.warn("ZRM initial full sync wait: %s" % err)
-                return err
+                return ZrmAgentRsp(
+                    success=False,
+                    error=err,
+                    lastSyncDataBytes=synced_bytes if synced_bytes > 0 else 0,
+                    lastSyncBytes=synced_bytes if synced_bytes > 0 else 0,
+                    totalSyncTargetBytes=target_bytes if target_bytes > 0 else 0,
+                    readyJobCount=ready_count,
+                    runningJobCount=running_count,
+                    concludedJobCount=concluded_count,
+                    concludedJobErrors=concluded_errors,
+                    totalJobs=len(job_ids),
+                    not_ready=not_ready,
+                    missing=missing
+                )
             if now - last_log_ts >= WAIT_INITIAL_LOG_INTERVAL:
                 logger.info("ZRM initial full sync wait: vm=%s not_ready=%s missing=%s" %
                             (vm_uuid, ",".join(not_ready), ",".join(missing)))
@@ -1107,11 +1219,9 @@ class ZrmPlugin(kvmagent.KvmAgent):
             timeout_seconds = getattr(cmd, "timeoutSeconds", None)
             if timeout_seconds is None:
                 timeout_seconds = 0
-            err = self._wait_initial_full_sync(vm_uuid, vol_uuids,
+            rsp = self._wait_initial_full_sync(vm_uuid, vol_uuids,
                                                int(timeout_seconds) if timeout_seconds else 0)
-            if err:
-                return jsonobject.dumps(ZrmAgentRsp(success=False, error=err))
-            return jsonobject.dumps(ZrmAgentRsp())
+            return jsonobject.dumps(rsp or ZrmAgentRsp())
         except Exception as e:
             logger.exception("ZRM replication wait-initial failed")
             return jsonobject.dumps(ZrmAgentRsp(success=False, error=str(e)))

--- a/kvmagent/kvmagent/plugins/zrm_plugin.py
+++ b/kvmagent/kvmagent/plugins/zrm_plugin.py
@@ -1,0 +1,1322 @@
+# -*- coding: utf-8 -*-
+"""
+ZRM agent plugin.
+
+Registers KVM agent HTTP endpoints under /zrm/replication/*, /zrm/bitmap/*,
+/zrm/checkpoint/* and /zrm/recovery/* for block replication, bitmap management,
+checkpoint management and recovery flows.
+
+The implementation is decoupled from CDP; it uses drive-mirror + NBD based
+replication similar to the CDP / dual-active design (see kvmagent_implementation_design.md).
+"""
+from __future__ import absolute_import
+
+import json
+from kvmagent import kvmagent
+from zstacklib.utils import http
+from zstacklib.utils import jsonobject
+from zstacklib.utils import log
+from zstacklib.utils import qmp
+import time
+
+logger = log.get_logger(__name__)
+
+# Python 2/3 string-type compatibility.
+# On Python 2 json.loads returns unicode; basestring covers both str and unicode.
+# On Python 3 basestring does not exist; str is sufficient.
+try:
+    _str_types = basestring
+except NameError:
+    _str_types = str
+
+# Dirty bitmap name prefix used by ZR replication.
+# Different from CDP's "zsbm-" prefix; per-volume bitmap name is
+# "zrm-{first 16 chars of volumeUuid}".
+ZRM_BITMAP_PREFIX = "zrm-"
+
+# Number of leading characters of volumeUuid used to build the per-volume
+# dirty bitmap name: ZRM_BITMAP_PREFIX + volumeUuid[:BITMAP_UUID_TRUNCATE_LEN].
+BITMAP_UUID_TRUNCATE_LEN = 16
+
+# Number of leading characters of volumeUuid used to build the per-volume
+# mirror job ID: "zrm-mirror-" + volumeUuid[:MIRROR_JOB_UUID_TRUNCATE_LEN].
+MIRROR_JOB_UUID_TRUNCATE_LEN = 8
+
+# Default maximum timeout (seconds) for _wait_initial_full_sync when the
+# caller does not specify one. Prevents async HTTP handler threads from
+# blocking indefinitely.
+_DEFAULT_MAX_WAIT_TIMEOUT = 3600
+
+# Interval (seconds) between progress log messages inside _wait_initial_full_sync.
+WAIT_INITIAL_LOG_INTERVAL = 30.0
+
+
+def _to_long(v):
+    """Safely convert a value to int (long). Returns None on failure."""
+    if v is None:
+        return None
+    try:
+        return int(v)
+    except Exception:
+        try:
+            return int(float(v))
+        except Exception:
+            return None
+
+
+def execute_qmp_command_raw(domain_id, command, raise_exception=False):
+    """
+    Execute a raw QMP command represented as a full JSON *string*.
+
+    Delegates to the public ``qmp.execute_qmp_command_raw`` API.
+    This wrapper is kept for backward compatibility and to preserve the
+    default ``raise_exception=False`` used by ZRM bitmap operations.
+    """
+    return qmp.execute_qmp_command_raw(domain_id, command, raise_exception=raise_exception)
+
+
+class ZrmAgentRsp(object):
+    """Lightweight response object aligned with Java KVMAgentCommands.AgentResponse."""
+    def __init__(self, success=True, error=None, **kwargs):
+        self.success = success
+        self.error = error
+        for k, v in (kwargs or {}).items():
+            setattr(self, k, v)
+
+
+class ZrmPlugin(kvmagent.KvmAgent):
+    PATH_REPLICATION_START = "/zrm/replication/start"
+    PATH_REPLICATION_STOP = "/zrm/replication/stop"
+    PATH_REPLICATION_PAUSE = "/zrm/replication/pause"
+    PATH_REPLICATION_RESUME = "/zrm/replication/resume"
+    PATH_REPLICATION_SYNC = "/zrm/replication/sync"
+    PATH_REPLICATION_WAIT_INITIAL = "/zrm/replication/wait-initial"
+    PATH_BITMAP_CREATE = "/zrm/bitmap/create"
+    PATH_CHECKPOINT_CREATE = "/zrm/checkpoint/create"
+    PATH_RECOVERY_PREPARE = "/zrm/recovery/prepare"
+    PATH_REPLICATION_THROTTLE = "/zrm/replication/throttle"
+
+    def start(self):
+        http_server = kvmagent.get_http_server()
+        # All ZRM paths are invoked via KVMHostAsyncHttpCallMsg and must be registered as async URIs.
+        http_server.register_async_uri(self.PATH_REPLICATION_START, self.zrm_replication_start)
+        http_server.register_async_uri(self.PATH_REPLICATION_STOP, self.zrm_replication_stop)
+        http_server.register_async_uri(self.PATH_REPLICATION_PAUSE, self.zrm_replication_pause)
+        http_server.register_async_uri(self.PATH_REPLICATION_RESUME, self.zrm_replication_resume)
+        http_server.register_async_uri(self.PATH_REPLICATION_SYNC, self.zrm_replication_sync)
+        http_server.register_async_uri(self.PATH_REPLICATION_WAIT_INITIAL, self.zrm_replication_wait_initial)
+        http_server.register_async_uri(self.PATH_BITMAP_CREATE, self.zrm_bitmap_create)
+        http_server.register_async_uri(self.PATH_CHECKPOINT_CREATE, self.zrm_checkpoint_create)
+        http_server.register_async_uri(self.PATH_RECOVERY_PREPARE, self.zrm_recovery_prepare)
+        http_server.register_async_uri(self.PATH_REPLICATION_THROTTLE, self.zrm_replication_throttle)
+        logger.info("ZRM plugin started: registered /zrm/* paths as async URIs")
+
+    def stop(self):
+        pass
+
+    def configure(self, config):
+        self.config = config
+
+
+
+    @staticmethod
+    def _block_struct_contains_volume(obj, volume_uuid):
+        """
+        Recursively check whether any string value in a nested dict/list
+        structure contains the given volume_uuid.
+
+        Delegates to vm_plugin._block_struct_contains_volume_uuid when
+        available; keeps a local fallback to avoid a hard dependency.
+        """
+        try:
+            from kvmagent.plugins.vm_plugin import _block_struct_contains_volume_uuid
+            return _block_struct_contains_volume_uuid(obj, volume_uuid)
+        except ImportError:
+            pass
+        # Inline fallback (same logic) when vm_plugin is unavailable.
+        if isinstance(obj, _str_types):
+            return volume_uuid in obj
+        if isinstance(obj, dict):
+            for v in obj.values():
+                if ZrmPlugin._block_struct_contains_volume(v, volume_uuid):
+                    return True
+        elif isinstance(obj, list):
+            for v in obj:
+                if ZrmPlugin._block_struct_contains_volume(v, volume_uuid):
+                    return True
+        return False
+
+    def _get_drive_name_from_domain_xml(self, vm_uuid, volume_uuid):
+        """
+        Look up the disk in libvirt domain XML by volumeUuid and return a
+        CDP-style drive name (drive-<alias>).
+
+        The logic is aligned with vm_plugin.get_disk_device_name /
+        _get_target_disk to ensure VMs started with -drive can be mirrored
+        correctly. Returns None if the disk cannot be found or if domain XML
+        is not available (to avoid hard dependency on vm_plugin / libvirt).
+        """
+        if not vm_uuid or not volume_uuid:
+            return None
+        vol_str = volume_uuid if isinstance(volume_uuid, str) else str(volume_uuid)
+        try:
+            from kvmagent.plugins.vm_plugin import get_vm_by_uuid
+            vm = get_vm_by_uuid(vm_uuid, exception_if_not_existing=False)
+            if not vm or not getattr(vm, "domain_xmlobject", None):
+                return None
+            disks = vm.domain_xmlobject.devices.get_child_node_as_list("disk")
+            if not disks:
+                return None
+            for disk in disks:
+                # Skip disks without a source (e.g. cdrom without media)
+                if not getattr(disk, "source", None):
+                    continue
+                path = None
+                if getattr(disk.source, "file_", None):
+                    path = disk.source.file_
+                elif getattr(disk.source, "dev_", None):
+                    path = disk.source.dev_
+                elif getattr(disk.source, "name_", None):
+                    path = disk.source.name_
+                elif getattr(disk.source, "path_", None):
+                    path = disk.source.path_
+                if not path or vol_str not in (path or ""):
+                    continue
+                alias = getattr(getattr(disk, "alias", None), "name_", None)
+                if not alias:
+                    continue
+                drive_name = ("drive-" if getattr(disk, "type_", None) != "quorum" else "") + alias
+                logger.debug("ZRM drive name from domain XML: volume=%s -> %s" % (vol_str[:MIRROR_JOB_UUID_TRUNCATE_LEN], drive_name))
+                return drive_name
+        except Exception as e:
+            logger.debug("ZRM get drive from domain XML failed: %s" % e)
+        return None
+
+    def _parse_nbd_url(self, nbd_url):
+        """
+        Parse an NBD URL of the form nbd://host:port/export into
+        (host, port, export_name).
+
+        The port is converted to int; the export part defaults to an
+        empty string when omitted. Returns None if parsing fails.
+        """
+        if not nbd_url or not isinstance(nbd_url, _str_types):
+            return None
+        s = (nbd_url or "").strip()
+        if not s.startswith("nbd://"):
+            return None
+        try:
+            rest = s[6:]
+            slash = rest.find("/")
+            if slash >= 0:
+                host_port, export = rest[:slash], rest[slash + 1:]
+            else:
+                host_port, export = rest, ""
+            colon = host_port.rfind(":")
+            if colon <= 0:
+                return None
+            host = host_port[:colon]
+            port_str = host_port[colon + 1:]
+            port = int(port_str)
+            return (host, port, export or "")
+        except (ValueError, AttributeError):
+            return None
+
+    def _try_blockdev_mirror_to_nbd(self, vm_uuid, node_name, nbd_url, job_id, sync_mode, bitmap_name):
+        """
+        Fallback path when all drive-mirror attempts fail: create an NBD client
+        node via blockdev-add and then run blockdev-mirror to that node.
+
+        This is mainly used for -blockdev setups where devices are only
+        addressable by node-name and drive-mirror fails with root node errors.
+        node_name is the source BDS node name (for example libvirt-2-format);
+        sync_mode is either 'full' or 'incremental'; bitmap_name is required
+        for incremental sync. Returns True on success, otherwise False.
+        """
+        parsed = self._parse_nbd_url(nbd_url)
+        if not parsed or not node_name:
+            return False
+        host, port, export_name = parsed
+        if not export_name:
+            logger.warn("ZRM blockdev-mirror fallback: nbd export name empty")
+            return False
+        # Derive target node name from job_id; delete any stale node before re-adding.
+        job_suffix = job_id.replace("zrm-mirror-", "") if job_id else ""
+        if not job_suffix:
+            logger.warn("ZRM blockdev-mirror fallback: empty job_id suffix, skipping")
+            return False
+        tgt_node = "zrm-tgt-%s" % job_suffix
+        try:
+            # Best-effort removal of any previous node with the same name to avoid duplicate nodes.
+            blockdev_del = {"execute": "blockdev-del", "arguments": {"node-name": tgt_node}}
+            execute_qmp_command_raw(vm_uuid, json.dumps(blockdev_del), raise_exception=False)
+            # blockdev-add: wrap the NBD client with a raw node; QEMU requires the target to be an existing node.
+            blockdev_add = {
+                "execute": "blockdev-add",
+                "arguments": {
+                    "driver": "raw",
+                    "node-name": tgt_node,
+                    "file": {
+                        "driver": "nbd",
+                        "server": {"type": "inet", "host": host, "port": str(port)},
+                        "export": export_name
+                    }
+                }
+            }
+            execute_qmp_command_raw(vm_uuid, json.dumps(blockdev_add), raise_exception=True)
+            # blockdev-mirror: device is the source node-name, target is the NBD node just added.
+            mirror_args = {
+                "device": node_name,
+                "target": tgt_node,
+                "sync": sync_mode,
+                "job-id": job_id or tgt_node,
+                "auto-finalize": False,
+                "auto-dismiss": False
+            }
+            if bitmap_name and sync_mode == "incremental":
+                mirror_args["bitmap"] = bitmap_name
+            qmp.execute_qmp_command(vm_uuid, "blockdev-mirror", raise_exception=True, **mirror_args)
+            logger.info("ZRM replication start: blockdev-mirror fallback ok for node=%s -> %s (target=%s)" % (node_name, nbd_url, tgt_node))
+            return True
+        except Exception as e:
+            logger.warn("ZRM blockdev-mirror fallback failed: %s" % e)
+            return False
+
+    def _get_block_device_for_volume_uuid(self, domain_uuid, volume_uuid):
+        """
+        Locate the block device for a volume using QMP query-block.
+
+        Delegates to ``vm_plugin.get_mirror_device_for_volume_uuid`` which
+        walks the QEMU block graph for accurate root-node resolution, then
+        falls back to a simple query-block scan if the import fails.
+
+        Returns (device_name, node_name) for drive-mirror usage.
+        """
+        if not volume_uuid or not domain_uuid:
+            return None, None
+        # Prefer the authoritative implementation in vm_plugin.
+        try:
+            from kvmagent.plugins.vm_plugin import get_mirror_device_for_volume_uuid
+            node, device = get_mirror_device_for_volume_uuid(domain_uuid, volume_uuid)
+            if node or device:
+                return device or node, node or device
+        except Exception as e:
+            logger.debug("ZRM vm_plugin.get_mirror_device_for_volume_uuid unavailable: %s" % e)
+
+        # Lightweight fallback: scan query-block without block-graph walk.
+        blocks = self._query_blocks_for_vm(domain_uuid)
+        return self._find_block_entry_for_volume(blocks, volume_uuid)
+
+    def _query_blocks_for_vm(self, domain_uuid):
+        """
+        Perform a single query-block for the VM and return a normalized list
+        of block entries (list of dict).
+
+        This allows _start_mirrors_for_zr to reuse results across volumes and
+        avoid issuing one QMP query per volume, which would slow down API
+        responses. Returns None on failure or empty result.
+        """
+        if not domain_uuid:
+            return None
+        try:
+            blocks = qmp.execute_qmp_command(domain_uuid, "query-block", raise_exception=False)
+        except Exception as e:
+            logger.warn("ZRM query-block failed for vm[uuid:%s]: %s" % (domain_uuid, e))
+            return None
+        if not blocks:
+            return None
+        if isinstance(blocks, dict):
+            blocks = list(blocks.values())
+        return [b for b in (blocks or []) if isinstance(b, dict)]
+
+    @staticmethod
+    def _extract_device_node_from_block_entry(entry):
+        """
+        Extract (device, node_name) from a single query-block entry dict.
+
+        Shared by _find_block_entry_for_volume and the fallback path of
+        _get_block_device_for_volume_uuid to avoid duplicating the
+        device/qdev/node-name resolution logic.
+        Returns (device_or_None, node_name_or_None).
+        """
+        device = entry.get("device") or ""
+        if not isinstance(device, _str_types) or not device.strip():
+            device = None
+        qdev = entry.get("qdev") or entry.get("Qdev") or ""
+        if not isinstance(qdev, _str_types):
+            qdev = str(qdev) if qdev else ""
+        if (not device or not device.strip()) and qdev.strip():
+            parts = qdev.strip().rstrip("/").split("/")
+            for p in reversed(parts):
+                if p and p not in ("virtio-backend", "machine", "peripheral", "scsi-backend"):
+                    device = p
+                    break
+        node_name = None
+        inserted = entry.get("inserted") or {}
+        if isinstance(inserted, dict):
+            node_name = inserted.get("node-name")
+        return device, node_name
+
+    def _find_block_entry_for_volume(self, blocks_list, volume_uuid):
+        """
+        Find the query-block entry that contains the given volumeUuid from a
+        pre-fetched blocks_list and return (device, node_name).
+
+        Returns (None, None) when not found or when blocks_list is None.
+        """
+        if not blocks_list or not volume_uuid:
+            return None, None
+        vol_str = volume_uuid if isinstance(volume_uuid, str) else str(volume_uuid)
+        for b in blocks_list:
+            if not self._block_struct_contains_volume(b, vol_str):
+                continue
+            device, node_name = self._extract_device_node_from_block_entry(b)
+            if device or node_name:
+                return device or node_name, node_name or device
+        return None, None
+
+    def _diagnose_block_topology(self, vm_uuid, volume_uuid, node_name_used):
+        """
+        Diagnose libvirt/QEMU block topology for a given volume and node name.
+
+        Uses query-block to record the inserted node-name, device and qdev for
+        the volume, then delegates to ``vm_plugin._find_root_block_node`` to
+        walk ``x-debug-query-block-graph`` and determine the root block-driver
+        node.  Returns (suggested_root_node_name or None, summary_string).
+        """
+        if not vm_uuid or not volume_uuid:
+            return None, ""
+        vol_str = volume_uuid if isinstance(volume_uuid, str) else str(volume_uuid)
+        summary_parts = []
+
+        # 1) query-block: record inserted (root), device and qdev for the volume.
+        try:
+            blocks = qmp.execute_qmp_command(vm_uuid, "query-block", raise_exception=False)
+        except Exception as e:
+            summary_parts.append("query-block failed: %s" % e)
+            return None, "; ".join(summary_parts)
+        if blocks:
+            if isinstance(blocks, dict):
+                blocks = list(blocks.values())
+            for b in (blocks or []):
+                if not isinstance(b, dict) or not self._block_struct_contains_volume(b, vol_str):
+                    continue
+                inserted = b.get("inserted") or {}
+                ins_node = inserted.get("node-name") if isinstance(inserted, dict) else None
+                dev = b.get("device") or ""
+                qdev = b.get("qdev") or b.get("Qdev") or ""
+                summary_parts.append("query-block: inserted.node-name=%s device=%s qdev=%s" % (ins_node, dev or "(empty)", (qdev or "(empty)")[:60]))
+                break
+        if not summary_parts:
+            summary_parts.append("query-block: no block containing volume")
+
+        # 2) Delegate block-graph walk to vm_plugin._find_root_block_node.
+        #    It handles the x-debug-query-block-graph QMP call, capability
+        #    caching, and the upward traversal.  If the command is unsupported
+        #    it returns node_name_used unchanged (no-op).
+        suggested_root = None
+        try:
+            from kvmagent.plugins.vm_plugin import _find_root_block_node
+            root_name = _find_root_block_node(vm_uuid, node_name_used)
+            if root_name and root_name != node_name_used:
+                suggested_root = root_name
+                summary_parts.append("block-graph: node '%s' is NOT root; root of chain is '%s'" %
+                                     (node_name_used, root_name))
+            elif root_name == node_name_used:
+                summary_parts.append("block-graph: node '%s' is ROOT (or graph unavailable)" % node_name_used)
+        except Exception as e:
+            summary_parts.append("block-graph walk failed: %s" % e)
+
+        return suggested_root, "; ".join(summary_parts)
+
+    def _zrm_bitmap_name(self, volume_uuid):
+        """Return the fixed per-volume bitmap name for ZRM, distinct from CDP's zsbm- prefix."""
+        return ZRM_BITMAP_PREFIX + (volume_uuid or "")[:BITMAP_UUID_TRUNCATE_LEN]
+
+    def _has_dirty_bitmap(self, domain_uuid, node_name, bitmap_name):
+        """Return True if a dirty bitmap exists on the given node, otherwise False."""
+        if not node_name or not bitmap_name:
+            return False
+        try:
+            # Use a full arguments dict to avoid name collisions with qmp.execute_qmp_command's name parameter.
+            qmp_cmd = {"execute": "block-dirty-bitmap-query", "arguments": {"node": node_name, "name": bitmap_name}}
+            execute_qmp_command_raw(domain_uuid, json.dumps(qmp_cmd), raise_exception=True)
+            return True
+        except Exception:
+            return False
+
+    def _add_dirty_bitmap(self, domain_uuid, node_name, bitmap_name):
+        """Create a dirty bitmap on the given block node using QMP block-dirty-bitmap-add."""
+        if not node_name or not bitmap_name:
+            return False
+        try:
+            # Use a full arguments dict to avoid collisions with qmp.execute_qmp_command's name parameter.
+            qmp_cmd = {"execute": "block-dirty-bitmap-add", "arguments": {"node": node_name, "name": bitmap_name}}
+            execute_qmp_command_raw(domain_uuid, json.dumps(qmp_cmd), raise_exception=True)
+            logger.info("ZRM bitmap added: vm=%s node=%s name=%s" % (domain_uuid, node_name, bitmap_name))
+            return True
+        except Exception as e:
+            logger.warn("ZRM block-dirty-bitmap-add failed: %s" % e)
+            return False
+
+    def _remove_dirty_bitmap(self, domain_uuid, node_name, bitmap_name):
+        """Remove a dirty bitmap from the given block node using QMP block-dirty-bitmap-remove."""
+        if not node_name or not bitmap_name:
+            return False
+        try:
+            qmp_cmd = {"execute": "block-dirty-bitmap-remove", "arguments": {"node": node_name, "name": bitmap_name}}
+            execute_qmp_command_raw(domain_uuid, json.dumps(qmp_cmd), raise_exception=True)
+            logger.info("ZRM bitmap removed: vm=%s node=%s name=%s" % (domain_uuid, node_name, bitmap_name))
+            return True
+        except Exception as e:
+            logger.warn("ZRM block-dirty-bitmap-remove failed: %s" % e)
+            return False
+
+    def _get_zrm_block_jobs(self, vm_uuid):
+        """
+        Query all ZR mirror jobs on the VM (devices starting with zrm-mirror-).
+
+        Returns a mapping device -> job object that is used by the replication
+        state machine to evaluate ready/running states.
+        """
+        try:
+            by_dev = qmp.query_block_jobs_by_device(vm_uuid)
+        except Exception as e:
+            logger.debug("ZRM query-block-jobs failed for vm %s: %s" % (vm_uuid, e))
+            return {}
+        if not by_dev:
+            return {}
+        return {k: v for k, v in by_dev.items() if k and (k.startswith("zrm-mirror-"))}
+
+    def _collect_bitmap_status(self, vm_uuid):
+        """
+        Collect dirty bitmap status for all ZRM bitmaps on this VM.
+
+        Returns a list of dicts, each containing:
+          - name: bitmap name (e.g. "zrm-0e9d21d9c80046cf")
+          - recording: True if the bitmap is actively recording writes
+          - node: the block node name the bitmap is attached to
+
+        This information helps the ZRM server decide whether incremental
+        recovery is possible (bitmap intact) or a full sync is needed.
+        """
+        result = []
+        try:
+            block_info = qmp.execute_qmp_command(vm_uuid, "query-block", raise_exception=False)
+            if not block_info:
+                return result
+            if isinstance(block_info, dict):
+                block_info = list(block_info.values())
+            for entry in (block_info or []):
+                inserted = entry.get("inserted") or entry.get("image") or {}
+                dirty_bitmaps = inserted.get("dirty-bitmaps") or []
+                node_name = inserted.get("node-name") or entry.get("device") or ""
+                for bm in dirty_bitmaps:
+                    bm_name = bm.get("name") or ""
+                    if bm_name.startswith(ZRM_BITMAP_PREFIX):
+                        result.append({
+                            "name": bm_name,
+                            "recording": bm.get("recording", False),
+                            "node": node_name
+                        })
+        except Exception as e:
+            logger.debug("ZRM _collect_bitmap_status failed for vm %s: %s" % (vm_uuid, e))
+        return result
+
+    def _wait_initial_full_sync(self, vm_uuid, volume_uuids, timeout_seconds):
+        """
+        Wait for initial full mirror completion of the specified volumes.
+
+        All zrm-mirror-* jobs for the volumes must reach a ready state
+        (job.ready is True or status == "ready"). Returns None on success,
+        or an error string on timeout or when jobs are missing.
+        """
+        if isinstance(volume_uuids, (str, bytes)):
+            volume_uuids = [volume_uuids] if volume_uuids else []
+        vols = [v.strip() for v in (volume_uuids or []) if (v or "").strip()]
+        if not vols:
+            return "no volumeUuids specified for initial full sync wait"
+        job_ids = ["zrm-mirror-%s" % v[:MIRROR_JOB_UUID_TRUNCATE_LEN] for v in vols]
+        # Enforce a deadline to prevent indefinite thread blocking.
+        effective_timeout = timeout_seconds if (timeout_seconds and timeout_seconds > 0) else _DEFAULT_MAX_WAIT_TIMEOUT
+        deadline = time.time() + effective_timeout
+        last_log_ts = 0.0
+        while True:
+            jobs = self._get_zrm_block_jobs(vm_uuid)
+            not_ready = []
+            missing = []
+            for job_id in job_ids:
+                job = jobs.get(job_id)
+                if not job:
+                    missing.append(job_id)
+                    continue
+                status = (job.get("status") or "").lower()
+                ready = job.get("ready") is True or status == "ready"
+                if not ready:
+                    not_ready.append(job_id)
+            now = time.time()
+            if not not_ready and not missing:
+                logger.info("ZRM initial full sync wait: all jobs ready for vm=%s volumes=%s" %
+                            (vm_uuid, ",".join([v[:MIRROR_JOB_UUID_TRUNCATE_LEN] for v in vols])))
+                return None
+            if now >= deadline:
+                err = "initial full sync timeout for vm=%s, not_ready=%s, missing=%s" % (
+                    vm_uuid, ",".join(not_ready), ",".join(missing))
+                logger.warn("ZRM initial full sync wait: %s" % err)
+                return err
+            if now - last_log_ts >= WAIT_INITIAL_LOG_INTERVAL:
+                logger.info("ZRM initial full sync wait: vm=%s not_ready=%s missing=%s" %
+                            (vm_uuid, ",".join(not_ready), ",".join(missing)))
+                last_log_ts = now
+            time.sleep(1.0)
+
+    def _build_mirror_candidates(self, vm_uuid, vol_uuid, device, node_name, blocks_cache):
+        """
+        Build an ordered list of QEMU device/node identifiers to try for
+        drive-mirror, from most specific to most generic:
+
+          1. BDS node-name (from _get_block_device_for_volume_uuid, which
+             already delegates to vm_plugin's block-graph walker)
+          2. Domain XML drive name (drive-<alias>)
+          3. qdev path from query-block
+          4. drive-<device> heuristic
+          5. Raw device name
+
+        Returns a non-empty list.
+        """
+        candidates = []
+
+        def _add(c):
+            if c and c not in candidates:
+                candidates.append(c)
+
+        # 1. Node-name is the most reliable identifier for -blockdev VMs.
+        _add(node_name)
+        # 2. Domain XML drive name (libvirt alias).
+        _add(self._get_drive_name_from_domain_xml(vm_uuid, vol_uuid))
+        # 3. qdev path from cached query-block entry.
+        if blocks_cache:
+            for _b in blocks_cache:
+                if self._block_struct_contains_volume(_b, vol_uuid):
+                    qdev_path = _b.get("qdev") or _b.get("Qdev")
+                    if isinstance(qdev_path, _str_types) and qdev_path:
+                        _add(qdev_path)
+                    break
+        # 4. drive-<device> heuristic (for -drive style VMs).
+        _dev = device or node_name
+        if _dev and not _dev.startswith("drive-") and not _dev.startswith("#") and "format" not in _dev:
+            _add("drive-" + _dev)
+        # 5. Raw device name.
+        _add(device)
+
+        return candidates if candidates else [node_name or device]
+
+    def _start_mirrors_for_zr(self, vm_uuid, volume_uuids, target_nbd_base_url, sync_mode_hint=None):
+        """
+        Start drive-mirror replication to the target NBD for each volume.
+
+        target_nbd_base_url is of the form nbd://host:port; the ZR server
+        exports each volume as vol-{volumeUuid}. If a volume already has a
+        dirty bitmap, use sync=incremental to send only dirty blocks; otherwise
+        add a bitmap and start with sync=full. The state machine completes any
+        ready ZR jobs (block-job-complete) before starting a new mirror, and
+        reuses running jobs.
+
+        sync_mode_hint: optional hint from ZRM:
+          - 'INCREMENTAL': prefer incremental sync via dirty bitmap; error if bitmap not found
+          - 'FULL_SYNC': force full sync, remove existing bitmap first
+          - None/empty: auto-detect (existing behavior)
+        """
+        if isinstance(volume_uuids, (_str_types, bytes)):
+            volume_uuids = [volume_uuids] if volume_uuids else []
+        if not volume_uuids:
+            return "no volumeUuids or volumeUuid in command"
+        base = (target_nbd_base_url or "").rstrip("/")
+        if not base.startswith("nbd://"):
+            return "targetNbdUrl must be nbd://host:port"
+        # Reuse a single query-block result for all volumes to keep API latency low.
+        blocks_cache = self._query_blocks_for_vm(vm_uuid)
+        # Pre-query all ZR jobs on this VM for use by the per-volume state machine.
+        zrm_jobs = self._get_zrm_block_jobs(vm_uuid)
+        first_error = None
+        for vol_uuid in volume_uuids:
+            vol_uuid = (vol_uuid or "").strip()
+            if not vol_uuid:
+                continue
+            # ZR state machine: complete ready jobs, reuse running ones.
+            job_id = "zrm-mirror-%s" % vol_uuid[:MIRROR_JOB_UUID_TRUNCATE_LEN]
+            existing = zrm_jobs.get(job_id)
+            if existing:
+                status = (existing.get("status") or "").lower()
+                ready = existing.get("ready") is True or status == "ready"
+                paused = existing.get("paused") is True
+                err_text = existing.get("error")
+                reusable_running = ((status == "running") and (not paused) and (not err_text)) or (ready and (not err_text) and status != "concluded")
+                if reusable_running:
+                    logger.info("ZRM replication start: volume %s already has running mirror job %s, reuse" % (vol_uuid[:MIRROR_JOB_UUID_TRUNCATE_LEN], job_id))
+                    continue
+                else:
+                    if status == "concluded":
+                        qmp.execute_qmp_command(vm_uuid, "block-job-dismiss", raise_exception=False, id=job_id)
+                    else:
+                        qmp.block_job_cancel(vm_uuid, job_id)
+                        # Wait for cancel to settle so the new drive-mirror doesn't hit a job-id conflict.
+                        _cancel_deadline = time.time() + 5
+                        _cleared = False
+                        while time.time() < _cancel_deadline:
+                            _cur = self._get_zrm_block_jobs(vm_uuid).get(job_id)
+                            if not _cur:
+                                _cleared = True
+                                break
+                            _cur_status = (_cur.get("status") or "").lower()
+                            if _cur_status == "concluded":
+                                qmp.execute_qmp_command(vm_uuid, "block-job-dismiss",
+                                                        raise_exception=False, id=job_id)
+                                _cleared = True
+                                break
+                            if _cur_status == "null":
+                                _cleared = True
+                                break
+                            time.sleep(0.3)
+                        if not _cleared:
+                            # Force-dismiss as last resort: job did not reach concluded/null
+                            # within the deadline.  Attempt dismiss with force=True to avoid
+                            # leaving an orphan job that blocks the next drive-mirror.
+                            logger.warn("ZRM replication start: cancel deadline expired for job %s, attempting force dismiss" % job_id)
+                            qmp.execute_qmp_command(vm_uuid, "block-job-dismiss",
+                                                    raise_exception=False, id=job_id)
+                    logger.info("ZRM replication start: cleared stale mirror job %s for volume %s (status=%s paused=%s error=%s)" %
+                                (job_id, vol_uuid[:MIRROR_JOB_UUID_TRUNCATE_LEN], status, paused, err_text if err_text else ""))
+            nbd_url = "%s/vol-%s" % (base, vol_uuid)
+            # Resolve device/node_name -- _get_block_device_for_volume_uuid already
+            # delegates to vm_plugin.get_mirror_device_for_volume_uuid internally.
+            device, node_name = self._find_block_entry_for_volume(blocks_cache, vol_uuid) if blocks_cache else (None, None)
+            if not device and not node_name:
+                device, node_name = self._get_block_device_for_volume_uuid(vm_uuid, vol_uuid)
+            if not device and not node_name:
+                err = "no block device found for volume %s on vm %s (query-block)" % (vol_uuid, vm_uuid)
+                logger.warn("ZRM replication start: %s" % err)
+                if first_error is None:
+                    first_error = err
+                continue
+            mirror_candidates = self._build_mirror_candidates(vm_uuid, vol_uuid, device, node_name, blocks_cache)
+            bitmap_node = node_name or device
+            logger.debug("ZRM replication volume=%s mirror_candidates=%s bitmap_node=%s" %
+                         (vol_uuid[:MIRROR_JOB_UUID_TRUNCATE_LEN], mirror_candidates, bitmap_node))
+            bitmap_name = self._zrm_bitmap_name(vol_uuid)
+            has_bitmap = self._has_dirty_bitmap(vm_uuid, bitmap_node, bitmap_name)
+            hint = (sync_mode_hint or "").strip().upper()
+            if hint == "FULL_SYNC":
+                # Force full sync: remove existing bitmap so we start clean.
+                if has_bitmap:
+                    self._remove_dirty_bitmap(vm_uuid, bitmap_node, bitmap_name)
+                    logger.info("ZRM replication start: FULL_SYNC forced, removed existing bitmap for %s" % vol_uuid)
+                    has_bitmap = False
+                # Create fresh bitmap to track writes from this point.
+                if not self._add_dirty_bitmap(vm_uuid, bitmap_node, bitmap_name):
+                    logger.warn("ZRM replication start: add bitmap failed for %s" % vol_uuid)
+                sync_mode = "full"
+            elif hint == "INCREMENTAL":
+                if has_bitmap:
+                    sync_mode = "incremental"
+                    logger.info("ZRM replication start: INCREMENTAL mode, bitmap found for %s" % vol_uuid)
+                else:
+                    err = "syncMode=INCREMENTAL but no dirty bitmap found for volume %s -- bitmap must exist before incremental sync" % vol_uuid
+                    logger.warn("ZRM replication start: %s" % err)
+                    if first_error is None:
+                        first_error = err
+                    continue
+            else:
+                # AUTO: use bitmap if exists, otherwise full
+                if has_bitmap:
+                    sync_mode = "incremental"
+                    logger.info("ZRM replication start: auto-detected existing bitmap for %s, using incremental" % vol_uuid)
+                else:
+                    if not self._add_dirty_bitmap(vm_uuid, bitmap_node, bitmap_name):
+                        logger.warn("ZRM replication start: add bitmap failed for %s, continue with sync=full" % vol_uuid)
+                    sync_mode = "full"
+            base_mirror_kw = dict(
+                job_id=job_id, target=nbd_url, mode="existing", format="nbd", sync=sync_mode,
+                auto_finalize=False, auto_dismiss=False
+            )
+            if sync_mode == "incremental" and bitmap_name:
+                base_mirror_kw["bitmap"] = bitmap_name
+            last_err = None
+            for mirror_device in mirror_candidates:
+                if not mirror_device:
+                    continue
+                mirror_kw = dict(device=mirror_device, **base_mirror_kw)
+                try:
+                    qmp.execute_qmp_command(vm_uuid, "drive-mirror", raise_exception=True, **mirror_kw)
+                    logger.info("ZRM replication start: drive-mirror %s for volume %s -> %s (device=%s)" % (sync_mode, vol_uuid, nbd_url, mirror_device))
+                    last_err = None
+                    break
+                except Exception as e:
+                    err_str = str(e)
+                    # Retry with next candidate when device is not found or root node is required.
+                    if "Cannot find device" in err_str or "Need a root block node" in err_str:
+                        logger.debug("ZRM drive-mirror device=%s failed (%s), try next candidate" % (mirror_device, err_str[:80]))
+                        last_err = e
+                        continue
+                    last_err = e
+                    break
+            # If all drive-mirror candidates fail, diagnose block topology, then try the suggested root or blockdev fallback.
+            if last_err is not None:
+                suggested_root, topo_summary = self._diagnose_block_topology(vm_uuid, vol_uuid, node_name or device)
+                logger.warn("ZRM replication topology diagnosis volume=%s: %s" % (vol_uuid[:MIRROR_JOB_UUID_TRUNCATE_LEN], topo_summary))
+                if suggested_root and suggested_root not in mirror_candidates:
+                    try:
+                        mirror_kw = dict(device=suggested_root, **base_mirror_kw)
+                        qmp.execute_qmp_command(vm_uuid, "drive-mirror", raise_exception=True, **mirror_kw)
+                        logger.info("ZRM replication start: drive-mirror ok with topology-suggested device=%s" % suggested_root)
+                        last_err = None
+                    except Exception as e:
+                        logger.debug("ZRM drive-mirror device=%s (from topology) failed: %s" % (suggested_root, e))
+            if last_err is not None and node_name:
+                if self._try_blockdev_mirror_to_nbd(vm_uuid, node_name, nbd_url, job_id, sync_mode, bitmap_name):
+                    last_err = None
+            if last_err is not None:
+                err = "drive-mirror failed for volume %s: %s" % (vol_uuid, last_err)
+                logger.warn("ZRM replication start: %s" % err)
+                if first_error is None:
+                    first_error = err
+        return first_error
+
+    def _replication_start(self, req):
+        """
+        Start replication: validate targetNbdUrl and issue drive-mirror to the
+        target NBD for each volume in volumeUuids/volumeUuid so that VM writes
+        flow to the ZR server.
+
+        Note: jsonobject.loads returns a JsonObject which does not implement
+        .get; use getattr(cmd, 'key', None) to access fields.
+        """
+        try:
+            body = req.get(http.REQUEST_BODY)
+            if not body:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="missing body"))
+            cmd = jsonobject.loads(body)
+            target_nbd_url = (getattr(cmd, "targetNbdUrl", None) or "").strip()
+            if not target_nbd_url:
+                return jsonobject.dumps(ZrmAgentRsp(
+                    success=False,
+                    error="targetNbdUrl required for replication (call target ZR session/prepare and addvolume first)"
+                ))
+            vm_uuid = (getattr(cmd, "vmUuid", None) or "").strip()
+            if not vm_uuid:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="vmUuid required"))
+            volume_uuids = getattr(cmd, "volumeUuids", None) or []
+            if not volume_uuids:
+                single = getattr(cmd, "volumeUuid", None)
+                volume_uuids = [single] if single else []
+            sync_mode_hint = (getattr(cmd, "syncMode", None) or "").strip()
+            err = self._start_mirrors_for_zr(vm_uuid, volume_uuids, target_nbd_url, sync_mode_hint)
+            if err:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error=err))
+            return jsonobject.dumps(ZrmAgentRsp())
+        except Exception as e:
+            logger.exception("ZRM replication start failed")
+            return jsonobject.dumps(ZrmAgentRsp(success=False, error=str(e)))
+
+    @kvmagent.replyerror
+    def zrm_replication_start(self, req):
+        return self._replication_start(req)
+
+    def _replication_stop(self, req):
+        """
+        Stop all ZR mirror jobs on the VM by issuing block-job-cancel for
+        devices whose names start with zrm-mirror-.
+
+        The request body must contain vmUuid (and an optional sessionUuid).
+        """
+        try:
+            body = req.get(http.REQUEST_BODY)
+            if not body:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="missing body"))
+            cmd = jsonobject.loads(body)
+            vm_uuid = (getattr(cmd, "vmUuid", None) or "").strip()
+            if not vm_uuid:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="vmUuid required"))
+            zrm_jobs = self._get_zrm_block_jobs(vm_uuid)
+            cancelled_devices = []
+            for device in zrm_jobs:
+                try:
+                    qmp.block_job_cancel(vm_uuid, device)
+                    cancelled_devices.append(device)
+                    logger.info("ZRM replication stop: cancel requested for job %s on vm %s" % (device, vm_uuid))
+                except Exception as cancel_err:
+                    logger.warn("ZRM replication stop: cancel failed for %s: %s" % (device, cancel_err))
+            # Wait for cancelled jobs to disappear or reach concluded state, then dismiss.
+            stale_jobs = []
+            if cancelled_devices:
+                _stop_deadline = time.time() + 10
+                while time.time() < _stop_deadline:
+                    remaining = self._get_zrm_block_jobs(vm_uuid)
+                    still_active = [d for d in cancelled_devices if d in remaining
+                                    and (remaining[d].get("status") or "").lower() not in ("concluded", "null")]
+                    # Dismiss any concluded jobs immediately.
+                    for d in cancelled_devices:
+                        if d in remaining and (remaining[d].get("status") or "").lower() == "concluded":
+                            try:
+                                qmp.execute_qmp_command(vm_uuid, "block-job-dismiss",
+                                                        raise_exception=False, id=d)
+                            except Exception:
+                                pass
+                    if not still_active:
+                        break
+                    time.sleep(0.5)
+                # Detect stale jobs that survived the cancel deadline.
+                remaining = self._get_zrm_block_jobs(vm_uuid)
+                for d in cancelled_devices:
+                    if d in remaining:
+                        st = (remaining[d].get("status") or "unknown").lower()
+                        stale_jobs.append({"device": d, "status": st})
+                        logger.warn("ZRM replication stop: stale job %s (status=%s) on vm %s after cancel deadline" %
+                                    (d, st, vm_uuid))
+                if not stale_jobs:
+                    logger.info("ZRM replication stop: all cancel requests settled for vm %s" % vm_uuid)
+            rsp = ZrmAgentRsp()
+            if stale_jobs:
+                rsp.staleJobs = stale_jobs
+            return jsonobject.dumps(rsp)
+        except Exception as e:
+            logger.exception("ZRM replication stop failed")
+            return jsonobject.dumps(ZrmAgentRsp(success=False, error=str(e)))
+
+    def _replication_pause(self, req):
+        """
+        Pause all running ZRM mirror jobs on the VM by issuing block-job-pause
+        for each zrm-mirror-* device.
+
+        QMP ``block-job-pause`` suspends write mirroring; dirty writes are
+        still tracked by the bitmap so that a subsequent resume can catch up
+        without a full re-sync.
+
+        Request body: vmUuid (required), sessionUuid (optional).
+        """
+        try:
+            body = req.get(http.REQUEST_BODY)
+            if not body:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="missing body"))
+            cmd = jsonobject.loads(body)
+            vm_uuid = (getattr(cmd, "vmUuid", None) or "").strip()
+            if not vm_uuid:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="vmUuid required"))
+            zrm_jobs = self._get_zrm_block_jobs(vm_uuid)
+            if not zrm_jobs:
+                logger.info("ZRM replication pause: no zrm mirror jobs on vm %s" % vm_uuid)
+                return jsonobject.dumps(ZrmAgentRsp())
+            paused_devices = []
+            errors = []
+            for device, job in zrm_jobs.items():
+                status = (job.get("status") or "").lower()
+                already_paused = job.get("paused") is True
+                if already_paused:
+                    logger.debug("ZRM replication pause: job %s already paused on vm %s" % (device, vm_uuid))
+                    paused_devices.append(device)
+                    continue
+                if status not in ("running", "ready"):
+                    logger.debug("ZRM replication pause: skipping job %s (status=%s) on vm %s" % (device, status, vm_uuid))
+                    continue
+                try:
+                    qmp.execute_qmp_command(vm_uuid, "block-job-pause", device=device)
+                    paused_devices.append(device)
+                    logger.info("ZRM replication pause: paused job %s on vm %s" % (device, vm_uuid))
+                except Exception as pause_err:
+                    err_msg = "failed to pause job %s: %s" % (device, pause_err)
+                    logger.warn("ZRM replication pause: %s" % err_msg)
+                    errors.append(err_msg)
+            if errors:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="; ".join(errors)))
+            return jsonobject.dumps(ZrmAgentRsp())
+        except Exception as e:
+            logger.exception("ZRM replication pause failed")
+            return jsonobject.dumps(ZrmAgentRsp(success=False, error=str(e)))
+
+    def _replication_resume(self, req):
+        """
+        Resume all paused ZRM mirror jobs on the VM by issuing block-job-resume
+        for each paused zrm-mirror-* device.
+
+        After resume, QEMU will re-sync any dirty regions tracked by the
+        bitmap while the job was paused.
+
+        Request body: vmUuid (required), sessionUuid (optional).
+        """
+        try:
+            body = req.get(http.REQUEST_BODY)
+            if not body:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="missing body"))
+            cmd = jsonobject.loads(body)
+            vm_uuid = (getattr(cmd, "vmUuid", None) or "").strip()
+            if not vm_uuid:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="vmUuid required"))
+            zrm_jobs = self._get_zrm_block_jobs(vm_uuid)
+            if not zrm_jobs:
+                logger.info("ZRM replication resume: no zrm mirror jobs on vm %s" % vm_uuid)
+                return jsonobject.dumps(ZrmAgentRsp())
+            resumed_devices = []
+            errors = []
+            for device, job in zrm_jobs.items():
+                paused = job.get("paused") is True
+                if not paused:
+                    logger.debug("ZRM replication resume: job %s not paused on vm %s, skip" % (device, vm_uuid))
+                    continue
+                try:
+                    qmp.execute_qmp_command(vm_uuid, "block-job-resume", device=device)
+                    resumed_devices.append(device)
+                    logger.info("ZRM replication resume: resumed job %s on vm %s" % (device, vm_uuid))
+                except Exception as resume_err:
+                    err_msg = "failed to resume job %s: %s" % (device, resume_err)
+                    logger.warn("ZRM replication resume: %s" % err_msg)
+                    errors.append(err_msg)
+            if errors:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="; ".join(errors)))
+            return jsonobject.dumps(ZrmAgentRsp())
+        except Exception as e:
+            logger.exception("ZRM replication resume failed")
+            return jsonobject.dumps(ZrmAgentRsp(success=False, error=str(e)))
+
+    def _replication_sync(self, req):
+        """
+        Acknowledge sync for current ZR mirror jobs without pivoting VM disks.
+
+        The request body must contain vmUuid (and an optional sessionUuid).
+        volumeUuids are not required.
+        """
+        try:
+            body = req.get(http.REQUEST_BODY)
+            if not body:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="missing body"))
+            cmd = jsonobject.loads(body)
+            vm_uuid = (getattr(cmd, "vmUuid", None) or "").strip()
+            if not vm_uuid:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="vmUuid required"))
+            zrm_jobs = self._get_zrm_block_jobs(vm_uuid)
+            ready_count = 0
+            running_count = 0
+            concluded_count = 0
+            concluded_errors = []
+            synced_bytes = 0
+            target_bytes = 0
+
+            for device, job in zrm_jobs.items():
+                status = (job.get("status") or "").lower()
+                ready = job.get("ready") is True or status == "ready"
+                if ready:
+                    ready_count += 1
+                elif status == "running":
+                    running_count += 1
+                elif status == "concluded":
+                    # A concluded mirror job means the job has finished -- possibly
+                    # with an error (e.g. NBD target disconnected). We must report
+                    # this to the ZRM so it can trigger recovery, and dismiss the
+                    # job to clean up QEMU state (same as _start_mirrors_for_zr).
+                    concluded_count += 1
+                    err_text = job.get("error") or "no error detail"
+                    concluded_errors.append({"device": device, "error": str(err_text)})
+                    try:
+                        qmp.execute_qmp_command(vm_uuid, "block-job-dismiss",
+                                                raise_exception=False, id=device)
+                    except Exception:
+                        pass
+
+                # query-block-jobs fields:
+                #   offset: copied bytes so far for this mirror round
+                #   len:    total bytes of this mirror round
+                off = _to_long(job.get("offset"))
+                ln = _to_long(job.get("len"))
+                if off is not None and off > 0:
+                    synced_bytes += off
+                if ln is not None and ln > 0:
+                    target_bytes += ln
+
+            if concluded_count > 0:
+                logger.warn("ZRM replication sync: vm=%s has %s CONCLUDED mirror jobs (errors: %s)" %
+                            (vm_uuid, concluded_count, concluded_errors))
+                # Collect bitmap status to help ZRM decide recovery strategy:
+                # if bitmaps are intact, incremental sync is possible without full copy.
+                bitmap_status = self._collect_bitmap_status(vm_uuid)
+                return jsonobject.dumps(ZrmAgentRsp(
+                    success=False,
+                    error="ZRM mirror job concluded during sync: %s" % concluded_errors,
+                    lastSyncDataBytes=synced_bytes if synced_bytes > 0 else 0,
+                    lastSyncBytes=synced_bytes if synced_bytes > 0 else 0,
+                    totalSyncTargetBytes=target_bytes if target_bytes > 0 else 0,
+                    readyJobCount=ready_count,
+                    runningJobCount=running_count,
+                    concludedJobCount=concluded_count,
+                    concludedJobErrors=concluded_errors,
+                    totalJobs=len(zrm_jobs),
+                    bitmapStatus=bitmap_status
+                ))
+            if len(zrm_jobs) == 0:
+                logger.warn("ZRM replication sync: vm=%s has no active zrm mirror jobs" % vm_uuid)
+                bitmap_status = self._collect_bitmap_status(vm_uuid)
+                return jsonobject.dumps(ZrmAgentRsp(
+                    success=False,
+                    error="no active ZRM mirror jobs found for vm=%s" % vm_uuid,
+                    lastSyncDataBytes=0,
+                    lastSyncBytes=0,
+                    totalSyncTargetBytes=0,
+                    readyJobCount=0,
+                    runningJobCount=0,
+                    concludedJobCount=0,
+                    concludedJobErrors=[],
+                    totalJobs=0,
+                    bitmapStatus=bitmap_status
+                ))
+            logger.info("ZRM replication sync: vm=%s ready_jobs=%s running_jobs=%s concluded_jobs=%s total_zrm_jobs=%s" %
+                        (vm_uuid, ready_count, running_count, concluded_count, len(zrm_jobs)))
+            return jsonobject.dumps(ZrmAgentRsp(
+                success=True,
+                lastSyncDataBytes=synced_bytes if synced_bytes > 0 else 0,
+                lastSyncBytes=synced_bytes if synced_bytes > 0 else 0,
+                totalSyncTargetBytes=target_bytes if target_bytes > 0 else 0,
+                readyJobCount=ready_count,
+                runningJobCount=running_count,
+                concludedJobCount=concluded_count,
+                concludedJobErrors=concluded_errors,
+                totalJobs=len(zrm_jobs)
+            ))
+        except Exception as e:
+            logger.exception("ZRM replication sync failed")
+            return jsonobject.dumps(ZrmAgentRsp(success=False, error=str(e)))
+
+    def _replication_wait_initial(self, req):
+        """
+        Wait for initial full sync completion: block until all zrm-mirror-*
+        jobs for the specified volumes reach ready state or timeout.
+
+        Request body: vmUuid, volumeUuid/volumeUuids, timeoutSeconds (optional).
+        """
+        try:
+            body = req.get(http.REQUEST_BODY)
+            if not body:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="missing body"))
+            cmd = jsonobject.loads(body)
+            vm_uuid = (getattr(cmd, "vmUuid", None) or "").strip()
+            if not vm_uuid:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="vmUuid required"))
+            vol_uuid = getattr(cmd, "volumeUuid", None)
+            vol_uuids = getattr(cmd, "volumeUuids", None)
+            if vol_uuids is None and vol_uuid is not None:
+                vol_uuids = [vol_uuid] if vol_uuid else []
+            if vol_uuids is None:
+                vol_uuids = []
+            timeout_seconds = getattr(cmd, "timeoutSeconds", None)
+            if timeout_seconds is None:
+                timeout_seconds = 0
+            err = self._wait_initial_full_sync(vm_uuid, vol_uuids,
+                                               int(timeout_seconds) if timeout_seconds else 0)
+            if err:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error=err))
+            return jsonobject.dumps(ZrmAgentRsp())
+        except Exception as e:
+            logger.exception("ZRM replication wait-initial failed")
+            return jsonobject.dumps(ZrmAgentRsp(success=False, error=str(e)))
+
+    @kvmagent.replyerror
+    def zrm_replication_stop(self, req):
+        return self._replication_stop(req)
+
+    @kvmagent.replyerror
+    def zrm_replication_pause(self, req):
+        return self._replication_pause(req)
+
+    @kvmagent.replyerror
+    def zrm_replication_resume(self, req):
+        return self._replication_resume(req)
+
+    @kvmagent.replyerror
+    def zrm_replication_sync(self, req):
+        return self._replication_sync(req)
+
+    @kvmagent.replyerror
+    def zrm_replication_wait_initial(self, req):
+        return self._replication_wait_initial(req)
+
+    def _bitmap_create(self, req):
+        """
+        Create dirty bitmaps for the specified VM volumes (similar to CDP/backup
+        block-dirty-bitmap-add) so that subsequent replication/start calls can
+        use sync=incremental.
+
+        Request body: vmUuid, volumeUuid/volumeUuids, bitmapName (optional).
+        Note: cmd is a JsonObject; use getattr(cmd, 'key', None) for fields.
+        """
+        try:
+            body = req.get(http.REQUEST_BODY)
+            if not body:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="missing body"))
+            cmd = jsonobject.loads(body)
+            vm_uuid = (getattr(cmd, "vmUuid", None) or "").strip()
+            if not vm_uuid:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="vmUuid required"))
+            vol_uuid = getattr(cmd, "volumeUuid", None)
+            vol_uuids = getattr(cmd, "volumeUuids", None)
+            if vol_uuids is None and vol_uuid is not None:
+                vol_uuids = [vol_uuid] if vol_uuid else []
+            if vol_uuids is None:
+                vol_uuids = []
+            if isinstance(vol_uuids, (str, bytes)):
+                vol_uuids = [vol_uuids] if vol_uuids else []
+            bitmap_name_override = (getattr(cmd, "bitmapName", None) or "").strip()
+            first_error = None
+            for vu in vol_uuids:
+                vu = (vu or "").strip()
+                if not vu:
+                    continue
+                device, node_name = self._get_block_device_for_volume_uuid(vm_uuid, vu)
+                if not node_name:
+                    node_name = device
+                if not node_name:
+                    err = "no block device for volume %s on vm %s" % (vu, vm_uuid)
+                    if first_error is None:
+                        first_error = err
+                    continue
+                name = bitmap_name_override or self._zrm_bitmap_name(vu)
+                if self._has_dirty_bitmap(vm_uuid, node_name, name):
+                    logger.info("ZRM bitmap already exists: vm=%s vol=%s name=%s" % (vm_uuid, vu, name))
+                    continue
+                if not self._add_dirty_bitmap(vm_uuid, node_name, name):
+                    err = "block-dirty-bitmap-add failed for volume %s" % vu
+                    if first_error is None:
+                        first_error = err
+            if first_error:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error=first_error))
+            return jsonobject.dumps(ZrmAgentRsp())
+        except Exception as e:
+            logger.exception("ZRM bitmap create failed")
+            return jsonobject.dumps(ZrmAgentRsp(success=False, error=str(e)))
+
+    @kvmagent.replyerror
+    def zrm_bitmap_create(self, req):
+        return self._bitmap_create(req)
+
+    @kvmagent.replyerror
+    def zrm_checkpoint_create(self, req):
+        logger.info("ZRM checkpoint/create called -- not yet implemented")
+        return jsonobject.dumps(ZrmAgentRsp(
+            success=False,
+            error="ZR_AGENT.NOT_IMPLEMENTED: checkpoint/create is not implemented in this agent version"))
+
+    @kvmagent.replyerror
+    def zrm_recovery_prepare(self, req):
+        logger.info("ZRM recovery/prepare called -- not yet implemented")
+        return jsonobject.dumps(ZrmAgentRsp(
+            success=False,
+            error="ZR_AGENT.NOT_IMPLEMENTED: recovery/prepare is not implemented in this agent version"))
+
+    @kvmagent.replyerror
+    def zrm_replication_throttle(self, req):
+        return self._replication_throttle(req)
+
+    def _replication_throttle(self, req):
+        """
+        Set mirror job speed for all zrm-mirror-* block jobs on the VM.
+
+        Caller semantics (API layer, NOT QEMU semantics):
+          - speed=0  → "quiesce": remove speed limit (QEMU speed=0 = unlimited)
+                        so mirrors converge as fast as possible, then poll until
+                        all jobs reach ready state or waitReadyTimeout expires.
+          - speed>0  → set QEMU speed to that value (bytes/s throttle) and return.
+          - speed=-1 → same as speed=0 (unlimited), but do NOT poll for ready.
+
+        QEMU block-job-set-speed semantics:
+          speed=0  → unlimited (no throttle, maximum rate)
+          speed>0  → limit to N bytes/s
+
+        Request body: vmUuid, speed, waitReadyTimeout (seconds, default 10).
+        Response: allReady, readyCount, runningCount, totalJobs.
+        """
+        try:
+            body = req.get(http.REQUEST_BODY)
+            if not body:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="missing body"))
+            cmd = jsonobject.loads(body)
+            vm_uuid = (getattr(cmd, "vmUuid", None) or "").strip()
+            if not vm_uuid:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="vmUuid required"))
+
+            speed = getattr(cmd, "speed", None)
+            if speed is None:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="speed required"))
+            speed = int(speed)
+            wait_timeout = int(getattr(cmd, "waitReadyTimeout", None) or 10)
+
+            # Map API speed to QEMU speed:
+            #   API  0 (quiesce)   → QEMU 0 (unlimited, converge fastest)
+            #   API -1 (unlimited) → QEMU 0 (unlimited)
+            #   API >0 (throttle)  → QEMU N (that exact value)
+            qemu_speed = 0 if speed <= 0 else speed
+
+            all_jobs = self._get_zrm_block_jobs(vm_uuid)
+            # Filter out concluded/completed jobs -- QEMU rejects set-speed on them
+            zrm_jobs = {d: j for d, j in all_jobs.items()
+                        if (j.get("status") or "").lower() not in ("concluded", "null")}
+            total_jobs = len(zrm_jobs)
+
+            # Set speed on active mirror jobs only
+            for device in zrm_jobs:
+                try:
+                    qmp.block_job_set_speed(vm_uuid, device, qemu_speed)
+                except Exception as ex:
+                    logger.warn("ZRM throttle: set-speed failed for %s on vm %s: %s" % (device, vm_uuid, ex))
+
+            if total_jobs == 0:
+                rsp = ZrmAgentRsp()
+                rsp.allReady = True
+                rsp.readyCount = 0
+                rsp.runningCount = 0
+                rsp.totalJobs = 0
+                return jsonobject.dumps(rsp)
+
+            # When quiescing (speed==0), poll until all mirrors ready or timeout.
+            # speed==-1 also sets QEMU unlimited but skips the wait.
+            if speed == 0 and wait_timeout > 0:
+                deadline = time.time() + wait_timeout
+                while time.time() < deadline:
+                    zrm_jobs = self._get_zrm_block_jobs(vm_uuid)
+                    ready_count = 0
+                    running_count = 0
+                    for device, job in zrm_jobs.items():
+                        status = (job.get("status") or "").lower()
+                        ready = job.get("ready") is True or status == "ready"
+                        if ready:
+                            ready_count += 1
+                        elif status == "running":
+                            running_count += 1
+                    if ready_count >= len(zrm_jobs):
+                        rsp = ZrmAgentRsp()
+                        rsp.allReady = True
+                        rsp.readyCount = ready_count
+                        rsp.runningCount = running_count
+                        rsp.totalJobs = len(zrm_jobs)
+                        logger.info("ZRM throttle: vm=%s all %d mirrors ready (quiesce)" % (vm_uuid, ready_count))
+                        return jsonobject.dumps(rsp)
+                    time.sleep(0.5)
+
+            # Final state snapshot
+            zrm_jobs = self._get_zrm_block_jobs(vm_uuid)
+            ready_count = 0
+            running_count = 0
+            for device, job in zrm_jobs.items():
+                status = (job.get("status") or "").lower()
+                ready = job.get("ready") is True or status == "ready"
+                if ready:
+                    ready_count += 1
+                elif status == "running":
+                    running_count += 1
+
+            rsp = ZrmAgentRsp()
+            rsp.allReady = ready_count >= len(zrm_jobs) and len(zrm_jobs) > 0
+            rsp.readyCount = ready_count
+            rsp.runningCount = running_count
+            rsp.totalJobs = len(zrm_jobs)
+            logger.info("ZRM throttle: vm=%s speed=%d qemu_speed=%d ready=%d running=%d total=%d allReady=%s" %
+                        (vm_uuid, speed, qemu_speed, ready_count, running_count, len(zrm_jobs), rsp.allReady))
+            return jsonobject.dumps(rsp)
+        except Exception as e:
+            logger.exception("ZRM replication throttle failed")
+            return jsonobject.dumps(ZrmAgentRsp(success=False, error=str(e)))

--- a/kvmagent/kvmagent/plugins/zrm_plugin.py
+++ b/kvmagent/kvmagent/plugins/zrm_plugin.py
@@ -572,20 +572,28 @@ class ZrmPlugin(kvmagent.KvmAgent):
         effective_timeout = timeout_seconds if (timeout_seconds and timeout_seconds > 0) else _DEFAULT_MAX_WAIT_TIMEOUT
         deadline = time.time() + effective_timeout
         last_log_ts = 0.0
+        query_retry_count = 0
+        query_failure_start_ts = None
         while True:
             jobs, query_error = self._query_zrm_block_jobs(vm_uuid)
             if query_error:
                 now = time.time()
+                query_retry_count += 1
+                if query_failure_start_ts is None:
+                    query_failure_start_ts = now
                 if now >= deadline:
                     err = "initial full sync observation failed for vm=%s: query-block-jobs error=%s" % (
                         vm_uuid, query_error)
                     logger.warn("ZRM initial full sync wait: %s" % err)
+                    total_query_failure_duration = now - query_failure_start_ts if query_failure_start_ts is not None else 0
                     return ZrmAgentRsp(
                         success=False,
                         error=err,
                         queryBlockJobsFailed=True,
                         queryBlockJobsError=query_error,
                         queryBlockJobsRetriable=True,
+                        queryRetryCount=query_retry_count,
+                        totalQueryFailureDuration=total_query_failure_duration,
                         readyJobCount=0,
                         runningJobCount=0,
                         concludedJobCount=0,
@@ -599,6 +607,8 @@ class ZrmPlugin(kvmagent.KvmAgent):
                     last_log_ts = now
                 time.sleep(1.0)
                 continue
+            query_retry_count = 0
+            query_failure_start_ts = None
             not_ready = []
             missing = []
             ready_count = 0
@@ -959,7 +969,13 @@ class ZrmPlugin(kvmagent.KvmAgent):
             vm_uuid = (getattr(cmd, "vmUuid", None) or "").strip()
             if not vm_uuid:
                 return jsonobject.dumps(ZrmAgentRsp(success=False, error="vmUuid required"))
-            zrm_jobs = self._get_zrm_block_jobs(vm_uuid)
+            zrm_jobs, query_error = self._query_zrm_block_jobs(vm_uuid)
+            if query_error:
+                return jsonobject.dumps(ZrmAgentRsp(
+                    success=False,
+                    error="query-block-jobs failed: %s" % query_error,
+                    queryBlockJobsFailed=True,
+                    queryBlockJobsError=query_error))
             cancelled_devices = []
             cancel_failed_jobs = []
             for device in zrm_jobs:
@@ -972,11 +988,17 @@ class ZrmPlugin(kvmagent.KvmAgent):
                     cancel_failed_jobs.append({"device": device, "error": err_msg})
                     logger.warn("ZRM replication stop: cancel failed for %s: %s" % (device, err_msg))
             # Wait for cancelled jobs to disappear or reach concluded state, then dismiss.
+            # block_job_cancel suppresses QMP command errors, so the post-cancel
+            # query is the authoritative proof that recovery can safely continue.
             stale_jobs = []
             if cancelled_devices:
+                post_cancel_query_error = None
                 _stop_deadline = time.time() + 10
                 while time.time() < _stop_deadline:
-                    remaining = self._get_zrm_block_jobs(vm_uuid)
+                    remaining, query_error = self._query_zrm_block_jobs(vm_uuid)
+                    if query_error:
+                        post_cancel_query_error = query_error
+                        break
                     still_active = [d for d in cancelled_devices if d in remaining
                                     and (remaining[d].get("status") or "").lower() not in ("concluded", "null")]
                     # Dismiss any concluded jobs immediately.
@@ -990,8 +1012,22 @@ class ZrmPlugin(kvmagent.KvmAgent):
                     if not still_active:
                         break
                     time.sleep(0.5)
+                if post_cancel_query_error:
+                    return jsonobject.dumps(ZrmAgentRsp(
+                        success=False,
+                        error="query-block-jobs failed after cancel: %s" % post_cancel_query_error,
+                        queryBlockJobsFailed=True,
+                        queryBlockJobsError=post_cancel_query_error,
+                        cancelRequestedDevices=cancelled_devices))
                 # Detect stale jobs that survived the cancel deadline.
-                remaining = self._get_zrm_block_jobs(vm_uuid)
+                remaining, query_error = self._query_zrm_block_jobs(vm_uuid)
+                if query_error:
+                    return jsonobject.dumps(ZrmAgentRsp(
+                        success=False,
+                        error="query-block-jobs failed after cancel: %s" % query_error,
+                        queryBlockJobsFailed=True,
+                        queryBlockJobsError=query_error,
+                        cancelRequestedDevices=cancelled_devices))
                 for d in cancelled_devices:
                     if d in remaining:
                         st = (remaining[d].get("status") or "unknown").lower()
@@ -1361,7 +1397,6 @@ class ZrmPlugin(kvmagent.KvmAgent):
                     success=False,
                     error="vmUuid, sessionUuid, checkpointUuid, zrServerUrl are all required"))
 
-            # Step A: speed=0 (quiesce) + wait allReady via _replication_throttle
             throttle_req = {
                 http.REQUEST_BODY: json.dumps({
                     "vmUuid": vm_uuid,
@@ -1369,41 +1404,48 @@ class ZrmPlugin(kvmagent.KvmAgent):
                     "waitReadyTimeout": wait_timeout
                 })
             }
-            throttle_rsp_json = self._replication_throttle(throttle_req)
-            throttle_rsp = jsonobject.loads(throttle_rsp_json)
+            result = None
+            checkpoint_created = False
+            restore_error = None
+            restore_failures = None
 
-            # Speed may now be 0; use try/finally so original_speed is always restored
-            # regardless of which failure path is taken below.
             try:
-                if not getattr(throttle_rsp, "success", True):
-                    return jsonobject.dumps(ZrmAgentRsp(
-                        success=False,
-                        error="mirror convergence failed: %s" % (getattr(throttle_rsp, "error", "") or "")))
+                throttle_rsp_json = self._replication_throttle(throttle_req)
+                throttle_rsp = jsonobject.loads(throttle_rsp_json)
 
-                if not getattr(throttle_rsp, "allReady", False):
-                    return jsonobject.dumps(ZrmAgentRsp(
+                if not getattr(throttle_rsp, "success", True):
+                    result = ZrmAgentRsp(
+                        success=False,
+                        error="mirror convergence failed: %s" % (getattr(throttle_rsp, "error", "") or ""))
+
+                elif not getattr(throttle_rsp, "allReady", False):
+                    result = ZrmAgentRsp(
                         success=False,
                         error="mirrors not ready after %ds (ready=%s total=%s)" % (
                             wait_timeout,
                             getattr(throttle_rsp, "readyCount", "?"),
-                            getattr(throttle_rsp, "totalJobs", "?"))))
+                            getattr(throttle_rsp, "totalJobs", "?")))
+                else:
+                    # Step B: POST to ZR Server /zr/checkpoint/create
+                    url = zr_server_url.rstrip("/") + "/zr/checkpoint/create"
+                    cp_body = json.dumps({"sessionUuid": session_uuid, "checkpointUuid": checkpoint_uuid})
+                    zr_rsp_raw = http.json_post(url, body=cp_body, fail_soon=True)
+                    zr_rsp = jsonobject.loads(zr_rsp_raw)
 
-                # Step B: POST to ZR Server /zr/checkpoint/create
-                url = zr_server_url.rstrip("/") + "/zr/checkpoint/create"
-                cp_body = json.dumps({"sessionUuid": session_uuid, "checkpointUuid": checkpoint_uuid})
-                zr_rsp_raw = http.json_post(url, body=cp_body, fail_soon=True)
-                zr_rsp = jsonobject.loads(zr_rsp_raw)
-
-                if not getattr(zr_rsp, "success", False):
-                    return jsonobject.dumps(ZrmAgentRsp(
-                        success=False,
-                        error="ZR Server checkpoint/create failed: %s" % (getattr(zr_rsp, "error", "") or "")))
-
-                logger.info("zrm_checkpoint_create: vm=%s session=%s checkpoint=%s success" %
-                            (vm_uuid, session_uuid, checkpoint_uuid))
-                return jsonobject.dumps(ZrmAgentRsp(checkpointUuid=checkpoint_uuid))
+                    if not getattr(zr_rsp, "success", False):
+                        result = ZrmAgentRsp(
+                            success=False,
+                            error="ZR Server checkpoint/create failed: %s" % (getattr(zr_rsp, "error", "") or ""))
+                    else:
+                        checkpoint_created = True
+                        logger.info("zrm_checkpoint_create: vm=%s session=%s checkpoint=%s success" %
+                                    (vm_uuid, session_uuid, checkpoint_uuid))
+                        result = ZrmAgentRsp(checkpointUuid=checkpoint_uuid)
+            except Exception as op_ex:
+                logger.exception("zrm_checkpoint_create operation failed")
+                result = ZrmAgentRsp(success=False, error=str(op_ex))
             finally:
-                # Step C: restore original mirror speed (best-effort, failure is non-fatal)
+                # Step C: restore original mirror speed; report failures to the caller.
                 try:
                     restore_req = {
                         http.REQUEST_BODY: json.dumps({
@@ -1412,10 +1454,58 @@ class ZrmPlugin(kvmagent.KvmAgent):
                             "waitReadyTimeout": 0
                         })
                     }
-                    self._replication_throttle(restore_req)
+                    restore_rsp_json = self._replication_throttle(restore_req)
+                    try:
+                        restore_body = json.loads(restore_rsp_json)
+                    except Exception as parse_ex:
+                        restore_body = None
+                        restore_error = "unable to parse mirror speed restoration response: %s" % parse_ex
+                    if restore_body is not None and not isinstance(restore_body, dict):
+                        restore_error = "unexpected mirror speed restoration response: %s" % restore_body
+                    elif restore_body is not None and not restore_body.get("success", True):
+                        restore_error = restore_body.get("error") or "unknown mirror speed restoration failure"
+                        restore_failures = restore_body.get("speedSetFailures")
                 except Exception as restore_ex:
-                    logger.warn("zrm_checkpoint_create: failed to restore mirror speed for vm %s: %s" %
-                                (vm_uuid, restore_ex))
+                    restore_error = str(restore_ex)
+                if restore_error:
+                    if checkpoint_created:
+                        logger.error("zrm_checkpoint_create: failed to restore mirror speed for vm %s: %s "
+                                     "(checkpoint %s created)" % (vm_uuid, restore_error, checkpoint_uuid))
+                    else:
+                        logger.warn("zrm_checkpoint_create: failed to restore mirror speed for vm %s: %s" %
+                                    (vm_uuid, restore_error))
+
+            if restore_error:
+                original_error = getattr(result, "error", None) if result is not None else None
+                error_msg = "mirror speed restoration failed: %s" % restore_error
+                if checkpoint_created:
+                    error_msg = (
+                        "checkpoint %s created successfully but mirror speed restoration failed: %s. "
+                        "Checkpoint is usable. ACTION REQUIRED: retry speed throttle to restore replication rate." % (
+                            checkpoint_uuid, restore_error))
+                elif original_error:
+                    error_msg = error_msg + "; original checkpoint error: " + original_error
+                rsp = ZrmAgentRsp(
+                    success=(True if checkpoint_created else False),
+                    error=error_msg,
+                    checkpointUuid=checkpoint_uuid,
+                    degraded=(True if checkpoint_created else False),
+                    speedRestoreFailed=True,
+                    speedRestoreError=restore_error)
+                if restore_failures is not None:
+                    rsp.speedRestoreFailures = restore_failures
+                if original_error:
+                    rsp.checkpointError = original_error
+                return jsonobject.dumps(rsp)
+
+            if result is None:
+                logger.error(
+                    "zrm_checkpoint_create: unexpected nil result for vm %s session %s checkpoint %s "
+                    "(checkpoint_created=%s, restore_error=%s, restore_failures=%s)" % (
+                        vm_uuid, session_uuid, checkpoint_uuid,
+                        checkpoint_created, restore_error, restore_failures))
+                result = ZrmAgentRsp(success=False, error="checkpoint operation did not produce response")
+            return jsonobject.dumps(result)
 
         except Exception as e:
             logger.exception("zrm_checkpoint_create failed")
@@ -1534,8 +1624,15 @@ class ZrmPlugin(kvmagent.KvmAgent):
                 stale_jobs = getattr(stop_rsp, "staleJobs", None)
                 if not stop_success:
                     err = getattr(stop_rsp, "error", "unknown error")
-                    return jsonobject.dumps(ZrmAgentRsp(success=False,
-                        error="replication_stop failed: %s" % err))
+                    rsp = ZrmAgentRsp(success=False,
+                        error="replication_stop failed: %s" % err)
+                    if getattr(stop_rsp, "queryBlockJobsFailed", False):
+                        rsp.queryBlockJobsFailed = True
+                        rsp.queryBlockJobsError = getattr(stop_rsp, "queryBlockJobsError", None)
+                        cancel_requested_devices = getattr(stop_rsp, "cancelRequestedDevices", None)
+                        if cancel_requested_devices is not None:
+                            rsp.cancelRequestedDevices = cancel_requested_devices
+                    return jsonobject.dumps(rsp)
                 if stale_jobs:
                     return jsonobject.dumps(ZrmAgentRsp(success=False,
                         error="replication_stop: stale mirror jobs remain: %s" % stale_jobs))
@@ -1802,18 +1899,42 @@ class ZrmPlugin(kvmagent.KvmAgent):
             #   API >0 (throttle)  → QEMU N (that exact value)
             qemu_speed = 0 if speed <= 0 else speed
 
-            all_jobs = self._get_zrm_block_jobs(vm_uuid)
+            all_jobs, query_error = self._query_zrm_block_jobs(vm_uuid)
+            if query_error:
+                return jsonobject.dumps(ZrmAgentRsp(
+                    success=False,
+                    error="query-block-jobs failed: %s" % query_error,
+                    queryBlockJobsFailed=True,
+                    queryBlockJobsError=query_error))
             # Filter out concluded/completed jobs -- QEMU rejects set-speed on them
             zrm_jobs = {d: j for d, j in all_jobs.items()
                         if (j.get("status") or "").lower() not in ("concluded", "null")}
             total_jobs = len(zrm_jobs)
 
             # Set speed on active mirror jobs only
+            speed_set_failures = []
+            speed_set_devices = []
             for device in zrm_jobs:
                 try:
                     qmp.block_job_set_speed(vm_uuid, device, qemu_speed)
+                    speed_set_devices.append(device)
                 except Exception as ex:
-                    logger.warn("ZRM throttle: set-speed failed for %s on vm %s: %s" % (device, vm_uuid, ex))
+                    err = str(ex)
+                    speed_set_failures.append({"device": device, "error": err})
+                    logger.warn("ZRM throttle: set-speed failed for %s on vm %s: %s" % (device, vm_uuid, err))
+
+            if speed_set_failures:
+                rsp = ZrmAgentRsp(
+                    success=False,
+                    error="failed to set speed for ZRM mirror jobs: %s" % (
+                        "; ".join(["%s: %s" % (f["device"], f["error"]) for f in speed_set_failures])),
+                    speedSetFailed=True,
+                    speedSetFailures=speed_set_failures,
+                    speedSetDevices=speed_set_devices)
+                rsp.readyCount = 0
+                rsp.runningCount = total_jobs
+                rsp.totalJobs = total_jobs
+                return jsonobject.dumps(rsp)
 
             if total_jobs == 0:
                 rsp = ZrmAgentRsp()
@@ -1828,7 +1949,15 @@ class ZrmPlugin(kvmagent.KvmAgent):
             if speed == 0 and wait_timeout > 0:
                 deadline = time.time() + wait_timeout
                 while time.time() < deadline:
-                    zrm_jobs = self._get_zrm_block_jobs(vm_uuid)
+                    zrm_jobs, query_error = self._query_zrm_block_jobs(vm_uuid)
+                    if query_error:
+                        return jsonobject.dumps(ZrmAgentRsp(
+                            success=False,
+                            error="query-block-jobs failed: %s" % query_error,
+                            queryBlockJobsFailed=True,
+                            queryBlockJobsError=query_error,
+                            speedSetDevices=speed_set_devices,
+                            totalJobs=total_jobs))
                     ready_count = 0
                     running_count = 0
                     for device, job in zrm_jobs.items():
@@ -1849,7 +1978,15 @@ class ZrmPlugin(kvmagent.KvmAgent):
                     time.sleep(0.5)
 
             # Final state snapshot
-            zrm_jobs = self._get_zrm_block_jobs(vm_uuid)
+            zrm_jobs, query_error = self._query_zrm_block_jobs(vm_uuid)
+            if query_error:
+                return jsonobject.dumps(ZrmAgentRsp(
+                    success=False,
+                    error="query-block-jobs failed: %s" % query_error,
+                    queryBlockJobsFailed=True,
+                    queryBlockJobsError=query_error,
+                    speedSetDevices=speed_set_devices,
+                    totalJobs=total_jobs))
             ready_count = 0
             running_count = 0
             for device, job in zrm_jobs.items():

--- a/kvmagent/kvmagent/plugins/zrm_plugin.py
+++ b/kvmagent/kvmagent/plugins/zrm_plugin.py
@@ -961,13 +961,16 @@ class ZrmPlugin(kvmagent.KvmAgent):
                 return jsonobject.dumps(ZrmAgentRsp(success=False, error="vmUuid required"))
             zrm_jobs = self._get_zrm_block_jobs(vm_uuid)
             cancelled_devices = []
+            cancel_failed_jobs = []
             for device in zrm_jobs:
                 try:
                     qmp.block_job_cancel(vm_uuid, device)
                     cancelled_devices.append(device)
                     logger.info("ZRM replication stop: cancel requested for job %s on vm %s" % (device, vm_uuid))
                 except Exception as cancel_err:
-                    logger.warn("ZRM replication stop: cancel failed for %s: %s" % (device, cancel_err))
+                    err_msg = str(cancel_err)
+                    cancel_failed_jobs.append({"device": device, "error": err_msg})
+                    logger.warn("ZRM replication stop: cancel failed for %s: %s" % (device, err_msg))
             # Wait for cancelled jobs to disappear or reach concluded state, then dismiss.
             stale_jobs = []
             if cancelled_devices:
@@ -998,6 +1001,10 @@ class ZrmPlugin(kvmagent.KvmAgent):
                 if not stale_jobs:
                     logger.info("ZRM replication stop: all cancel requests settled for vm %s" % vm_uuid)
             rsp = ZrmAgentRsp()
+            if cancel_failed_jobs:
+                rsp.success = False
+                rsp.error = "failed to cancel ZRM mirror jobs: %s" % cancel_failed_jobs
+                rsp.cancelFailedJobs = cancel_failed_jobs
             if stale_jobs:
                 rsp.staleJobs = stale_jobs
             return jsonobject.dumps(rsp)
@@ -1602,6 +1609,30 @@ class ZrmPlugin(kvmagent.KvmAgent):
                 return False, "QGA command disabled: " + cmd
         return True, None
 
+    def _get_cached_linux_fsfreeze_count(self, qga):
+        vm_uuid = getattr(qga, "vm_uuid", None)
+        cache = getattr(self, "_linux_fsfreeze_counts", None) or {}
+        try:
+            return int(cache.get(vm_uuid, 0) or 0)
+        except Exception:
+            return 0
+
+    def _set_cached_linux_fsfreeze_count(self, qga, fs_count):
+        vm_uuid = getattr(qga, "vm_uuid", None)
+        if not vm_uuid:
+            return
+        cache = getattr(self, "_linux_fsfreeze_counts", None)
+        if cache is None:
+            cache = {}
+            self._linux_fsfreeze_counts = cache
+        cache[vm_uuid] = fs_count if isinstance(fs_count, int) else 0
+
+    def _clear_cached_linux_fsfreeze_count(self, qga):
+        vm_uuid = getattr(qga, "vm_uuid", None)
+        cache = getattr(self, "_linux_fsfreeze_counts", None)
+        if vm_uuid and cache:
+            cache.pop(vm_uuid, None)
+
     def _linux_guest_fsfreeze(self, qga, action, timeout_seconds):
         """Linux path: freeze/thaw via QGA fsfreeze commands."""
         ok, reason = self._qga_supports_fsfreeze(qga)
@@ -1616,9 +1647,7 @@ class ZrmPlugin(kvmagent.KvmAgent):
                 status = qga.call_qga_command(
                     self._FSFREEZE_CMD_STATUS, timeout=timeout_seconds)
                 if status == "frozen":
-                    frozen_list = qga.call_qga_command(
-                        "guest-fsfreeze-freeze-list", timeout=timeout_seconds)
-                    fs_count = len(frozen_list) if isinstance(frozen_list, list) else 0
+                    fs_count = self._get_cached_linux_fsfreeze_count(qga)
                     return self._guest_fsfreeze_response(
                         True, "frozen", fs_count, guest_os_type="linux",
                         quiesce_provider="qga-fsfreeze")
@@ -1634,6 +1663,7 @@ class ZrmPlugin(kvmagent.KvmAgent):
                         "unexpected fsfreeze status after freeze: " + str(status),
                         guest_os_type="linux", quiesce_provider="qga-fsfreeze",
                         error_code="QGA_RETURN_VALUE_ERROR")
+                self._set_cached_linux_fsfreeze_count(qga, fs_count)
                 return self._guest_fsfreeze_response(
                     True, "frozen", fs_count, guest_os_type="linux",
                     quiesce_provider="qga-fsfreeze")
@@ -1642,6 +1672,7 @@ class ZrmPlugin(kvmagent.KvmAgent):
                 status = qga.call_qga_command(
                     self._FSFREEZE_CMD_STATUS, timeout=timeout_seconds)
                 if status == "thawed":
+                    self._clear_cached_linux_fsfreeze_count(qga)
                     return self._guest_fsfreeze_response(
                         True, "thawed", 0, guest_os_type="linux",
                         quiesce_provider="qga-fsfreeze")
@@ -1657,6 +1688,7 @@ class ZrmPlugin(kvmagent.KvmAgent):
                         "unexpected fsfreeze status after thaw: " + str(status),
                         guest_os_type="linux", quiesce_provider="qga-fsfreeze",
                         error_code="QGA_RETURN_VALUE_ERROR")
+                self._clear_cached_linux_fsfreeze_count(qga)
                 return self._guest_fsfreeze_response(
                     True, "thawed", fs_count, guest_os_type="linux",
                     quiesce_provider="qga-fsfreeze")

--- a/kvmagent/kvmagent/plugins/zrm_plugin.py
+++ b/kvmagent/kvmagent/plugins/zrm_plugin.py
@@ -17,6 +17,7 @@ from zstacklib.utils import http
 from zstacklib.utils import jsonobject
 from zstacklib.utils import log
 from zstacklib.utils import qmp
+from zstacklib.utils.qga import VmQga
 import time
 
 logger = log.get_logger(__name__)
@@ -97,6 +98,12 @@ class ZrmPlugin(kvmagent.KvmAgent):
     PATH_CHECKPOINT_CREATE = "/zrm/checkpoint/create"
     PATH_RECOVERY_PREPARE = "/zrm/recovery/prepare"
     PATH_REPLICATION_THROTTLE = "/zrm/replication/throttle"
+    PATH_REPLICATION_GUEST_FSFREEZE = "/zrm/replication/guest-fsfreeze"
+
+    # QGA fsfreeze command names (Linux application-consistent quiesce).
+    _FSFREEZE_CMD_FREEZE = "guest-fsfreeze-freeze"
+    _FSFREEZE_CMD_THAW = "guest-fsfreeze-thaw"
+    _FSFREEZE_CMD_STATUS = "guest-fsfreeze-status"
 
     def start(self):
         http_server = kvmagent.get_http_server()
@@ -111,6 +118,7 @@ class ZrmPlugin(kvmagent.KvmAgent):
         http_server.register_async_uri(self.PATH_CHECKPOINT_CREATE, self.zrm_checkpoint_create)
         http_server.register_async_uri(self.PATH_RECOVERY_PREPARE, self.zrm_recovery_prepare)
         http_server.register_async_uri(self.PATH_REPLICATION_THROTTLE, self.zrm_replication_throttle)
+        http_server.register_async_uri(self.PATH_REPLICATION_GUEST_FSFREEZE, self.zrm_replication_guest_fsfreeze)
         logger.info("ZRM plugin started: registered /zrm/* paths as async URIs")
 
     def stop(self):
@@ -1321,6 +1329,186 @@ class ZrmPlugin(kvmagent.KvmAgent):
     @kvmagent.replyerror
     def zrm_replication_throttle(self, req):
         return self._replication_throttle(req)
+
+    @kvmagent.replyerror
+    def zrm_replication_guest_fsfreeze(self, req):
+        return self._replication_guest_fsfreeze(req)
+
+    def _get_vm_qga(self, vm_uuid):
+        """Return a connected VmQga for vm_uuid, or (None, error_message) on failure."""
+        try:
+            from kvmagent.plugins.vm_plugin import get_vm_by_uuid
+            vm = get_vm_by_uuid(vm_uuid)
+            if not vm or not getattr(vm, "domain", None):
+                return None, "unable to find vm domain: " + vm_uuid
+            qga = VmQga(vm.domain)
+            if qga.state != VmQga.QGA_STATE_RUNNING:
+                return None, "QEMU Guest Agent not in running state for vm " + vm_uuid
+            return qga, None
+        except Exception as ex:
+            return None, str(ex)
+
+    def _guest_fsfreeze_response(self, success, fs_status, filesystem_count=0,
+                                 error_message=None, guest_os_type=None,
+                                 quiesce_provider=None, error_code=None):
+        """Build agent response body compatible with ZRM GuestFsFreezeResult."""
+        fields = {
+            "success": success,
+            "fsFreezeStatus": fs_status,
+            "filesystemCount": filesystem_count,
+        }
+        if error_message is not None:
+            fields["errorMessage"] = error_message
+        if guest_os_type is not None:
+            fields["guestOsType"] = guest_os_type
+        if quiesce_provider is not None:
+            fields["quiesceProvider"] = quiesce_provider
+        if error_code is not None:
+            fields["errorCode"] = error_code
+        return jsonobject.dumps(ZrmAgentRsp(**fields))
+
+    def _qga_supports_fsfreeze(self, qga):
+        """Return whether QGA exposes and enables fsfreeze-related commands."""
+        required = (
+            self._FSFREEZE_CMD_FREEZE,
+            self._FSFREEZE_CMD_THAW,
+            self._FSFREEZE_CMD_STATUS,
+        )
+        for cmd in required:
+            if cmd not in qga.supported_commands:
+                return False, "QGA command not supported: " + cmd
+            if not qga.supported_commands.get(cmd):
+                return False, "QGA command disabled: " + cmd
+        return True, None
+
+    def _linux_guest_fsfreeze(self, qga, action, timeout_seconds):
+        """Linux path: freeze/thaw via QGA fsfreeze commands."""
+        ok, reason = self._qga_supports_fsfreeze(qga)
+        if not ok:
+            return self._guest_fsfreeze_response(
+                False, "error", 0, reason, guest_os_type="linux",
+                quiesce_provider="none", error_code="QGA_COMMAND_IS_DISABLED")
+
+        timeout_seconds = max(3, int(timeout_seconds or 30))
+        try:
+            if action == "freeze":
+                status = qga.call_qga_command(
+                    self._FSFREEZE_CMD_STATUS, timeout=timeout_seconds)
+                if status == "frozen":
+                    frozen_list = qga.call_qga_command(
+                        "guest-fsfreeze-freeze-list", timeout=timeout_seconds)
+                    fs_count = len(frozen_list) if isinstance(frozen_list, list) else 0
+                    return self._guest_fsfreeze_response(
+                        True, "frozen", fs_count, guest_os_type="linux",
+                        quiesce_provider="qga-fsfreeze")
+                fs_count = qga.call_qga_command(
+                    self._FSFREEZE_CMD_FREEZE, timeout=timeout_seconds)
+                if not isinstance(fs_count, int):
+                    fs_count = 0
+                status = qga.call_qga_command(
+                    self._FSFREEZE_CMD_STATUS, timeout=timeout_seconds)
+                if status != "frozen":
+                    return self._guest_fsfreeze_response(
+                        False, "error", fs_count,
+                        "unexpected fsfreeze status after freeze: " + str(status),
+                        guest_os_type="linux", quiesce_provider="qga-fsfreeze",
+                        error_code="QGA_RETURN_VALUE_ERROR")
+                return self._guest_fsfreeze_response(
+                    True, "frozen", fs_count, guest_os_type="linux",
+                    quiesce_provider="qga-fsfreeze")
+
+            if action == "thaw":
+                status = qga.call_qga_command(
+                    self._FSFREEZE_CMD_STATUS, timeout=timeout_seconds)
+                if status == "thawed":
+                    return self._guest_fsfreeze_response(
+                        True, "thawed", 0, guest_os_type="linux",
+                        quiesce_provider="qga-fsfreeze")
+                fs_count = qga.call_qga_command(
+                    self._FSFREEZE_CMD_THAW, timeout=timeout_seconds)
+                if not isinstance(fs_count, int):
+                    fs_count = 0
+                status = qga.call_qga_command(
+                    self._FSFREEZE_CMD_STATUS, timeout=timeout_seconds)
+                if status != "thawed":
+                    return self._guest_fsfreeze_response(
+                        False, "error", fs_count,
+                        "unexpected fsfreeze status after thaw: " + str(status),
+                        guest_os_type="linux", quiesce_provider="qga-fsfreeze",
+                        error_code="QGA_RETURN_VALUE_ERROR")
+                return self._guest_fsfreeze_response(
+                    True, "thawed", fs_count, guest_os_type="linux",
+                    quiesce_provider="qga-fsfreeze")
+
+            return self._guest_fsfreeze_response(
+                False, "error", 0, "unsupported action: " + str(action),
+                guest_os_type="linux", quiesce_provider="qga-fsfreeze",
+                error_code="QGA_COMMAND_ERROR")
+        except Exception as ex:
+            logger.warn("ZRM guest-fsfreeze linux action=%s vm=%s failed: %s" %
+                        (action, qga.vm_uuid, ex))
+            return self._guest_fsfreeze_response(
+                False, "error", 0, str(ex), guest_os_type="linux",
+                quiesce_provider="qga-fsfreeze", error_code="QGA_COMMAND_EXEC_ERROR")
+
+    def _windows_guest_fsfreeze(self, qga, action, timeout_seconds):
+        """Windows path: GuestTools zs-tools VSS; degrades when zs-tools is not installed."""
+        timeout_seconds = max(3, int(timeout_seconds or 30))
+        if not qga.guest_file_is_exist(VmQga.ZS_TOOLS_PATN_WIN):
+            return self._guest_fsfreeze_response(
+                False, "error", 0, "zstack-guest-tools zs-tools.exe not installed",
+                guest_os_type="windows", quiesce_provider="none",
+                error_code="GUESTTOOLS_NOT_INSTALLED")
+        operate = "freeze" if action == "freeze" else "thaw" if action == "thaw" else None
+        if operate is None:
+            return self._guest_fsfreeze_response(
+                False, "error", 0, "unsupported action: " + str(action),
+                guest_os_type="windows", quiesce_provider="guesttools-vss",
+                error_code="QGA_COMMAND_ERROR")
+        exit_code, output = qga.guest_exec_zs_tools(operate, "{}", output=True)
+        if exit_code != 0:
+            return self._guest_fsfreeze_response(
+                False, "error", 0, output or ("zs-tools " + operate + " failed"),
+                guest_os_type="windows", quiesce_provider="guesttools-vss",
+                error_code="VSS_WRITER_FAILED")
+        fs_status = "frozen" if operate == "freeze" else "thawed"
+        return self._guest_fsfreeze_response(
+            True, fs_status, 1, guest_os_type="windows",
+            quiesce_provider="guesttools-vss")
+
+    def _replication_guest_fsfreeze(self, req):
+        """
+        Guest quiesce endpoint invoked by ZRM createCheckpointInternal before checkpoint.
+
+        Request: vmUuid, action (freeze|thaw), timeoutSeconds
+        Response: success, fsFreezeStatus, filesystemCount, errorMessage, guestOsType, quiesceProvider, errorCode
+        """
+        try:
+            body = req.get(http.REQUEST_BODY)
+            if not body:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="missing body"))
+            cmd = jsonobject.loads(body)
+            vm_uuid = (getattr(cmd, "vmUuid", None) or "").strip()
+            action = (getattr(cmd, "action", None) or "").strip().lower()
+            timeout_seconds = getattr(cmd, "timeoutSeconds", None)
+            if not vm_uuid:
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="vmUuid required"))
+            if action not in ("freeze", "thaw"):
+                return jsonobject.dumps(ZrmAgentRsp(success=False, error="action must be freeze or thaw"))
+
+            qga, qga_err = self._get_vm_qga(vm_uuid)
+            if qga is None:
+                return self._guest_fsfreeze_response(
+                    False, "error", 0, qga_err, guest_os_type="unknown",
+                    quiesce_provider="none", error_code="QGA_NOT_RUNNING")
+
+            guest_os = (qga.os or "").lower()
+            if guest_os == VmQga.VM_OS_WINDOWS or "windows" in guest_os:
+                return self._windows_guest_fsfreeze(qga, action, timeout_seconds)
+            return self._linux_guest_fsfreeze(qga, action, timeout_seconds)
+        except Exception as e:
+            logger.exception("ZRM guest-fsfreeze failed")
+            return jsonobject.dumps(ZrmAgentRsp(success=False, error=str(e)))
 
     def _replication_throttle(self, req):
         """

--- a/kvmagent/kvmagent/test/run_test_checkpoint_create.py
+++ b/kvmagent/kvmagent/test/run_test_checkpoint_create.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Standalone test runner for zrm_checkpoint_create.
+
+zstacklib/kvmagent are Python 2 codebases that cannot be imported directly
+in Python 3 due to syntax differences (reload(sys), print statements, octal
+literals, etc.). This script mocks out all external dependencies and tests
+the checkpoint_create method logic in isolation.
+"""
+import json
+import sys
+import types
+import unittest
+
+
+# ============================================================
+# Mock infrastructure — fake modules so zrm_plugin can import
+# ============================================================
+
+def _make_module(name):
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    return mod
+
+
+# --- zstacklib.utils.jsonobject (minimal) ---
+jsonobject_mod = _make_module("zstacklib")
+utils_mod = _make_module("zstacklib.utils")
+jsonobject_mod = _make_module("zstacklib.utils.jsonobject")
+
+
+class _JsonObj(object):
+    """Minimal jsonobject replacement — attribute-style access on dicts."""
+    def __init__(self, d=None):
+        if d:
+            for k, v in d.items():
+                setattr(self, k, v)
+
+
+def _jo_loads(s):
+    d = json.loads(s) if isinstance(s, (str, bytes)) else s
+    return _JsonObj(d)
+
+
+def _jo_dumps(obj):
+    if isinstance(obj, dict):
+        return json.dumps(obj)
+    return json.dumps(obj.__dict__ if hasattr(obj, "__dict__") else {})
+
+
+jsonobject_mod.loads = _jo_loads
+jsonobject_mod.dumps = _jo_dumps
+
+# --- zstacklib.utils.http ---
+http_mod = _make_module("zstacklib.utils.http")
+http_mod.REQUEST_BODY = "body"
+http_mod.json_post = None  # will be patched per test
+
+# --- zstacklib.utils.log ---
+log_mod = _make_module("zstacklib.utils.log")
+
+
+class _FakeLogger(object):
+    def info(self, *a, **kw): pass
+    def warn(self, *a, **kw): pass
+    def debug(self, *a, **kw): pass
+    def error(self, *a, **kw): pass
+    def exception(self, *a, **kw): pass
+
+
+log_mod.get_logger = lambda *a, **kw: _FakeLogger()
+
+# --- zstacklib.utils.qmp ---
+qmp_mod = _make_module("zstacklib.utils.qmp")
+qmp_mod.query_block_jobs_by_device = lambda vm_uuid: {}
+qmp_mod.block_job_set_speed = lambda vm_uuid, device, speed: None
+qmp_mod.execute_qmp_command = lambda *a, **kw: None
+
+# --- zstacklib.utils.qga ---
+qga_mod = _make_module("zstacklib.utils.qga")
+qga_mod.VmQga = type("VmQga", (), {})
+
+# --- zstacklib.utils (namespace extras sometimes imported) ---
+for name in ["plugin", "daemon", "linux", "qemu"]:
+    _make_module("zstacklib.utils." + name)
+
+# --- kvmagent package mock ---
+kvmagent_pkg = _make_module("kvmagent")
+kvmagent_inner = _make_module("kvmagent.kvmagent")
+
+
+def _replyerror(func):
+    """Decorator stub — just returns the function unchanged."""
+    return func
+
+
+class _FakeKvmAgent(object):
+    """Minimal KvmAgent base class stub."""
+    pass
+
+
+kvmagent_inner.replyerror = _replyerror
+kvmagent_inner.SEND_COMMAND_URL = "SEND_COMMAND_URL"
+kvmagent_inner.KvmAgent = _FakeKvmAgent
+kvmagent_pkg.replyerror = _replyerror
+
+# --- kvmagent.plugins namespace ---
+plugins_mod = _make_module("kvmagent.plugins")
+
+# --- time module (already available, but we'll patch per test) ---
+import time as real_time
+
+# ============================================================
+# NOW load zrm_plugin directly via importlib (bypass package resolution)
+# ============================================================
+import importlib.util
+import pathlib
+
+_zrm_plugin_path = str(pathlib.Path(__file__).resolve().parents[1] / "plugins" / "zrm_plugin.py")
+_spec = importlib.util.spec_from_file_location("kvmagent.plugins.zrm_plugin", _zrm_plugin_path)
+zrm_plugin = importlib.util.module_from_spec(_spec)
+sys.modules["kvmagent.plugins.zrm_plugin"] = zrm_plugin
+_spec.loader.exec_module(zrm_plugin)
+
+
+# ============================================================
+# Test cases
+# ============================================================
+
+class TestZrmCheckpointCreate(unittest.TestCase):
+    """Tests for zrm_checkpoint_create source-side gate logic."""
+
+    def setUp(self):
+        self.plugin = object.__new__(zrm_plugin.ZrmPlugin)
+        self._orig_json_post = http_mod.json_post
+        self._throttle_calls = []
+        self._http_post_calls = []
+
+    def tearDown(self):
+        http_mod.json_post = self._orig_json_post
+
+    def _make_req(self, body_dict):
+        return {http_mod.REQUEST_BODY: json.dumps(body_dict)}
+
+    def _load_rsp(self, rsp_json):
+        return json.loads(rsp_json)
+
+    def _mock_throttle(self, response_dict):
+        """Replace _replication_throttle with a mock returning given response."""
+        def fake_throttle(req):
+            self._throttle_calls.append(req)
+            return json.dumps(response_dict)
+        self.plugin._replication_throttle = fake_throttle
+
+    def _mock_http_post(self, response_dict):
+        """Replace http.json_post with a mock returning given response."""
+        def fake_post(url, body=None, fail_soon=False):
+            self._http_post_calls.append({"url": url, "body": body, "fail_soon": fail_soon})
+            return json.dumps(response_dict)
+        http_mod.json_post = fake_post
+
+    # ----------------------------------------------------------
+    # Test 1: Happy path — mirrors ready, ZR Server succeeds
+    # ----------------------------------------------------------
+    def test_happy_path_returns_checkpoint_uuid(self):
+        self._mock_throttle({"success": True, "allReady": True, "readyCount": 2, "totalJobs": 2})
+        self._mock_http_post({"success": True})
+
+        req = self._make_req({
+            "vmUuid": "vm-123",
+            "sessionUuid": "sess-abc",
+            "checkpointUuid": "cp-xyz",
+            "zrServerUrl": "http://192.168.1.10:6800",
+            "waitReadyTimeout": 30,
+            "originalSpeed": 1048576
+        })
+
+        rsp = self._load_rsp(self.plugin.zrm_checkpoint_create(req))
+
+        self.assertTrue(rsp.get("success", True))
+        self.assertEqual("cp-xyz", rsp.get("checkpointUuid"))
+        # Verify throttle was called twice: speed=0 (Step A) + restore (Step C)
+        self.assertEqual(2, len(self._throttle_calls))
+        throttle_body_a = json.loads(self._throttle_calls[0][http_mod.REQUEST_BODY])
+        self.assertEqual(0, throttle_body_a["speed"])
+        self.assertEqual("vm-123", throttle_body_a["vmUuid"])
+        throttle_body_c = json.loads(self._throttle_calls[1][http_mod.REQUEST_BODY])
+        self.assertEqual(1048576, throttle_body_c["speed"])
+        self.assertEqual("vm-123", throttle_body_c["vmUuid"])
+        # Verify http.json_post was called to ZR Server
+        self.assertEqual(1, len(self._http_post_calls))
+        self.assertEqual("http://192.168.1.10:6800/zr/checkpoint/create",
+                         self._http_post_calls[0]["url"])
+        post_body = json.loads(self._http_post_calls[0]["body"])
+        self.assertEqual("sess-abc", post_body["sessionUuid"])
+        self.assertEqual("cp-xyz", post_body["checkpointUuid"])
+
+    # ----------------------------------------------------------
+    # Test 2: Mirrors not ready — should fail, NOT call ZR Server
+    # ----------------------------------------------------------
+    def test_mirrors_not_ready_returns_failure(self):
+        self._mock_throttle({"success": True, "allReady": False, "readyCount": 1, "totalJobs": 3})
+        self._mock_http_post({"success": True})  # should NOT be called
+
+        req = self._make_req({
+            "vmUuid": "vm-123",
+            "sessionUuid": "sess-abc",
+            "checkpointUuid": "cp-xyz",
+            "zrServerUrl": "http://192.168.1.10:6800"
+        })
+
+        rsp = self._load_rsp(self.plugin.zrm_checkpoint_create(req))
+
+        self.assertFalse(rsp.get("success"))
+        self.assertIn("not ready", rsp.get("error", ""))
+        # ZR Server should NOT have been called
+        self.assertEqual(0, len(self._http_post_calls))
+
+    # ----------------------------------------------------------
+    # Test 3: ZR Server returns failure
+    # ----------------------------------------------------------
+    def test_zr_server_failure_propagates_error(self):
+        self._mock_throttle({"success": True, "allReady": True, "readyCount": 2, "totalJobs": 2})
+        self._mock_http_post({"success": False, "error": "snapshot atomic commit failed"})
+
+        req = self._make_req({
+            "vmUuid": "vm-123",
+            "sessionUuid": "sess-abc",
+            "checkpointUuid": "cp-xyz",
+            "zrServerUrl": "http://192.168.1.10:6800"
+        })
+
+        rsp = self._load_rsp(self.plugin.zrm_checkpoint_create(req))
+
+        self.assertFalse(rsp.get("success"))
+        self.assertIn("snapshot atomic commit failed", rsp.get("error", ""))
+
+    # ----------------------------------------------------------
+    # Test 4: Missing required fields
+    # ----------------------------------------------------------
+    def test_missing_required_fields_returns_error(self):
+        req = self._make_req({
+            "vmUuid": "vm-123",
+            # sessionUuid missing
+            "checkpointUuid": "cp-xyz",
+            "zrServerUrl": "http://192.168.1.10:6800"
+        })
+
+        rsp = self._load_rsp(self.plugin.zrm_checkpoint_create(req))
+
+        self.assertFalse(rsp.get("success"))
+        self.assertIn("required", rsp.get("error", ""))
+
+    # ----------------------------------------------------------
+    # Test 5: Throttle convergence error (success=False)
+    # ----------------------------------------------------------
+    def test_throttle_failure_returns_convergence_error(self):
+        self._mock_throttle({"success": False, "error": "QMP connection lost"})
+        self._mock_http_post({"success": True})
+
+        req = self._make_req({
+            "vmUuid": "vm-123",
+            "sessionUuid": "sess-abc",
+            "checkpointUuid": "cp-xyz",
+            "zrServerUrl": "http://192.168.1.10:6800"
+        })
+
+        rsp = self._load_rsp(self.plugin.zrm_checkpoint_create(req))
+
+        self.assertFalse(rsp.get("success"))
+        self.assertIn("convergence failed", rsp.get("error", ""))
+        self.assertEqual(0, len(self._http_post_calls))
+
+    # ----------------------------------------------------------
+    # Test 6: No mirrors (totalJobs=0) — should still proceed
+    # ----------------------------------------------------------
+    def test_no_mirrors_still_calls_zr_server(self):
+        self._mock_throttle({"success": True, "allReady": True, "readyCount": 0, "totalJobs": 0})
+        self._mock_http_post({"success": True})
+
+        req = self._make_req({
+            "vmUuid": "vm-123",
+            "sessionUuid": "sess-abc",
+            "checkpointUuid": "cp-xyz",
+            "zrServerUrl": "http://192.168.1.10:6800"
+        })
+
+        rsp = self._load_rsp(self.plugin.zrm_checkpoint_create(req))
+
+        self.assertTrue(rsp.get("success", True))
+        self.assertEqual("cp-xyz", rsp.get("checkpointUuid"))
+        self.assertEqual(1, len(self._http_post_calls))
+
+    # ----------------------------------------------------------
+    # Test 7: Speed restore failure is non-fatal
+    # ----------------------------------------------------------
+    def test_speed_restore_failure_is_nonfatal(self):
+        call_count = {"throttle": 0}
+
+        def throttle_with_restore_failure(req):
+            call_count["throttle"] += 1
+            body = json.loads(req[http_mod.REQUEST_BODY])
+            if body.get("speed") == 0:
+                # First call: quiesce — success
+                return json.dumps({"success": True, "allReady": True, "readyCount": 1, "totalJobs": 1})
+            else:
+                # Second call: restore — raise exception
+                raise RuntimeError("VM already stopped")
+
+        self.plugin._replication_throttle = throttle_with_restore_failure
+        self._mock_http_post({"success": True})
+
+        req = self._make_req({
+            "vmUuid": "vm-123",
+            "sessionUuid": "sess-abc",
+            "checkpointUuid": "cp-xyz",
+            "zrServerUrl": "http://192.168.1.10:6800",
+            "originalSpeed": 1048576
+        })
+
+        rsp = self._load_rsp(self.plugin.zrm_checkpoint_create(req))
+
+        # Should still succeed despite restore failure
+        self.assertTrue(rsp.get("success", True))
+        self.assertEqual("cp-xyz", rsp.get("checkpointUuid"))
+        # Throttle should have been called twice (quiesce + restore attempt)
+        self.assertEqual(2, call_count["throttle"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/kvmagent/kvmagent/test/run_test_checkpoint_create.py
+++ b/kvmagent/kvmagent/test/run_test_checkpoint_create.py
@@ -293,9 +293,9 @@ class TestZrmCheckpointCreate(unittest.TestCase):
         self.assertEqual(1, len(self._http_post_calls))
 
     # ----------------------------------------------------------
-    # Test 7: Speed restore failure is non-fatal
+    # Test 7: Speed restore failure is visible to caller
     # ----------------------------------------------------------
-    def test_speed_restore_failure_is_nonfatal(self):
+    def test_speed_restore_failure_returns_error(self):
         call_count = {"throttle": 0}
 
         def throttle_with_restore_failure(req):
@@ -321,9 +321,15 @@ class TestZrmCheckpointCreate(unittest.TestCase):
 
         rsp = self._load_rsp(self.plugin.zrm_checkpoint_create(req))
 
-        # Should still succeed despite restore failure
         self.assertTrue(rsp.get("success", True))
+        self.assertTrue(rsp.get("degraded"))
         self.assertEqual("cp-xyz", rsp.get("checkpointUuid"))
+        self.assertTrue(rsp.get("speedRestoreFailed"))
+        self.assertIn("checkpoint cp-xyz created successfully", rsp.get("error"))
+        self.assertIn("Checkpoint is usable", rsp.get("error"))
+        self.assertIn("retry speed throttle", rsp.get("error"))
+        self.assertIn("ACTION REQUIRED", rsp.get("error"))
+        self.assertIn("VM already stopped", rsp.get("speedRestoreError"))
         # Throttle should have been called twice (quiesce + restore attempt)
         self.assertEqual(2, call_count["throttle"])
 

--- a/kvmagent/kvmagent/test/test_zrm_plugin.py
+++ b/kvmagent/kvmagent/test/test_zrm_plugin.py
@@ -149,5 +149,124 @@ class TestZrmPluginWaitInitial(unittest.TestCase):
         self.assertEqual(1, rsp_dict.get("concludedJobCount"))
 
 
+class TestZrmPluginGuestFsfreeze(unittest.TestCase):
+    def setUp(self):
+        self.plugin = object.__new__(zrm_plugin.ZrmPlugin)
+
+    def _make_req(self, body_dict):
+        return {
+            http.REQUEST_BODY: json.dumps(body_dict)
+        }
+
+    def _load_rsp(self, rsp_json):
+        rsp = jsonobject.loads(rsp_json)
+        body = json.loads(rsp_json)
+        return rsp, body
+
+    def test_guest_fsfreeze_missing_vm_uuid(self):
+        rsp_json = self.plugin._replication_guest_fsfreeze(self._make_req({
+            "action": "freeze",
+            "timeoutSeconds": 10
+        }))
+        rsp, body = self._load_rsp(rsp_json)
+        self.assertFalse(rsp.success)
+        self.assertEqual("vmUuid required", rsp.error)
+        self.assertEqual(False, body.get("success"))
+
+    def test_guest_fsfreeze_linux_freeze_success(self):
+        class FakeQga(object):
+            vm_uuid = "vm-linux-1"
+            os = "centos"
+            supported_commands = {
+                "guest-fsfreeze-freeze": True,
+                "guest-fsfreeze-thaw": True,
+                "guest-fsfreeze-status": True,
+                "guest-fsfreeze-freeze-list": True,
+            }
+
+            def call_qga_command(self, command, args=None, timeout=3):
+                if command == "guest-fsfreeze-status":
+                    return "thawed"
+                if command == "guest-fsfreeze-freeze":
+                    return 2
+                raise AssertionError("unexpected command: %s" % command)
+
+        self.plugin._get_vm_qga = lambda vm_uuid: (FakeQga(), None)
+        rsp_json = self.plugin._replication_guest_fsfreeze(self._make_req({
+            "vmUuid": "vm-linux-1",
+            "action": "freeze",
+            "timeoutSeconds": 15
+        }))
+        rsp, body = self._load_rsp(rsp_json)
+        self.assertTrue(body.get("success"))
+        self.assertEqual("frozen", body.get("fsFreezeStatus"))
+        self.assertEqual(2, body.get("filesystemCount"))
+        self.assertEqual("linux", body.get("guestOsType"))
+        self.assertEqual("qga-fsfreeze", body.get("quiesceProvider"))
+
+    def test_guest_fsfreeze_linux_thaw_success(self):
+        class FakeQga(object):
+            vm_uuid = "vm-linux-2"
+            os = "centos"
+            supported_commands = {
+                "guest-fsfreeze-freeze": True,
+                "guest-fsfreeze-thaw": True,
+                "guest-fsfreeze-status": True,
+            }
+
+            def call_qga_command(self, command, args=None, timeout=3):
+                if command == "guest-fsfreeze-status":
+                    return "frozen"
+                if command == "guest-fsfreeze-thaw":
+                    return 2
+                if command == "guest-fsfreeze-status":
+                    return "thawed"
+                raise AssertionError("unexpected command: %s" % command)
+
+        class ThawFakeQga(FakeQga):
+            def call_qga_command(self, command, args=None, timeout=3):
+                calls = []
+                if command == "guest-fsfreeze-status":
+                    calls.append("status")
+                    return "thawed" if len(calls) > 1 else "frozen"
+                if command == "guest-fsfreeze-thaw":
+                    return 2
+                raise AssertionError("unexpected command: %s" % command)
+
+        thaw_qga = ThawFakeQga()
+        status_calls = {"count": 0}
+
+        def fake_call(command, args=None, timeout=3):
+            if command == "guest-fsfreeze-status":
+                status_calls["count"] += 1
+                return "frozen" if status_calls["count"] == 1 else "thawed"
+            if command == "guest-fsfreeze-thaw":
+                return 2
+            raise AssertionError("unexpected command: %s" % command)
+
+        thaw_qga.call_qga_command = fake_call
+        self.plugin._get_vm_qga = lambda vm_uuid: (thaw_qga, None)
+        rsp_json = self.plugin._replication_guest_fsfreeze(self._make_req({
+            "vmUuid": "vm-linux-2",
+            "action": "thaw",
+            "timeoutSeconds": 10
+        }))
+        _, body = self._load_rsp(rsp_json)
+        self.assertTrue(body.get("success"))
+        self.assertEqual("thawed", body.get("fsFreezeStatus"))
+
+    def test_guest_fsfreeze_qga_not_running(self):
+        self.plugin._get_vm_qga = lambda vm_uuid: (None, "QEMU Guest Agent not in running state")
+        rsp_json = self.plugin._replication_guest_fsfreeze(self._make_req({
+            "vmUuid": "vm-down",
+            "action": "freeze",
+            "timeoutSeconds": 10
+        }))
+        _, body = self._load_rsp(rsp_json)
+        self.assertFalse(body.get("success"))
+        self.assertEqual("error", body.get("fsFreezeStatus"))
+        self.assertEqual("QGA_NOT_RUNNING", body.get("errorCode"))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/kvmagent/kvmagent/test/test_zrm_plugin.py
+++ b/kvmagent/kvmagent/test/test_zrm_plugin.py
@@ -211,35 +211,15 @@ class TestZrmPluginGuestFsfreeze(unittest.TestCase):
         self.assertEqual("qga-fsfreeze", body.get("quiesceProvider"))
 
     def test_guest_fsfreeze_linux_thaw_success(self):
-        class FakeQga(object):
-            vm_uuid = "vm-linux-2"
-            os = "centos"
-            supported_commands = {
+        thaw_qga = type("ThawFakeQga", (), {
+            "vm_uuid": "vm-linux-2",
+            "os": "centos",
+            "supported_commands": {
                 "guest-fsfreeze-freeze": True,
                 "guest-fsfreeze-thaw": True,
                 "guest-fsfreeze-status": True,
-            }
-
-            def call_qga_command(self, command, args=None, timeout=3):
-                if command == "guest-fsfreeze-status":
-                    return "frozen"
-                if command == "guest-fsfreeze-thaw":
-                    return 2
-                if command == "guest-fsfreeze-status":
-                    return "thawed"
-                raise AssertionError("unexpected command: %s" % command)
-
-        class ThawFakeQga(FakeQga):
-            def call_qga_command(self, command, args=None, timeout=3):
-                calls = []
-                if command == "guest-fsfreeze-status":
-                    calls.append("status")
-                    return "thawed" if len(calls) > 1 else "frozen"
-                if command == "guest-fsfreeze-thaw":
-                    return 2
-                raise AssertionError("unexpected command: %s" % command)
-
-        thaw_qga = ThawFakeQga()
+            },
+        })()
         status_calls = {"count": 0}
 
         def fake_call(command, args=None, timeout=3):

--- a/kvmagent/kvmagent/test/test_zrm_plugin.py
+++ b/kvmagent/kvmagent/test/test_zrm_plugin.py
@@ -1,5 +1,11 @@
+import itertools
 import json
 import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from zstacklib.utils import http
 from zstacklib.utils import jsonobject
@@ -395,6 +401,119 @@ class TestZrmPluginCheckpointCreate(unittest.TestCase):
         self.assertIn("mirror convergence failed", body.get("error"))
         self.assertIn("QMP connection lost", body.get("error"))
         self.assertEqual(0, len(self.json_post_calls))
+
+
+class TestZrmPluginRecoveryPrepare(unittest.TestCase):
+    def setUp(self):
+        self.plugin = object.__new__(zrm_plugin.ZrmPlugin)
+
+    def _make_req(self, body_dict):
+        return {http.REQUEST_BODY: json.dumps(body_dict)}
+
+    def _load_rsp(self, rsp_json):
+        return json.loads(rsp_json)
+
+    def _fake_domain(self, states):
+        domain = mock.MagicMock()
+        domain.state.side_effect = states
+        domain.XMLDesc.return_value = (
+            "<domain><devices>"
+            "<interface type='bridge'><alias name='net0'/></interface>"
+            "<interface type='bridge'><alias name='net1'/></interface>"
+            "</devices></domain>"
+        )
+        return domain
+
+    def _fake_vm(self, domain):
+        vm = mock.MagicMock()
+        vm.domain = domain
+        return vm
+
+    def test_happy_path_clean_shutdown(self):
+        import libvirt as _libvirt
+        domain = self._fake_domain([
+            (_libvirt.VIR_DOMAIN_RUNNING, 0),
+            (_libvirt.VIR_DOMAIN_SHUTOFF, 0),
+        ])
+        stop_rsp = json.dumps({"success": True})
+        with mock.patch("kvmagent.plugins.vm_plugin.get_vm_by_uuid",
+                        return_value=self._fake_vm(domain)), \
+             mock.patch.object(self.plugin, "_replication_stop", return_value=stop_rsp):
+            body = self._load_rsp(self.plugin.zrm_recovery_prepare(
+                self._make_req({"vmUuid": "vm-1", "sessionUuid": "sess-1"})))
+        self.assertTrue(body["success"])
+        domain.shutdown.assert_called_once()
+
+    def test_shutdown_timeout_falls_back_to_nic_detach(self):
+        import libvirt as _libvirt
+        running = (_libvirt.VIR_DOMAIN_RUNNING, 0)
+        # Two state() calls: pre-shutdown check + one in-loop poll before deadline fires.
+        domain = self._fake_domain([running, running])
+        stop_rsp = json.dumps({"success": True})
+        # time.time: first two calls return 0.0 (deadline setup + first loop check),
+        # all subsequent calls return 100.0 so the deadline fires regardless of how
+        # many times the implementation calls time.time() inside the loop.
+        with mock.patch("kvmagent.plugins.vm_plugin.get_vm_by_uuid",
+                        return_value=self._fake_vm(domain)), \
+             mock.patch.object(self.plugin, "_replication_stop", return_value=stop_rsp), \
+             mock.patch("time.sleep"), \
+             mock.patch("time.time", side_effect=itertools.chain([0.0, 0.0], itertools.repeat(100.0))):
+            body = self._load_rsp(self.plugin.zrm_recovery_prepare(
+                self._make_req({"vmUuid": "vm-1", "sessionUuid": "sess-1",
+                                "shutdownTimeout": 2})))
+        self.assertTrue(body["success"])
+        self.assertEqual(2, domain.detachDeviceFlags.call_count)
+
+    def test_state_error_does_not_report_success(self):
+        domain = self._fake_domain([RuntimeError("libvirt connection lost")])
+        stop_rsp = json.dumps({"success": True})
+        with mock.patch("kvmagent.plugins.vm_plugin.get_vm_by_uuid",
+                        return_value=self._fake_vm(domain)), \
+             mock.patch.object(self.plugin, "_replication_stop", return_value=stop_rsp):
+            body = self._load_rsp(self.plugin.zrm_recovery_prepare(
+                self._make_req({"vmUuid": "vm-1", "sessionUuid": "sess-1"})))
+        self.assertFalse(body["success"])
+        self.assertIn("vm state check failed", body["error"])
+        self.assertEqual(0, domain.shutdown.call_count)
+
+    def test_partial_nic_detach_failure_aborts(self):
+        domain = self._fake_domain([])
+        domain.detachDeviceFlags.side_effect = [None, RuntimeError("detach net1 failed")]
+        stop_rsp = json.dumps({"success": True})
+        with mock.patch("kvmagent.plugins.vm_plugin.get_vm_by_uuid",
+                        return_value=self._fake_vm(domain)), \
+             mock.patch.object(self.plugin, "_replication_stop", return_value=stop_rsp):
+            body = self._load_rsp(self.plugin.zrm_recovery_prepare(
+                self._make_req({"vmUuid": "vm-1", "sessionUuid": "sess-1",
+                                "forceIsolate": True})))
+        self.assertFalse(body["success"])
+        self.assertIn("network isolation failed", body["error"])
+        self.assertIn("vNIC(s) remain", body["error"])
+
+    def test_vm_not_found_treated_as_stopped(self):
+        stop_rsp = json.dumps({"success": True})
+        with mock.patch("kvmagent.plugins.vm_plugin.get_vm_by_uuid", return_value=None), \
+             mock.patch.object(self.plugin, "_replication_stop", return_value=stop_rsp):
+            body = self._load_rsp(self.plugin.zrm_recovery_prepare(
+                self._make_req({"vmUuid": "vm-gone", "sessionUuid": "sess-1"})))
+        self.assertTrue(body["success"])
+
+    def test_replication_stop_failure_aborts(self):
+        stop_rsp = json.dumps({"success": False, "error": "QMP timeout"})
+        with mock.patch.object(self.plugin, "_replication_stop", return_value=stop_rsp):
+            body = self._load_rsp(self.plugin.zrm_recovery_prepare(
+                self._make_req({"vmUuid": "vm-1", "sessionUuid": "sess-1"})))
+        self.assertFalse(body["success"])
+        self.assertIn("replication_stop failed", body["error"])
+
+    def test_stale_jobs_aborts(self):
+        stop_rsp = json.dumps({"success": True,
+                               "staleJobs": [{"device": "vda", "status": "active"}]})
+        with mock.patch.object(self.plugin, "_replication_stop", return_value=stop_rsp):
+            body = self._load_rsp(self.plugin.zrm_recovery_prepare(
+                self._make_req({"vmUuid": "vm-1", "sessionUuid": "sess-1"})))
+        self.assertFalse(body["success"])
+        self.assertIn("stale mirror jobs", body["error"])
 
 
 if __name__ == '__main__':

--- a/kvmagent/kvmagent/test/test_zrm_plugin.py
+++ b/kvmagent/kvmagent/test/test_zrm_plugin.py
@@ -49,14 +49,14 @@ class TestZrmPluginWaitInitial(unittest.TestCase):
         self.assertEqual("no volumeUuids specified for initial full sync wait", rsp_dict.get("error"))
 
     def test_wait_initial_all_ready_returns_progress_fields(self):
-        self.plugin._get_zrm_block_jobs = lambda vm_uuid: {
+        self.plugin._query_zrm_block_jobs = lambda vm_uuid: ({
             "zrm-mirror-volready": {
                 "status": "ready",
                 "ready": True,
                 "offset": 128,
                 "len": 256
             }
-        }
+        }, None)
         req = self._make_req({
             "vmUuid": "vm-1",
             "volumeUuids": ["volready-uuid"],
@@ -77,14 +77,14 @@ class TestZrmPluginWaitInitial(unittest.TestCase):
         self.assertEqual(1, rsp_dict.get("readyJobCount"))
 
     def test_wait_initial_timeout_returns_failure_response(self):
-        self.plugin._get_zrm_block_jobs = lambda vm_uuid: {
+        self.plugin._query_zrm_block_jobs = lambda vm_uuid: ({
             "zrm-mirror-voltimeo": {
                 "status": "running",
                 "ready": False,
                 "offset": 64,
                 "len": 256
             }
-        }
+        }, None)
         time_points = [100.0, 101.5]
 
         def fake_time():
@@ -110,9 +110,33 @@ class TestZrmPluginWaitInitial(unittest.TestCase):
         self.assertEqual([], list(rsp.missing))
         self.assertEqual(False, rsp_dict.get("success"))
 
+    def test_wait_initial_query_failure_reports_retry_metrics(self):
+        self.plugin._query_zrm_block_jobs = lambda vm_uuid: ({}, "query-block-jobs timeout")
+        time_points = [100.0, 100.0, 101.1]
+
+        def fake_time():
+            return time_points.pop(0) if time_points else 101.1
+
+        zrm_plugin.time.time = fake_time
+        zrm_plugin.time.sleep = lambda seconds: None
+
+        rsp_json = self.plugin._replication_wait_initial(self._make_req({
+            "vmUuid": "vm-1",
+            "volumeUuids": ["volquery-uuid"],
+            "timeoutSeconds": 1
+        }))
+
+        rsp, rsp_dict = self._load_rsp(rsp_json)
+        self.assertFalse(rsp.success)
+        self.assertTrue(rsp.queryBlockJobsFailed)
+        self.assertEqual("query-block-jobs timeout", rsp.queryBlockJobsError)
+        self.assertEqual(2, rsp.queryRetryCount)
+        self.assertAlmostEqual(1.1, rsp.totalQueryFailureDuration)
+        self.assertEqual(2, rsp_dict.get("queryRetryCount"))
+
     def test_wait_initial_concluded_returns_failure_and_dismisses_job(self):
         dismiss_calls = []
-        self.plugin._get_zrm_block_jobs = lambda vm_uuid: {
+        self.plugin._query_zrm_block_jobs = lambda vm_uuid: ({
             "zrm-mirror-volconcl": {
                 "status": "concluded",
                 "ready": False,
@@ -120,7 +144,7 @@ class TestZrmPluginWaitInitial(unittest.TestCase):
                 "len": 512,
                 "error": "Input/output error"
             }
-        }
+        }, None)
 
         def fake_execute_qmp_command(vm_uuid, command, raise_exception=False, id=None):
             dismiss_calls.append({
@@ -420,14 +444,172 @@ class TestZrmPluginCheckpointCreate(unittest.TestCase):
         self.assertIn("QMP connection lost", body.get("error"))
         self.assertEqual(0, len(self.json_post_calls))
 
+    def test_speed_restore_failure_returns_visible_error(self):
+        throttle_calls = []
+
+        def fake_throttle(req):
+            throttle_calls.append(json.loads(req[http.REQUEST_BODY]))
+            if throttle_calls[-1]["speed"] == 0:
+                return json.dumps({
+                    "success": True,
+                    "allReady": True,
+                    "readyCount": 1,
+                    "runningCount": 0,
+                    "totalJobs": 1
+                })
+            return json.dumps({
+                "success": False,
+                "error": "failed to set speed for ZRM mirror jobs: zrm-mirror-vol1: QMP connection lost",
+                "speedSetFailed": True,
+                "speedSetFailures": [{
+                    "device": "zrm-mirror-vol1",
+                    "error": "QMP connection lost"
+                }]
+            })
+
+        self.plugin._replication_throttle = fake_throttle
+        self._mock_json_post({"success": True})
+
+        rsp_json = self.plugin.zrm_checkpoint_create(self._make_req({
+            "vmUuid": "vm-1",
+            "sessionUuid": "sess-1",
+            "checkpointUuid": "cp-restore-failed",
+            "zrServerUrl": "http://10.0.0.1:6800",
+            "originalSpeed": 1048576
+        }))
+
+        rsp, body = self._load_rsp(rsp_json)
+        self.assertTrue(body.get("success"))
+        self.assertTrue(body.get("degraded"))
+        self.assertEqual("cp-restore-failed", body.get("checkpointUuid"))
+        self.assertTrue(body.get("speedRestoreFailed"))
+        self.assertIn("checkpoint cp-restore-failed created successfully", body.get("error"))
+        self.assertIn("Checkpoint is usable", body.get("error"))
+        self.assertIn("retry speed throttle", body.get("error"))
+        self.assertIn("ACTION REQUIRED", body.get("error"))
+        self.assertEqual([{
+            "device": "zrm-mirror-vol1",
+            "error": "QMP connection lost"
+        }], body.get("speedRestoreFailures"))
+        self.assertEqual(2, len(throttle_calls))
+
+
+class TestZrmPluginReplicationThrottle(unittest.TestCase):
+    def setUp(self):
+        self.plugin = object.__new__(zrm_plugin.ZrmPlugin)
+        self._orig_query_block_jobs_by_device = zrm_plugin.qmp.query_block_jobs_by_device
+        self._orig_block_job_set_speed = zrm_plugin.qmp.block_job_set_speed
+
+    def tearDown(self):
+        zrm_plugin.qmp.query_block_jobs_by_device = self._orig_query_block_jobs_by_device
+        zrm_plugin.qmp.block_job_set_speed = self._orig_block_job_set_speed
+
+    def _make_req(self, body_dict):
+        return {http.REQUEST_BODY: json.dumps(body_dict)}
+
+    def _load_rsp(self, rsp_json):
+        return json.loads(rsp_json)
+
+    def test_set_speed_failure_returns_error_details(self):
+        zrm_plugin.qmp.query_block_jobs_by_device = lambda vm_uuid: {
+            "zrm-mirror-vol1": {"status": "running"}
+        }
+
+        def fake_block_job_set_speed(vm_uuid, device, speed):
+            raise RuntimeError("QMP connection lost")
+
+        zrm_plugin.qmp.block_job_set_speed = fake_block_job_set_speed
+
+        body = self._load_rsp(self.plugin._replication_throttle(
+            self._make_req({"vmUuid": "vm-1", "speed": 1048576, "waitReadyTimeout": 0})))
+
+        self.assertFalse(body["success"])
+        self.assertTrue(body["speedSetFailed"])
+        self.assertIn("failed to set speed", body["error"])
+        self.assertEqual([{
+            "device": "zrm-mirror-vol1",
+            "error": "QMP connection lost"
+        }], body["speedSetFailures"])
+        self.assertEqual(1, body["totalJobs"])
+
+    def test_partial_speed_set_failure_returns_failed_subset(self):
+        zrm_plugin.qmp.query_block_jobs_by_device = lambda vm_uuid: {
+            "zrm-mirror-vol1": {"status": "running"},
+            "zrm-mirror-vol2": {"status": "running"},
+            "zrm-mirror-vol3": {"status": "running"}
+        }
+
+        def fake_block_job_set_speed(vm_uuid, device, speed):
+            if device == "zrm-mirror-vol2":
+                raise RuntimeError("vol2 NBD server unreachable")
+
+        zrm_plugin.qmp.block_job_set_speed = fake_block_job_set_speed
+
+        body = self._load_rsp(self.plugin._replication_throttle(
+            self._make_req({"vmUuid": "vm-1", "speed": 1048576, "waitReadyTimeout": 0})))
+
+        self.assertFalse(body["success"])
+        self.assertTrue(body["speedSetFailed"])
+        self.assertIn("zrm-mirror-vol2", body["error"])
+        self.assertEqual([{
+            "device": "zrm-mirror-vol2",
+            "error": "vol2 NBD server unreachable"
+        }], body["speedSetFailures"])
+        self.assertEqual(3, body["totalJobs"])
+
+    def test_query_failure_returns_error(self):
+        def fake_query_block_jobs(vm_uuid):
+            raise RuntimeError("query-block-jobs timeout")
+
+        zrm_plugin.qmp.query_block_jobs_by_device = fake_query_block_jobs
+
+        body = self._load_rsp(self.plugin._replication_throttle(
+            self._make_req({"vmUuid": "vm-1", "speed": 1048576, "waitReadyTimeout": 0})))
+
+        self.assertFalse(body["success"])
+        self.assertTrue(body["queryBlockJobsFailed"])
+        self.assertIn("query-block-jobs failed", body["error"])
+        self.assertEqual("query-block-jobs timeout", body["queryBlockJobsError"])
+
+    def test_final_query_failure_returns_speed_set_devices(self):
+        query_calls = {"count": 0}
+        set_speed_calls = []
+
+        def fake_query_block_jobs(vm_uuid):
+            query_calls["count"] += 1
+            if query_calls["count"] == 1:
+                return {
+                    "zrm-mirror-vol1": {"status": "running"},
+                    "zrm-mirror-vol2": {"status": "running"}
+                }
+            raise RuntimeError("query-block-jobs lost after set-speed")
+
+        def fake_block_job_set_speed(vm_uuid, device, speed):
+            set_speed_calls.append(device)
+
+        zrm_plugin.qmp.query_block_jobs_by_device = fake_query_block_jobs
+        zrm_plugin.qmp.block_job_set_speed = fake_block_job_set_speed
+
+        body = self._load_rsp(self.plugin._replication_throttle(
+            self._make_req({"vmUuid": "vm-1", "speed": 1048576, "waitReadyTimeout": 0})))
+
+        self.assertFalse(body["success"])
+        self.assertTrue(body["queryBlockJobsFailed"])
+        self.assertEqual("query-block-jobs lost after set-speed", body["queryBlockJobsError"])
+        self.assertEqual(set(["zrm-mirror-vol1", "zrm-mirror-vol2"]), set(body["speedSetDevices"]))
+        self.assertEqual(set(set_speed_calls), set(body["speedSetDevices"]))
+        self.assertEqual(2, body["totalJobs"])
+
 
 class TestZrmPluginReplicationStop(unittest.TestCase):
     def setUp(self):
         self.plugin = object.__new__(zrm_plugin.ZrmPlugin)
         self._orig_block_job_cancel = zrm_plugin.qmp.block_job_cancel
+        self._orig_query_block_jobs_by_device = zrm_plugin.qmp.query_block_jobs_by_device
 
     def tearDown(self):
         zrm_plugin.qmp.block_job_cancel = self._orig_block_job_cancel
+        zrm_plugin.qmp.query_block_jobs_by_device = self._orig_query_block_jobs_by_device
 
     def _make_req(self, body_dict):
         return {http.REQUEST_BODY: json.dumps(body_dict)}
@@ -436,7 +618,7 @@ class TestZrmPluginReplicationStop(unittest.TestCase):
         return json.loads(rsp_json)
 
     def test_cancel_failure_returns_error_with_failed_job(self):
-        self.plugin._get_zrm_block_jobs = lambda vm_uuid: {
+        zrm_plugin.qmp.query_block_jobs_by_device = lambda vm_uuid: {
             "zrm-mirror-volfail": {"status": "running"}
         }
 
@@ -454,6 +636,41 @@ class TestZrmPluginReplicationStop(unittest.TestCase):
             "device": "zrm-mirror-volfail",
             "error": "QMP connection lost"
         }], body["cancelFailedJobs"])
+
+    def test_initial_query_failure_returns_error(self):
+        def fake_query_block_jobs(vm_uuid):
+            raise RuntimeError("query-block-jobs timeout")
+
+        zrm_plugin.qmp.query_block_jobs_by_device = fake_query_block_jobs
+
+        body = self._load_rsp(self.plugin._replication_stop(
+            self._make_req({"vmUuid": "vm-1", "sessionUuid": "sess-1"})))
+
+        self.assertFalse(body["success"])
+        self.assertIn("query-block-jobs failed", body["error"])
+        self.assertTrue(body["queryBlockJobsFailed"])
+        self.assertEqual("query-block-jobs timeout", body["queryBlockJobsError"])
+
+    def test_post_cancel_query_failure_returns_error(self):
+        query_calls = {"count": 0}
+
+        def fake_query_block_jobs(vm_uuid):
+            query_calls["count"] += 1
+            if query_calls["count"] == 1:
+                return {"zrm-mirror-volquery": {"status": "running"}}
+            raise RuntimeError("query-block-jobs lost after cancel")
+
+        zrm_plugin.qmp.query_block_jobs_by_device = fake_query_block_jobs
+        zrm_plugin.qmp.block_job_cancel = lambda vm_uuid, device: None
+
+        body = self._load_rsp(self.plugin._replication_stop(
+            self._make_req({"vmUuid": "vm-1", "sessionUuid": "sess-1"})))
+
+        self.assertFalse(body["success"])
+        self.assertIn("query-block-jobs failed after cancel", body["error"])
+        self.assertTrue(body["queryBlockJobsFailed"])
+        self.assertEqual("query-block-jobs lost after cancel", body["queryBlockJobsError"])
+        self.assertEqual(["zrm-mirror-volquery"], body["cancelRequestedDevices"])
 
 
 class TestZrmPluginRecoveryPrepare(unittest.TestCase):
@@ -560,11 +777,9 @@ class TestZrmPluginRecoveryPrepare(unittest.TestCase):
         self.assertIn("replication_stop failed", body["error"])
 
     def test_cancel_failure_aborts_before_isolation(self):
-        self.plugin._get_zrm_block_jobs = lambda vm_uuid: {
-            "zrm-mirror-volfail": {"status": "running"}
-        }
-
-        with mock.patch.object(zrm_plugin.qmp, "block_job_cancel",
+        with mock.patch.object(zrm_plugin.qmp, "query_block_jobs_by_device",
+                               return_value={"zrm-mirror-volfail": {"status": "running"}}), \
+             mock.patch.object(zrm_plugin.qmp, "block_job_cancel",
                                side_effect=RuntimeError("QMP connection lost")), \
              mock.patch.object(self.plugin, "_vm_shutdown_and_isolate",
                                return_value=(True, None)) as isolate:
@@ -576,6 +791,47 @@ class TestZrmPluginRecoveryPrepare(unittest.TestCase):
         self.assertIn("failed to cancel ZRM mirror jobs", body["error"])
         isolate.assert_not_called()
 
+    def test_initial_query_failure_aborts_before_isolation(self):
+        with mock.patch.object(zrm_plugin.qmp, "query_block_jobs_by_device",
+                               side_effect=RuntimeError("query-block-jobs timeout")), \
+             mock.patch.object(self.plugin, "_vm_shutdown_and_isolate",
+                               return_value=(True, None)) as isolate:
+            body = self._load_rsp(self.plugin.zrm_recovery_prepare(
+                self._make_req({"vmUuid": "vm-1", "sessionUuid": "sess-1"})))
+
+        self.assertFalse(body["success"])
+        self.assertIn("replication_stop failed", body["error"])
+        self.assertIn("query-block-jobs failed", body["error"])
+        self.assertTrue(body["queryBlockJobsFailed"])
+        self.assertEqual("query-block-jobs timeout", body["queryBlockJobsError"])
+        isolate.assert_not_called()
+
+    def test_post_cancel_query_failure_aborts_before_isolation(self):
+        query_calls = {"count": 0}
+
+        def fake_query_block_jobs(vm_uuid):
+            query_calls["count"] += 1
+            if query_calls["count"] == 1:
+                return {"zrm-mirror-volquery": {"status": "running"}}
+            raise RuntimeError("query-block-jobs lost after cancel")
+
+        with mock.patch.object(zrm_plugin.qmp, "query_block_jobs_by_device",
+                               side_effect=fake_query_block_jobs), \
+             mock.patch.object(zrm_plugin.qmp, "block_job_cancel",
+                               return_value=None), \
+             mock.patch.object(self.plugin, "_vm_shutdown_and_isolate",
+                               return_value=(True, None)) as isolate:
+            body = self._load_rsp(self.plugin.zrm_recovery_prepare(
+                self._make_req({"vmUuid": "vm-1", "sessionUuid": "sess-1"})))
+
+        self.assertFalse(body["success"])
+        self.assertIn("replication_stop failed", body["error"])
+        self.assertIn("query-block-jobs failed after cancel", body["error"])
+        self.assertTrue(body["queryBlockJobsFailed"])
+        self.assertEqual("query-block-jobs lost after cancel", body["queryBlockJobsError"])
+        self.assertEqual(["zrm-mirror-volquery"], body["cancelRequestedDevices"])
+        isolate.assert_not_called()
+
     def test_stale_jobs_aborts(self):
         stop_rsp = json.dumps({"success": True,
                                "staleJobs": [{"device": "vda", "status": "active"}]})
@@ -584,6 +840,47 @@ class TestZrmPluginRecoveryPrepare(unittest.TestCase):
                 self._make_req({"vmUuid": "vm-1", "sessionUuid": "sess-1"})))
         self.assertFalse(body["success"])
         self.assertIn("stale mirror jobs", body["error"])
+
+
+class TestVmPluginBlockGraphFallback(unittest.TestCase):
+    def setUp(self):
+        from kvmagent.plugins import vm_plugin
+        self.vm_plugin = vm_plugin
+        self._orig_execute_qmp_command = vm_plugin.qmp.execute_qmp_command
+        self._orig_block_graph_capability = dict(vm_plugin._BLOCK_GRAPH_CAPABILITY)
+        vm_plugin._BLOCK_GRAPH_CAPABILITY.clear()
+
+    def tearDown(self):
+        self.vm_plugin.qmp.execute_qmp_command = self._orig_execute_qmp_command
+        self.vm_plugin._BLOCK_GRAPH_CAPABILITY.clear()
+        self.vm_plugin._BLOCK_GRAPH_CAPABILITY.update(self._orig_block_graph_capability)
+
+    def test_query_block_match_is_used_when_block_graph_unavailable(self):
+        calls = []
+
+        def fake_execute_qmp_command(vm_uuid, command, raise_exception=False, **kwargs):
+            calls.append(command)
+            if command == "query-block":
+                return [{
+                    "device": "drive-virtio-disk0",
+                    "inserted": {
+                        "node-name": "drive-node0",
+                        "file": "/var/lib/zstack/volumes/volume-vol-old-qemu.qcow2"
+                    }
+                }]
+            if command == "x-debug-query-block-graph":
+                return None
+            return None
+
+        self.vm_plugin.qmp.execute_qmp_command = fake_execute_qmp_command
+
+        node_name, device_name = self.vm_plugin.get_mirror_device_for_volume_uuid(
+            "vm-qemu-old", "vol-old-qemu")
+
+        self.assertEqual("drive-node0", node_name)
+        self.assertEqual("drive-virtio-disk0", device_name)
+        self.assertEqual(False, self.vm_plugin._BLOCK_GRAPH_CAPABILITY.get("vm-qemu-old"))
+        self.assertEqual(["query-block", "x-debug-query-block-graph"], calls)
 
 
 if __name__ == '__main__':

--- a/kvmagent/kvmagent/test/test_zrm_plugin.py
+++ b/kvmagent/kvmagent/test/test_zrm_plugin.py
@@ -1,0 +1,153 @@
+import json
+import unittest
+
+from zstacklib.utils import http
+from zstacklib.utils import jsonobject
+
+from kvmagent.plugins import zrm_plugin
+
+
+class TestZrmPluginWaitInitial(unittest.TestCase):
+    def setUp(self):
+        self.plugin = object.__new__(zrm_plugin.ZrmPlugin)
+        self._orig_time_time = zrm_plugin.time.time
+        self._orig_time_sleep = zrm_plugin.time.sleep
+        self._orig_execute_qmp_command = zrm_plugin.qmp.execute_qmp_command
+
+    def tearDown(self):
+        zrm_plugin.time.time = self._orig_time_time
+        zrm_plugin.time.sleep = self._orig_time_sleep
+        zrm_plugin.qmp.execute_qmp_command = self._orig_execute_qmp_command
+
+    def _make_req(self, body_dict):
+        return {
+            http.REQUEST_BODY: json.dumps(body_dict)
+        }
+
+    def _load_rsp(self, rsp_json):
+        rsp = jsonobject.loads(rsp_json)
+        return rsp, json.loads(rsp_json)
+
+    def test_wait_initial_empty_volume_returns_agent_response(self):
+        req = self._make_req({
+            "vmUuid": "vm-1",
+            "volumeUuids": []
+        })
+
+        rsp_json = self.plugin._replication_wait_initial(req)
+
+        rsp, rsp_dict = self._load_rsp(rsp_json)
+        self.assertFalse(rsp.success)
+        self.assertEqual("no volumeUuids specified for initial full sync wait", rsp.error)
+        self.assertEqual(False, rsp_dict.get("success"))
+        self.assertEqual("no volumeUuids specified for initial full sync wait", rsp_dict.get("error"))
+
+    def test_wait_initial_all_ready_returns_progress_fields(self):
+        self.plugin._get_zrm_block_jobs = lambda vm_uuid: {
+            "zrm-mirror-volready": {
+                "status": "ready",
+                "ready": True,
+                "offset": 128,
+                "len": 256
+            }
+        }
+        req = self._make_req({
+            "vmUuid": "vm-1",
+            "volumeUuids": ["volready-uuid"],
+            "timeoutSeconds": 1
+        })
+
+        rsp_json = self.plugin._replication_wait_initial(req)
+
+        rsp, rsp_dict = self._load_rsp(rsp_json)
+        self.assertTrue(rsp.success)
+        self.assertEqual(128, rsp.lastSyncDataBytes)
+        self.assertEqual(128, rsp.lastSyncBytes)
+        self.assertEqual(256, rsp.totalSyncTargetBytes)
+        self.assertEqual(1, rsp.readyJobCount)
+        self.assertEqual(0, rsp.runningJobCount)
+        self.assertEqual(0, rsp.concludedJobCount)
+        self.assertEqual(1, rsp.totalJobs)
+        self.assertEqual(1, rsp_dict.get("readyJobCount"))
+
+    def test_wait_initial_timeout_returns_failure_response(self):
+        self.plugin._get_zrm_block_jobs = lambda vm_uuid: {
+            "zrm-mirror-voltimeo": {
+                "status": "running",
+                "ready": False,
+                "offset": 64,
+                "len": 256
+            }
+        }
+        time_points = [100.0, 101.5]
+
+        def fake_time():
+            return time_points.pop(0) if time_points else 101.5
+
+        zrm_plugin.time.time = fake_time
+        zrm_plugin.time.sleep = lambda seconds: None
+        req = self._make_req({
+            "vmUuid": "vm-1",
+            "volumeUuids": ["voltimeo-uuid"],
+            "timeoutSeconds": 1
+        })
+
+        rsp_json = self.plugin._replication_wait_initial(req)
+
+        rsp, rsp_dict = self._load_rsp(rsp_json)
+        self.assertFalse(rsp.success)
+        self.assertIn("initial full sync timeout", rsp.error)
+        self.assertEqual(0, rsp.readyJobCount)
+        self.assertEqual(1, rsp.runningJobCount)
+        self.assertEqual(0, rsp.concludedJobCount)
+        self.assertEqual(["zrm-mirror-voltimeo"], list(rsp.not_ready))
+        self.assertEqual([], list(rsp.missing))
+        self.assertEqual(False, rsp_dict.get("success"))
+
+    def test_wait_initial_concluded_returns_failure_and_dismisses_job(self):
+        dismiss_calls = []
+        self.plugin._get_zrm_block_jobs = lambda vm_uuid: {
+            "zrm-mirror-volconcl": {
+                "status": "concluded",
+                "ready": False,
+                "offset": 32,
+                "len": 512,
+                "error": "Input/output error"
+            }
+        }
+
+        def fake_execute_qmp_command(vm_uuid, command, raise_exception=False, id=None):
+            dismiss_calls.append({
+                "vmUuid": vm_uuid,
+                "command": command,
+                "raise_exception": raise_exception,
+                "id": id
+            })
+            return None
+
+        zrm_plugin.qmp.execute_qmp_command = fake_execute_qmp_command
+        req = self._make_req({
+            "vmUuid": "vm-1",
+            "volumeUuids": ["volconcl-uuid"],
+            "timeoutSeconds": 5
+        })
+
+        rsp_json = self.plugin._replication_wait_initial(req)
+
+        rsp, rsp_dict = self._load_rsp(rsp_json)
+        self.assertFalse(rsp.success)
+        self.assertIn("mirror job concluded during initial full sync", rsp.error)
+        self.assertEqual(1, rsp.concludedJobCount)
+        self.assertEqual(0, rsp.readyJobCount)
+        self.assertEqual(0, rsp.runningJobCount)
+        self.assertEqual(1, len(rsp.concludedJobErrors))
+        self.assertEqual("zrm-mirror-volconcl", rsp.concludedJobErrors[0].device)
+        self.assertEqual("Input/output error", rsp.concludedJobErrors[0].error)
+        self.assertEqual(1, len(dismiss_calls))
+        self.assertEqual("block-job-dismiss", dismiss_calls[0]["command"])
+        self.assertEqual("zrm-mirror-volconcl", dismiss_calls[0]["id"])
+        self.assertEqual(1, rsp_dict.get("concludedJobCount"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kvmagent/kvmagent/test/test_zrm_plugin.py
+++ b/kvmagent/kvmagent/test/test_zrm_plugin.py
@@ -268,5 +268,134 @@ class TestZrmPluginGuestFsfreeze(unittest.TestCase):
         self.assertEqual("QGA_NOT_RUNNING", body.get("errorCode"))
 
 
+class TestZrmPluginCheckpointCreate(unittest.TestCase):
+    def setUp(self):
+        self.plugin = object.__new__(zrm_plugin.ZrmPlugin)
+        self._orig_json_post = http.json_post
+        self.json_post_calls = []
+
+    def tearDown(self):
+        http.json_post = self._orig_json_post
+
+    def _make_req(self, body_dict):
+        return {
+            http.REQUEST_BODY: json.dumps(body_dict)
+        }
+
+    def _load_rsp(self, rsp_json):
+        rsp = jsonobject.loads(rsp_json)
+        body = json.loads(rsp_json)
+        return rsp, body
+
+    def _mock_throttle(self, allReady=True, success=True, readyCount=2, totalJobs=2, error=None):
+        """Replace _replication_throttle with a fake that returns the given state."""
+        def fake_throttle(req):
+            rsp = {"success": success, "allReady": allReady,
+                   "readyCount": readyCount, "runningCount": 0 if allReady else 1,
+                   "totalJobs": totalJobs}
+            if error:
+                rsp["error"] = error
+            return json.dumps(rsp)
+        self.plugin._replication_throttle = fake_throttle
+
+    def _mock_json_post(self, response_dict):
+        """Replace http.json_post with a fake that records calls and returns response_dict."""
+        def fake_post(url, body=None, headers=None, fail_soon=False, **kwargs):
+            self.json_post_calls.append({"url": url, "body": body, "fail_soon": fail_soon})
+            return json.dumps(response_dict)
+        http.json_post = fake_post
+
+    def test_happy_path_returns_checkpoint_uuid(self):
+        self._mock_throttle(allReady=True, totalJobs=2, readyCount=2)
+        self._mock_json_post({"success": True})
+
+        rsp_json = self.plugin.zrm_checkpoint_create(self._make_req({
+            "vmUuid": "vm-1",
+            "sessionUuid": "sess-1",
+            "checkpointUuid": "cp-uuid-123",
+            "zrServerUrl": "http://192.168.1.10:6800",
+            "waitReadyTimeout": 10,
+            "originalSpeed": 1048576
+        }))
+
+        rsp, body = self._load_rsp(rsp_json)
+        self.assertTrue(body.get("success"))
+        self.assertEqual("cp-uuid-123", body.get("checkpointUuid"))
+        # Verify ZR Server was called
+        self.assertEqual(1, len(self.json_post_calls))
+        self.assertEqual("http://192.168.1.10:6800/zr/checkpoint/create", self.json_post_calls[0]["url"])
+        self.assertTrue(self.json_post_calls[0]["fail_soon"])
+        # Verify body sent to ZR Server
+        sent_body = json.loads(self.json_post_calls[0]["body"])
+        self.assertEqual("sess-1", sent_body["sessionUuid"])
+        self.assertEqual("cp-uuid-123", sent_body["checkpointUuid"])
+
+    def test_mirrors_not_ready_returns_failure_and_skips_zr_call(self):
+        self._mock_throttle(allReady=False, readyCount=1, totalJobs=3)
+        self._mock_json_post({"success": True})  # should not be called
+
+        rsp_json = self.plugin.zrm_checkpoint_create(self._make_req({
+            "vmUuid": "vm-1",
+            "sessionUuid": "sess-1",
+            "checkpointUuid": "cp-uuid-456",
+            "zrServerUrl": "http://192.168.1.10:6800",
+            "waitReadyTimeout": 5
+        }))
+
+        rsp, body = self._load_rsp(rsp_json)
+        self.assertFalse(body.get("success"))
+        self.assertIn("mirrors not ready", body.get("error"))
+        self.assertIn("ready=1", body.get("error"))
+        self.assertIn("total=3", body.get("error"))
+        # http.json_post must NOT have been called
+        self.assertEqual(0, len(self.json_post_calls))
+
+    def test_zr_server_failure_returns_error(self):
+        self._mock_throttle(allReady=True, totalJobs=1, readyCount=1)
+        self._mock_json_post({"success": False, "error": "disk full on target"})
+
+        rsp_json = self.plugin.zrm_checkpoint_create(self._make_req({
+            "vmUuid": "vm-1",
+            "sessionUuid": "sess-1",
+            "checkpointUuid": "cp-uuid-789",
+            "zrServerUrl": "http://192.168.1.10:6800"
+        }))
+
+        rsp, body = self._load_rsp(rsp_json)
+        self.assertFalse(body.get("success"))
+        self.assertIn("disk full on target", body.get("error"))
+        self.assertIn("ZR Server", body.get("error"))
+
+    def test_missing_required_fields_returns_error(self):
+        # No mock needed — validation fails before throttle/post
+        rsp_json = self.plugin.zrm_checkpoint_create(self._make_req({
+            "vmUuid": "vm-1",
+            "sessionUuid": "",
+            "checkpointUuid": "cp-1",
+            "zrServerUrl": ""
+        }))
+
+        rsp, body = self._load_rsp(rsp_json)
+        self.assertFalse(body.get("success"))
+        self.assertIn("required", body.get("error"))
+
+    def test_throttle_failure_returns_error(self):
+        self._mock_throttle(success=False, allReady=False, error="QMP connection lost")
+        self._mock_json_post({"success": True})
+
+        rsp_json = self.plugin.zrm_checkpoint_create(self._make_req({
+            "vmUuid": "vm-1",
+            "sessionUuid": "sess-1",
+            "checkpointUuid": "cp-1",
+            "zrServerUrl": "http://10.0.0.1:6800"
+        }))
+
+        rsp, body = self._load_rsp(rsp_json)
+        self.assertFalse(body.get("success"))
+        self.assertIn("mirror convergence failed", body.get("error"))
+        self.assertIn("QMP connection lost", body.get("error"))
+        self.assertEqual(0, len(self.json_post_calls))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/kvmagent/kvmagent/test/test_zrm_plugin.py
+++ b/kvmagent/kvmagent/test/test_zrm_plugin.py
@@ -190,9 +190,13 @@ class TestZrmPluginGuestFsfreeze(unittest.TestCase):
                 "guest-fsfreeze-freeze-list": True,
             }
 
+            def __init__(self):
+                self.status_calls = 0
+
             def call_qga_command(self, command, args=None, timeout=3):
                 if command == "guest-fsfreeze-status":
-                    return "thawed"
+                    self.status_calls += 1
+                    return "thawed" if self.status_calls == 1 else "frozen"
                 if command == "guest-fsfreeze-freeze":
                     return 2
                 raise AssertionError("unexpected command: %s" % command)
@@ -209,6 +213,38 @@ class TestZrmPluginGuestFsfreeze(unittest.TestCase):
         self.assertEqual(2, body.get("filesystemCount"))
         self.assertEqual("linux", body.get("guestOsType"))
         self.assertEqual("qga-fsfreeze", body.get("quiesceProvider"))
+        self.assertEqual(2, self.plugin._linux_fsfreeze_counts["vm-linux-1"])
+
+    def test_guest_fsfreeze_linux_freeze_already_frozen_uses_cached_count(self):
+        class FakeQga(object):
+            vm_uuid = "vm-linux-frozen"
+            os = "centos"
+            supported_commands = {
+                "guest-fsfreeze-freeze": True,
+                "guest-fsfreeze-thaw": True,
+                "guest-fsfreeze-status": True,
+            }
+
+            def call_qga_command(self, command, args=None, timeout=3):
+                if command == "guest-fsfreeze-status":
+                    return "frozen"
+                if command == "guest-fsfreeze-freeze-list":
+                    raise AssertionError("freeze-list must not be called when already frozen")
+                raise AssertionError("unexpected command: %s" % command)
+
+        self.plugin._linux_fsfreeze_counts = {"vm-linux-frozen": 3}
+        self.plugin._get_vm_qga = lambda vm_uuid: (FakeQga(), None)
+
+        rsp_json = self.plugin._replication_guest_fsfreeze(self._make_req({
+            "vmUuid": "vm-linux-frozen",
+            "action": "freeze",
+            "timeoutSeconds": 15
+        }))
+
+        _, body = self._load_rsp(rsp_json)
+        self.assertTrue(body.get("success"))
+        self.assertEqual("frozen", body.get("fsFreezeStatus"))
+        self.assertEqual(3, body.get("filesystemCount"))
 
     def test_guest_fsfreeze_linux_thaw_success(self):
         thaw_qga = type("ThawFakeQga", (), {
@@ -231,6 +267,7 @@ class TestZrmPluginGuestFsfreeze(unittest.TestCase):
             raise AssertionError("unexpected command: %s" % command)
 
         thaw_qga.call_qga_command = fake_call
+        self.plugin._linux_fsfreeze_counts = {"vm-linux-2": 2}
         self.plugin._get_vm_qga = lambda vm_uuid: (thaw_qga, None)
         rsp_json = self.plugin._replication_guest_fsfreeze(self._make_req({
             "vmUuid": "vm-linux-2",
@@ -240,6 +277,7 @@ class TestZrmPluginGuestFsfreeze(unittest.TestCase):
         _, body = self._load_rsp(rsp_json)
         self.assertTrue(body.get("success"))
         self.assertEqual("thawed", body.get("fsFreezeStatus"))
+        self.assertNotIn("vm-linux-2", self.plugin._linux_fsfreeze_counts)
 
     def test_guest_fsfreeze_qga_not_running(self):
         self.plugin._get_vm_qga = lambda vm_uuid: (None, "QEMU Guest Agent not in running state")
@@ -383,6 +421,41 @@ class TestZrmPluginCheckpointCreate(unittest.TestCase):
         self.assertEqual(0, len(self.json_post_calls))
 
 
+class TestZrmPluginReplicationStop(unittest.TestCase):
+    def setUp(self):
+        self.plugin = object.__new__(zrm_plugin.ZrmPlugin)
+        self._orig_block_job_cancel = zrm_plugin.qmp.block_job_cancel
+
+    def tearDown(self):
+        zrm_plugin.qmp.block_job_cancel = self._orig_block_job_cancel
+
+    def _make_req(self, body_dict):
+        return {http.REQUEST_BODY: json.dumps(body_dict)}
+
+    def _load_rsp(self, rsp_json):
+        return json.loads(rsp_json)
+
+    def test_cancel_failure_returns_error_with_failed_job(self):
+        self.plugin._get_zrm_block_jobs = lambda vm_uuid: {
+            "zrm-mirror-volfail": {"status": "running"}
+        }
+
+        def fake_block_job_cancel(vm_uuid, device):
+            raise RuntimeError("QMP connection lost")
+
+        zrm_plugin.qmp.block_job_cancel = fake_block_job_cancel
+
+        body = self._load_rsp(self.plugin._replication_stop(
+            self._make_req({"vmUuid": "vm-1", "sessionUuid": "sess-1"})))
+
+        self.assertFalse(body["success"])
+        self.assertIn("failed to cancel ZRM mirror jobs", body["error"])
+        self.assertEqual([{
+            "device": "zrm-mirror-volfail",
+            "error": "QMP connection lost"
+        }], body["cancelFailedJobs"])
+
+
 class TestZrmPluginRecoveryPrepare(unittest.TestCase):
     def setUp(self):
         self.plugin = object.__new__(zrm_plugin.ZrmPlugin)
@@ -485,6 +558,23 @@ class TestZrmPluginRecoveryPrepare(unittest.TestCase):
                 self._make_req({"vmUuid": "vm-1", "sessionUuid": "sess-1"})))
         self.assertFalse(body["success"])
         self.assertIn("replication_stop failed", body["error"])
+
+    def test_cancel_failure_aborts_before_isolation(self):
+        self.plugin._get_zrm_block_jobs = lambda vm_uuid: {
+            "zrm-mirror-volfail": {"status": "running"}
+        }
+
+        with mock.patch.object(zrm_plugin.qmp, "block_job_cancel",
+                               side_effect=RuntimeError("QMP connection lost")), \
+             mock.patch.object(self.plugin, "_vm_shutdown_and_isolate",
+                               return_value=(True, None)) as isolate:
+            body = self._load_rsp(self.plugin.zrm_recovery_prepare(
+                self._make_req({"vmUuid": "vm-1", "sessionUuid": "sess-1"})))
+
+        self.assertFalse(body["success"])
+        self.assertIn("replication_stop failed", body["error"])
+        self.assertIn("failed to cancel ZRM mirror jobs", body["error"])
+        isolate.assert_not_called()
 
     def test_stale_jobs_aborts(self):
         stop_rsp = json.dumps({"success": True,

--- a/zstacklib/zstacklib/utils/qmp.py
+++ b/zstacklib/zstacklib/utils/qmp.py
@@ -118,6 +118,25 @@ def execute_qmp_command(domain, name, raise_exception=True, **kwargs):
     return _execute_qmp_command(domain, json.dumps(qmp_cmd).encode('utf-8'), raise_exception)
 
 
+def execute_qmp_command_raw(domain_id, command_json, raise_exception=True):
+    """
+    Execute a pre-serialised QMP command JSON string.
+
+    Use this when QMP arguments contain fields that collide with
+    execute_qmp_command's Python parameter ``name`` (e.g. block-dirty-bitmap-add
+    requires an arguments.name field which shadows the function's positional
+    ``name`` parameter).
+
+    :param domain_id: VM UUID / libvirt domain ID
+    :param command_json: complete QMP command as JSON str (not bytes)
+    :param raise_exception: raise on error if True (default True)
+    :return: the 'return' value from QMP response, or None on suppressed error
+    """
+    if not isinstance(command_json, str):
+        command_json = command_json.decode("utf-8") if hasattr(command_json, "decode") else str(command_json)
+    return _execute_qmp_command(domain_id, command_json, raise_exception=raise_exception)
+
+
 def qmp_subcmd(qemu_version, s_cmd):
     # object-add option props (removed in 6.0).
     # Specify the properties for the object as top-level arguments instead.


### PR DESCRIPTION
## Summary

Implements the complete ZLR/ZR replication lifecycle in kvmagent's `zrm_plugin`,
covering initialization, initial-sync observability, application-consistent quiesce,
checkpoint orchestration, and recovery preparation.

## Changes

### 1. kvmagent ZLR/ZR initialization (`vm_plugin` + `zrm_plugin` scaffold)
- Register `ZrmPlugin` with all ZLR/ZR URI handlers in kvmagent
- Add QMP utility helpers (`qmp.py`) for block-job introspection
- Wire `vm_plugin` ZR initialization submission path

### 2. Fix: preserve wait-initial-sync failure details
- `_wait_initial_full_sync` now returns a structured `ZrmAgentRsp` instead of
  collapsing all failures to a plain error string
- Callers can distinguish retriable observation failures from terminal full-sync failures
- Aggregates ready/running/concluded counts + sync bytes; dismisses concluded jobs
  after recording error details
- Falls back to `qmp._execute_qmp_command` when `execute_qmp_command_raw` is
  unavailable (older environments)

### 3. Guest filesystem freeze endpoint (`/zrm/replication/guest-fsfreeze`)
- New async URI for application-consistent quiesce before NBD throttle
- Linux path: QGA `guest-fsfreeze-freeze/thaw/status` via `VmQga`
- Windows path: GuestTools quiesce when available
- Response fields aligned with ZRM `GuestFsFreezeResult`(`success`, `fsFreezeStatus`, `filesystemCount`, `quiesceProvider`, `errorCode`)

### 4. Checkpoint gate with source-side mirror convergence (`zrm_checkpoint_create`)
- Replaces stub with3-step orchestration:
  1. Set mirror speed = 0, poll `allReady` via `_replication_throttle`
  2. POST `/zr/checkpoint/create` to ZR Server (fail-fast, no retry)
  3. Restore original mirror speed (best-effort, non-fatal)
- `totalJobs = 0` (no active mirrors) treated as converged — proceeds directlyto ZR Server

### 5. Recovery prepare with graceful shutdown + network isolation (`zrm_recovery_prepare`)
- Replaces `NOT_IMPLEMENTED` stub with full recovery-side orchestration:
  1. `_replication_stop()` — abort if stop fails or stale mirror jobs remain
  2. Graceful guest shutdown via `domain.shutdown()`, polling until `SHUTOFF`
     within `shutdown_timeout` (default 30 s)
  3. On timeout, fall back to live vNIC detach (`detachDeviceFlags`) for
     network isolation
  4. Re-read domain XML after detach errors to verify NICs are gone(handles already-absent NIC race condition)
- New helper `_vm_shutdown_and_isolate(vm_uuid, shutdown_timeout, force_isolate)`
- `force_isolate=True` skips shutdown and goes directly to vNIC detach
- No-interface VMs return success immediately

## Tests

| Commit | Suite | Cases |
|--------|-------|-------|
| wait-initial-sync fix | `test_zrm_plugin` | 6 cases covering query failure, timeout progress, concluded job error details |
| guest-fsfreeze | `test_zrm_plugin` | response shape, Linux QGA path, Windows GuestTools path |
| checkpoint create | `test_zrm_plugin` + `run_test_checkpoint_create.py` | happy path, mirrors not ready, ZR Server failure, missing fields, throttle failure (5 cases) |
| recovery prepare | `test_zrm_plugin` | clean shutdown, shutdown timeout → NIC detach, libvirt state error, partial NIC detach failure, VM not found, replication_stop failure, stale jobs (7 cases) |

## Files Changed

- `kvmagent/kvmagent/plugins/zrm_plugin.py` — core implementation
- `kvmagent/kvmagent/plugins/vm_plugin.py` — ZR init wiring
- `zstacklib/zstacklib/utils/qmp.py` — QMP helpers
- `kvmagent/kvmagent/test/test_zrm_plugin.py` — unit tests
- `kvmagent/kvmagent/test/run_test_checkpoint_create.py` — integration test runner

sync from gitlab !7431