### PR TITLE
<fix>[5.4.10][ZSTAC-86307]: convert legacy RBD snapshot XML

### DIFF
--- a/.gitconfig/hooks/commit-msg
+++ b/.gitconfig/hooks/commit-msg
@@ -61,7 +61,7 @@ def backup_and_exit(file_path):
 
     lines = []
     useful = ["\n\n"]
-    with open(file_path, 'r') as f:
+    with open(file_path, 'r', encoding='utf-8') as f:
         lines = f.readlines()
     for l in lines:
             if l.startswith("# Please enter the commit") or \
@@ -87,7 +87,7 @@ def fix_commit_msg(file_path):
     # see: https://superuser.com/questions/1367811/sometimes-git-includes-the-diff-to-commit-message-when-using-verbose
 
     fixed_commit_msg = []
-    with open(file_path, 'r') as f:
+    with open(file_path, 'r', encoding='utf-8') as f:
         lines = f.readlines()
         for no, line in enumerate(lines):
             if "# Everything below it will be ignored." in line.strip() or \
@@ -96,7 +96,7 @@ def fix_commit_msg(file_path):
                 break
     if len(fixed_commit_msg) == 0:
         return
-    with open(file_path, 'w') as f:
+    with open(file_path, 'w', encoding='utf-8') as f:
         f.writelines(fixed_commit_msg)
 
 
@@ -124,7 +124,7 @@ def check_commit_msg(file_path):
 
     jira_patterns = [r"\bZSTAC-\d+\b", r"\bZSTACK-\d+\b", r"\bMINI-\d+\b", 
                      r"\bZOPS-\d+\b", r"\bZHCI-\d+\b", r"\bZSV-\d+\b"]
-    with open(file_path, 'r') as f:
+    with open(file_path, 'r', encoding='utf-8') as f:
         lines = f.readlines()
         full_lines = len(lines)
 

--- a/.gitconfig/hooks/prepare-commit-msg
+++ b/.gitconfig/hooks/prepare-commit-msg
@@ -73,7 +73,7 @@ def write_commit_msg(commit_msg_filepath, type, scope, tags, jiras):
 # 3. Are there any side effects?\n
 '''
 
-    with open(commit_msg_filepath, 'r+') as msg:
+    with open(commit_msg_filepath, 'r+', encoding='utf-8') as msg:
         in_usable_content = False
         useable_contents = []
         for line in msg.readlines():
@@ -102,7 +102,7 @@ def write_commit_msg(commit_msg_filepath, type, scope, tags, jiras):
         
         real_commit_msg.append("\nChange-Id: %s\n" % get_change_id())
 
-    with open(commit_msg_filepath, 'w') as msg:
+    with open(commit_msg_filepath, 'w', encoding='utf-8') as msg:
         real_commit_msg.extend(useable_contents)
         msg.writelines(real_commit_msg)
 
@@ -118,7 +118,7 @@ def process_metadata(commit_msg_filepath):
 
     changed_folders = []
     changed_paths = {}
-    with open(commit_msg_filepath, 'r+') as msg:
+    with open(commit_msg_filepath, 'r+', encoding='utf-8') as msg:
         content = msg.readlines()
         for no, line in enumerate(content):
             line = line.strip()

--- a/docs/modules/kvmagent/nav.adoc
+++ b/docs/modules/kvmagent/nav.adoc
@@ -4,3 +4,4 @@
 ** xref:ha_plugin/index.adoc[]
 *** xref:ha_plugin/sharedblock.adoc[]
 *** xref:ha_plugin/ceph.adoc[]
+** xref:network/flat_eip.adoc[]

--- a/docs/modules/kvmagent/pages/network/flat_eip.adoc
+++ b/docs/modules/kvmagent/pages/network/flat_eip.adoc
@@ -1,0 +1,620 @@
+= 扁平网络 EIP 原理与实现
+:icons: font
+:source-highlighter: rouge
+:toc: left
+:toclevels: 3
+
+扁平网络 EIP（Elastic IP）是 ZStack 在扁平网络模式下为云主机提供公网访问能力的核心机制。本文档介绍其部署拓扑、通信原理、ebtables 规则设计，以及与网卡防欺诈、userdata 等功能的关系。
+
+核心实现位于 `kvmagent/kvmagent/plugins/deip.py`，辅助的 ebtables 链管理在 `kvmagent/kvmagent/plugins/mevoco.py`。
+
+== 部署拓扑
+
+=== 整体架构
+
+扁平网络 EIP 使用 Linux network namespace 在宿主机上为每个 EIP 创建一个独立的网络命名空间，完成私网 IP 和公网 VIP 之间的 NAT 转换。
+
+[source,text]
+----
+                 ┌──────────────────────────────────────────────────┐
+                 │              物理交换机 / 物理网关                  │
+                 │          GW_MAC=xx:xx  IP=192.168.2.1            │
+                 └──────────────────┬───────────────────────────────┘
+                                    │
+                               [上行口 zsn1.489]
+                                    │
+  ┌─────────────────────────────────┴──────────────────────────────────────────────────┐
+  │                          br_zns_489（扁平网络 bridge）                               │
+  │                                                                                    │
+  │   ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌─────────────────────────────┐  │
+  │   │ vnic1.0  │    │ vnic2.0  │    │ vnic3.0  │    │ a471aa10f_o (NS 私网外侧)    │  │
+  │   │  VM-A    │    │  VM-B    │    │  VM-C    │    │          ↕                   │  │
+  │   │ 有 EIP   │    │ 无 EIP   │    │ 无 EIP   │    │ a471aa10f_i (NS 网关接口)    │  │
+  │   │ .242     │    │ .243     │    │ .244     │    │   IP=192.168.2.1             │  │
+  │   │ 网关=.1  │    │ 网关=.1  │    │ 网关=.1  │    │          ↕                   │  │
+  │   └──────────┘    └──────────┘    └──────────┘    │ a471aa10f_ei (EIP .210)      │  │
+  │                                                    │          ↕                   │  │
+  │                                                    │ a471aa10f_eo                 │  │
+  └────────────────────────────────────────────────────┴──────┬──────────────────────┘  │
+                                                               │                        │
+                                                     ┌─────────┴──────────┐
+                                                     │ br_zsn0_31 公网bridge│
+                                                     └────────────────────┘
+----
+
+=== 拓扑中的关键角色
+
+[cols="1,2,3",options="header"]
+|===
+| 角色 | 示例 | 说明
+
+| 物理交换机/网关
+| IP=192.168.2.1, MAC=GW_MAC
+| 物理网络的默认网关，连接上行口。无 EIP 的 VM 以此为网关。
+
+| EIP namespace（NS）
+| a471aa10f_i/o/ei/eo
+| 宿主机上为 VM-A 创建的网络命名空间。私网侧 IP 同物理网关（192.168.2.1），充当 VM-A 的"虚拟网关"。
+
+| 有 EIP 的 VM（VM-A）
+| vnic1.0, IP=.242
+| 网关 IP 仍是 .1，但通过 ebtables arpreply 让 VM 解析到 **namespace MAC** 而非物理网关 MAC，流量走 namespace 做 NAT。
+
+| 无 EIP 的 VM（VM-B/C）
+| vnic2.0/vnic3.0, IP=.243/.244
+| 网关 IP 同为 .1，解析到 **物理网关 MAC**，流量直接走物理交换机。
+
+| 其它宿主机上的 EIP namespace
+| 各自独立的 namespace
+| 每个 EIP 在其所在宿主机上创建独立 namespace，结构与上图一致。不同宿主机的 namespace 通过各自的公网 bridge 和上行口互通。
+|===
+
+==== 核心约束
+
+**所有 VM 的网关 IP 都是同一个地址（192.168.2.1）**。同一个 bridge 上，同一个网关 IP，有 EIP 的 VM 必须解析到 namespace MAC，无 EIP 的 VM 必须解析到物理网关 MAC。这就是 ebtables 规则存在的根本原因。
+
+=== 跨宿主机拓扑
+
+[source,text]
+----
+  宿主机 A                                              宿主机 B
+ ┌──────────────────────────────┐  物理网络   ┌──────────────────────────────┐
+ │ br_zns_489                   │ ◄────────► │ br_zns_489                   │
+ │  ├─ vnic1.0 (VM-A, 有EIP)   │            │  ├─ vnic4.0 (VM-D, 有EIP)   │
+ │  ├─ vnic2.0 (VM-B, 无EIP)   │            │  ├─ vnic5.0 (VM-E, 无EIP)   │
+ │  └─ NS-A (a471aa10f_*)      │            │  └─ NS-D (b582bb21f_*)      │
+ │                              │            │                              │
+ │ br_zsn0_31 (公网)            │            │ br_zsn0_31 (公网)            │
+ └──────────────────────────────┘            └──────────────────────────────┘
+----
+
+每个宿主机上的 namespace 是独立的。VM-A 的 EIP namespace 在宿主机 A 上，VM-D 的在宿主机 B 上。它们各自通过公网 bridge 获得公网 VIP 的连通性。
+
+== 通信原理
+
+=== 同网段通信（L2 直通）
+
+同一扁平网络内的 VM 之间通信是标准的 L2 转发，不经过任何 namespace。
+
+[source,text]
+----
+VM-A (.242) ——ARP Request: who has .243?——→ bridge 广播 ——→ VM-B (.243)
+VM-B (.243) ——ARP Reply: .243 is at MAC-B——→ VM-A (.242)
+VM-A ——IP packet dst=MAC-B——→ bridge 转发 ——→ VM-B
+----
+
+有 EIP 和无 EIP 的 VM 之间同网段通信完全一样 —— EIP 只影响网关 ARP 解析，不影响同网段 VM 间的直接通信。
+
+=== 有 EIP 的 VM 跨网段通信
+
+有 EIP 的 VM（VM-A）需要与外部网络通信时，流量走 namespace：
+
+[source,text]
+----
+1. VM-A 发送目标为外部 IP 的数据包，需要先解析网关 .1 的 MAC
+2. VM-A 发 ARP Request: who has 192.168.2.1?
+3. ebtables PREROUTING 链拦截该 ARP，arpreply 返回 namespace 的 MAC（NS_MAC）
+4. VM-A 将数据包发往 NS_MAC → bridge 转发到 a471aa10f_o → 进入 namespace
+5. namespace 内部 iptables 规则执行 SNAT（.242 → VIP .210）
+6. 数据包从 a471aa10f_ei 出去 → a471aa10f_eo → br_zsn0_31 → 公网
+7. 返回流量：公网 → br_zsn0_31 → namespace → DNAT（VIP .210 → .242）→ bridge → VM-A
+----
+
+=== 无 EIP 的 VM 跨网段通信
+
+无 EIP 的 VM（VM-B）跨网段通信走物理网关，是标准的网络路径：
+
+[source,text]
+----
+1. VM-B 发 ARP Request: who has 192.168.2.1?
+2. 无 ebtables 拦截，ARP Request 广播到 bridge 所有端口（含上行口）
+3. 物理网关回复 ARP Reply，VM-B 学到物理网关的 GW_MAC
+4. VM-B 将数据包发往 GW_MAC → bridge → 上行口 → 物理交换机路由转发
+----
+
+=== ARP 行为对各设备的影响
+
+ARP 是 flat EIP 最核心的控制点。下表汇总了各种 ARP 场景对 bridge 上各设备 ARP 表的影响：
+
+[cols="2,3,3",options="header"]
+|===
+| ARP 发起者 | ARP 内容 | 对其它设备的影响
+
+| *物理网关*发送 ARP Request（查询 VM-A .242）
+| src-ip=.1, src-mac=GW_MAC, dst-ip=.242
+| 对有 EIP 的 VM-A：被 `eip-vnic1.0-arp` 链 DROP（GW_MAC ≠ NS_MAC）。物理网关无法通过私网直接 L2 访问有 EIP 的 VM —— 这是 EIP 架构的设计取舍。 +
+对无 EIP 的 VM-B/C：正常收到并更新 ARP 表。
+
+| *物理网关*发送免费 ARP（Gratuitous ARP）
+| src-ip=.1, src-mac=GW_MAC, dst-ip=.1
+| 对有 EIP 的 VM-A：Request 和 Reply 均被 `eip-vnic1.0-arp` DROP，不会污染 VM-A 的网关 MAC 缓存。 +
+对无 EIP 的 VM-B/C：正常收到，更新 .1 的 MAC 为 GW_MAC（正确行为）。
+
+| *EIP namespace* 发送免费 ARP（.1 → .1）
+| src-ip=.1, src-mac=NS_MAC, dst-ip=.1
+| `eip-a471aa10f_o-gw` 链的 dnat 规则将目标 MAC 改写为 VM-A 的 MAC，只有 VM-A 收到。 +
+其余 ARP 被兜底 DROP，不会泄漏到 VM-B/C 或上行口。
+
+| *EIP namespace* 发送 ARP Request 查询 VM-A
+| src-ip=.1, src-mac=NS_MAC, dst-ip=.242
+| `eip-a471aa10f_o-gw` 链 arpreply 直接回复 VM-A 的 MAC，不广播。
+
+| *EIP namespace* 发送 ARP Reply 给 VM-B（内核误回复）
+| src-ip=.1, src-mac=NS_MAC, dst=VM-B MAC
+| `eip-a471aa10f_o-gw` 的 dnat 规则（匹配 src-ip=.1）改写目标 MAC 为 VM-A，VM-B 收不到。 +
+兜底 DROP 作为最终防线。
+
+| *VM-A* 发送 ARP Request（查询 .243）
+| src-ip=.242, src-mac=VM-A-MAC, dst-ip=.243
+| `eip-vnic1.0-gw` 链不匹配（dst≠.1）→ RETURN → libvirt 放行 → 正常广播。
+
+| *VM-B* 发送 ARP Request（查询 .1）
+| src-ip=.243, src-mac=VM-B-MAC, dst-ip=.1
+| 无 EIP 链拦截，正常广播。物理网关回复。 +
+`eip-a471aa10f_o-arp` 链拦截向 namespace 方向的传播（VM-B 的 MAC ≠ VM-A 的 MAC → DROP）。
+|===
+
+== 实现原理：ebtables 规则详解
+
+=== Namespace 网络设备命名
+
+deip.py 使用 EIP UUID 的后 9 位作为设备名基础：
+
+[source,python]
+----
+EIP_UUID = eip.eipUuid[-9:]    # 例如 "a471aa10f"
+PUB_ODEV = "%s_eo" % EIP_UUID  # a471aa10f_eo  公网外侧
+PUB_IDEV = "%s_ei" % EIP_UUID  # a471aa10f_ei  公网内侧
+PRI_ODEV = "%s_o"  % EIP_UUID  # a471aa10f_o   私网外侧（连接扁平网络 bridge）
+PRI_IDEV = "%s_i"  % EIP_UUID  # a471aa10f_i   私网内侧（namespace 内部）
+----
+
+=== ebtables 链命名
+
+所有 EIP 相关的 ebtables 链都以 `eip-` 前缀命名，以便与 libvirt、userdata 等功能的链区分开：
+
+[cols="1,2",options="header"]
+|===
+| 链名 | 用途
+
+| `eip-{NIC_NAME}-gw`
+| PREROUTING，拦截有 EIP 的 VM 对网关的 ARP Request，arpreply 回复 namespace MAC
+
+| `eip-{PRI_ODEV}-gw`
+| PREROUTING，拦截 namespace 私网外侧口的 ARP，arpreply + dnat + 兜底 DROP
+
+| `eip-{NIC_NAME}-arp`
+| POSTROUTING，阻止冒充网关的 ARP 到达有 EIP 的 VM
+
+| `eip-{PRI_ODEV}-arp`
+| POSTROUTING，阻止非对应 VM 的 ARP 到达 namespace 私网口
+
+| `eip-{PUB_ODEV}-arp`
+| POSTROUTING，阻止对应 VM 的网关 ARP 泄漏到公网 bridge
+|===
+
+=== 完整 ebtables 规则表
+
+以 VM-A（vnic1.0, IP=.242, 有 EIP）为例：
+
+[source,text]
+----
+*nat
+:PREROUTING ACCEPT
+:OUTPUT ACCEPT
+:POSTROUTING ACCEPT
+
+# ==================== PREROUTING ====================
+
+# (1) EIP 链（-I 插入链头，排在 libvirt 前面，限定 -p ARP）
+-I PREROUTING -p ARP -i vnic1.0 -j eip-vnic1.0-gw
+
+# (2) libvirt anti-spoof 链（已存在，不由 deip.py 管理）
+# -A PREROUTING -i vnic1.0 -j libvirt-I-vnic1.0
+
+# (3) namespace 私网外侧入口
+-A PREROUTING -p ARP -i a471aa10f_o -j eip-a471aa10f_o-gw
+
+# --- eip-vnic1.0-gw (policy: RETURN) ---
+# VM 请求网关 → arpreply 回复 namespace MAC
+-A eip-vnic1.0-gw -p ARP --arp-op Request \
+   --arp-ip-dst 192.168.2.1 \
+   -j arpreply --arpreply-mac <namespace_MAC>
+# 不匹配的 ARP → RETURN 回 PREROUTING → 继续走 libvirt anti-spoof
+
+# --- eip-a471aa10f_o-gw (policy: RETURN) ---
+# namespace 请求 VM-A IP → arpreply 回复 VM-A MAC
+-I eip-a471aa10f_o-gw -p ARP --arp-op Request --arp-ip-dst 192.168.2.242 \
+   -j arpreply --arpreply-mac <VM-A_MAC>
+# namespace 网关 IP 的 ARP → dnat 目标 MAC 改为 VM-A（只让 VM-A 收到）
+-A eip-a471aa10f_o-gw -p ARP --arp-ip-src 192.168.2.1 \
+   -j dnat --to-dst <VM-A_MAC>
+# 兜底：其他所有 ARP → DROP（防止泄漏到其它 VM）
+-A eip-a471aa10f_o-gw -p ARP -j DROP
+
+
+# ==================== POSTROUTING ====================
+
+-I POSTROUTING -p ARP -o vnic1.0 -j eip-vnic1.0-arp
+-I POSTROUTING -p ARP -o a471aa10f_o -j eip-a471aa10f_o-arp
+-I POSTROUTING -p ARP -o a471aa10f_eo -j eip-a471aa10f_eo-arp
+
+# --- eip-vnic1.0-arp (policy: RETURN) ---
+# 拦截冒充网关 .1 的 ARP Request（物理网关、其它 NS 等，MAC ≠ namespace_MAC）
+-A eip-vnic1.0-arp --arp-op Request \
+   --arp-ip-src 192.168.2.1 --arp-mac-src ! <namespace_MAC> -j DROP
+# 拦截冒充网关 .1 的 ARP Reply（含免费 ARP Reply）
+-A eip-vnic1.0-arp --arp-op Reply \
+   --arp-ip-src 192.168.2.1 --arp-mac-src ! <namespace_MAC> -j DROP
+
+# --- eip-a471aa10f_o-arp (policy: RETURN) ---
+# 阻止非 VM-A 的 ARP Request 到达 namespace
+-A eip-a471aa10f_o-arp --arp-op Request \
+   --arp-ip-dst 192.168.2.1 --arp-mac-src ! <VM-A_MAC> -j DROP
+
+# --- eip-a471aa10f_eo-arp (policy: RETURN) ---
+# 阻止 VM-A 网关 ARP 泄漏到公网 bridge
+-A eip-a471aa10f_eo-arp --arp-op Request \
+   --arp-ip-dst 192.168.2.1 --arp-mac-src ! <VM-A_MAC> -j DROP
+----
+
+=== 规则处理流程图
+
+[source,text]
+----
+帧从 vnic1.0 进入 PREROUTING：
+
+  规则: -p ARP -i vnic1.0 -j eip-vnic1.0-gw
+     ├─ 非 ARP 帧 → 不匹配 -p ARP → 跳到下一条规则（libvirt）
+     └─ ARP 帧 → 进入 eip-vnic1.0-gw 链
+          ├─ dst-ip = 网关 → arpreply 回复 namespace MAC（包被消费）
+          └─ dst-ip ≠ 网关 → RETURN（链策略）→ 回到 PREROUTING
+                                                      ↓
+  规则: -i vnic1.0 -j libvirt-I-vnic1.0  （anti-spoof 检查）
+     ├─ 源 MAC/IP 合法 → RETURN
+     └─ 源 MAC/IP 伪造 → DROP
+                                                      ↓
+  PREROUTING policy: ACCEPT
+----
+
+== 与其它功能的关系
+
+=== 网卡防欺诈（libvirt anti-spoof）
+
+libvirt 的 nwfilter 功能会为每个 VM 网卡创建 ebtables 链（如 `libvirt-I-vnic1.0`），检查帧的源 MAC 和源 IP 是否与 VM 配置匹配。
+
+**EIP 链与 libvirt 链的协作关系**：
+
+[cols="1,3",options="header"]
+|===
+| 设计要点 | 说明
+
+| 插入顺序
+| EIP 链使用 `-I`（insert）插入 PREROUTING 链头，libvirt 链使用 `-A`（append）追加到链尾。确保 EIP 链先执行。
+
+| `-p ARP` 限定
+| EIP 的 PREROUTING 跳转规则限定 `-p ARP`，非 ARP 帧直接跳过 EIP 链，由 libvirt 检查。**这是关键安全保证**：如果没有 `-p ARP`，所有帧都进入 EIP 链，而 EIP 链的默认策略 ACCEPT/RETURN 将绕过 libvirt 的 anti-spoof 检查。
+
+| 链策略 RETURN
+| 所有 EIP 用户自定义链都设置策略为 RETURN（而非 ebtables 默认的 ACCEPT），不匹配的 ARP 返回 PREROUTING 链继续执行后续的 libvirt 链。这是 `-p ARP` 之外的第二层安全保险。
+
+| arpreply 副作用
+| 有 EIP 的 VM 发送伪造源的 ARP Request（目标为网关），arpreply 会消费该包而不经过 libvirt 检查。但伪造包不会广播到网络，VM 只得到网关 MAC（无害信息），实际影响极小。
+|===
+
+[IMPORTANT]
+====
+ebtables 的用户自定义链（`-N` 创建）默认策略是 **ACCEPT**，而非 iptables 中的 RETURN。如果 EIP 链不显式设 `-P RETURN`，且跳转规则不限定 `-p ARP`，将导致所有流量在 EIP 链中被 ACCEPT，完全绕过 libvirt anti-spoof。
+====
+
+=== Userdata ebtables 规则（mevoco.py）
+
+userdata 功能为每个 L3 网络创建 ebtables 链，将 VM 访问 `169.254.169.254` 的流量 dnat 到宿主机上的 userdata HTTP 服务。
+
+**userdata 链命名**：
+
+- legacy 模式：`USERDATA-<bridge_name[-12:]>-<l3_uuid[:8]>`
+- nf_tables 模式：`UD-<bridge_name_suffix>-<l3_uuid[:8]>`
+
+**userdata 链结构（nat 表）**：
+
+[source,text]
+----
+-I PREROUTING --logical-in <bridge> -j USERDATA-xxx
+  USERDATA-xxx:
+    -I -p IPv4 --ip-src <vm_cidr> --ip-dst 169.254.169.254 -j dnat --to-dst <inner_mac>
+    -I -p arp --arp-ip-dst 169.254.64.1 -j DROP
+    -A -j RETURN
+----
+
+**userdata 链结构（filter 表）**：
+
+[source,text]
+----
+-I FORWARD -p ARP --arp-ip-dst 169.254.169.254 -j USERDATA-xxx
+  USERDATA-xxx:
+    -I -i <phy_dev> -j DROP    # 阻止物理口来的 userdata ARP
+    -I -o <phy_dev> -j DROP    # 阻止 userdata ARP 泄漏到物理口
+    -A -j RETURN
+----
+
+**EIP 与 userdata 的共存**：
+
+- EIP 规则在 nat 表的 PREROUTING 链中，userdata 也在 PREROUTING 中。两者互不干扰：
+  * EIP 跳转条件是 `-p ARP -i <nic_name>`（特定 VM 网卡的 ARP）
+  * userdata 跳转条件是 `--logical-in <bridge>`（整个 bridge 的所有流量）
+- 同一个 VM 可以同时拥有 EIP 和 userdata，两套规则独立运作。
+
+=== kvmagent 重连时的 ebtables 恢复
+
+当 kvmagent 重启或重连管理节点时，`mevoco.py` 的 `connect()` 方法调用 `restore_ebtables_chain_except_kvmagent()`，该函数只保留匹配以下模式的链：
+
+[cols="1,2",options="header"]
+|===
+| 表 | 保留的链模式
+
+| nat
+| `libvirt`、`(^z\|^s)[0-9]*_`、`^eip-`
+
+| filter
+| `(^z\|^s)[0-9]*_\|^vr`
+|===
+
+`eip-` 前缀正是为了让 EIP 链在重连时被保留。其它未匹配的链（包括 `USERDATA-*`、`ZSTACK-*`）会被清除，由管理节点重新下发配置后重建。
+
+== 为什么需要这些 ebtables 规则
+
+=== 一句话总结
+
+**同一个 bridge 上，同一个网关 IP，不同 VM 需要解析到不同的 MAC 地址。** ebtables 规则的全部目的就是在 L2 层面精确控制 ARP 的可见性。
+
+=== 逐链解释
+
+==== eip-{NIC_NAME}-gw（PREROUTING）
+
+[cols="1,3",options="header"]
+|===
+| 规则 | 为什么需要
+
+| `--arp-op Request --arp-ip-dst <gateway> -j arpreply --arpreply-mac <ns_mac>`
+| **核心规则**。将有 EIP 的 VM 的网关 ARP 引导到 namespace。如果没有这条规则，VM 会学到物理网关的 MAC，跨网段流量直接走物理网关而非 namespace，EIP 的 SNAT/DNAT 完全失效。
+|===
+
+==== eip-{PRI_ODEV}-gw（PREROUTING）
+
+[cols="1,3",options="header"]
+|===
+| 规则 | 为什么需要
+
+| `--arp-op Request --arp-ip-dst <vm_ip> -j arpreply --arpreply-mac <vm_mac>`
+| namespace 需要知道 VM 的 MAC 才能发送数据包。用 arpreply 直接回复，避免 ARP Request 广播到 bridge 上。
+
+| `--arp-ip-src <gateway> -j dnat --to-destination <vm_mac>`
+| namespace 发出的网关 IP（.1）相关 ARP（含免费 ARP、Reply）只允许 VM-A 收到，通过 dnat 改写目标 MAC 为 VM-A 的 MAC。防止 namespace 的 .1 ARP 被无 EIP 的 VM 学到。
+
+| `-p ARP -j DROP`
+| 兜底规则。namespace 私网外侧口的其它所有 ARP 一律 DROP，防止任何未预期的 ARP 泄漏到扁平网络 bridge。
+|===
+
+==== eip-{NIC_NAME}-arp（POSTROUTING）
+
+[cols="1,3",options="header"]
+|===
+| 规则 | 为什么需要
+
+| `--arp-op Request --arp-ip-src <gateway> --arp-mac-src ! <ns_mac> -j DROP`
+| 物理网关的 ARP Request（.1, GW_MAC）到达 bridge 后会广播到所有端口。如果 VM-A 收到，会用 GW_MAC 覆盖已缓存的 namespace MAC，导致后续流量走错路。此规则确保只有 namespace 的 .1 ARP 能到达 VM-A。
+
+| `--arp-op Reply --arp-ip-src <gateway> --arp-mac-src ! <ns_mac> -j DROP`
+| 同上，但防护 ARP Reply 方向。物理网关或恶意设备发送的免费 ARP Reply（op=2, src-ip=.1）同样会污染 VM-A 的 ARP 表。
+|===
+
+==== eip-{PRI_ODEV}-arp（POSTROUTING）
+
+[cols="1,3",options="header"]
+|===
+| 规则 | 为什么需要
+
+| `--arp-op Request --arp-ip-dst <gateway> --arp-mac-src ! <vm_mac> -j DROP`
+| 无 EIP 的 VM-B 广播请求 .1 时，ARP Request 会到达 namespace 私网口。namespace 内核可能回复，导致 VM-B 学到 namespace MAC 而非物理网关 MAC。此规则阻止非对应 VM 的 ARP 到达 namespace。
+|===
+
+==== eip-{PUB_ODEV}-arp（POSTROUTING）
+
+[cols="1,3",options="header"]
+|===
+| 规则 | 为什么需要
+
+| `--arp-op Request --arp-ip-dst <gateway> --arp-mac-src ! <vm_mac> -j DROP`
+| 防止非 VM-A 的 .1 ARP 请求通过公网外侧口传播。纵深防御，与 `eip-{PRI_ODEV}-arp` 配合。
+|===
+
+=== 设计取舍
+
+[NOTE]
+====
+有 EIP 的 VM 对物理网关而言在私网层面是"不可达"的。物理网关直接发 ARP Request 查询 VM-A(.242) 时，`eip-vnic1.0-arp` 会 DROP 该包（GW_MAC ≠ NS_MAC）。这是 EIP 架构的设计取舍 —— 外部访问有 EIP 的 VM 必须通过 VIP（EIP 公网 IP）→ namespace 转发。同网段其他 VM（src-ip ≠ .1）的 ARP 不受影响。
+====
+
+== 场景验证矩阵
+
+以下验证矩阵覆盖了 EIP ebtables 规则在各种 ARP 场景下的预期行为，可作为测试用例参考。
+
+=== 基本 ARP 解析
+
+[cols="1,3,3,3,1",options="header"]
+|===
+| # | 场景 | 包路径 | 命中规则 | 结果
+
+| 1
+| VM-A(.242, 有EIP) 请求网关 .1
+| vnic1.0 入 → PREROUTING
+| `eip-vnic1.0-gw` arpreply
+| ✅ 得到 namespace MAC，原始包消费
+
+| 2
+| VM-A 请求 VM-B(.243)
+| vnic1.0 入 → PREROUTING
+| `-p ARP` 进入 `eip-vnic1.0-gw` → 不匹配 → RETURN → libvirt 放行
+| ✅ 正常广播
+
+| 3
+| VM-B(.243, 无EIP) 请求网关 .1
+| vnic2.0 入（无 EIP 链）→ 广播
+| 无 PREROUTING 拦截
+| ✅ 物理网关回复
+
+| 4
+| VM-B 请求 VM-A(.242)
+| vnic2.0 入 → 广播
+| 无拦截
+| ✅ VM-A 正常回复
+
+| 5
+| NS 请求 VM-A(.242)
+| a471aa10f_o 入
+| `eip-a471aa10f_o-gw` arpreply
+| ✅ 得到 VM MAC
+
+| 6
+| NS 请求 VM-B(.243)
+| a471aa10f_o 入
+| `eip-a471aa10f_o-gw` dnat src=.1 → 只到 VM-A（VM-B 收不到）
+| ✅ 被阻止
+|===
+
+=== 免费 ARP 防护
+
+[cols="1,3,3,3,1",options="header"]
+|===
+| # | 场景 | 包路径 | 命中规则 | 结果
+
+| 7
+| 物理网关 .1 免费 ARP Req → VM-A
+| 上行口入 → 出 vnic1.0
+| `eip-vnic1.0-arp` mac ≠ namespace → DROP
+| ✅ VM-A 不受影响
+
+| 8
+| 物理网关 .1 免费 ARP Reply → VM-A
+| 上行口入 → 出 vnic1.0
+| `eip-vnic1.0-arp` Reply 规则 DROP
+| ✅ VM-A 不受影响
+
+| 9
+| 物理网关 .1 免费 ARP → VM-B
+| 上行口入 → 出 vnic2.0
+| 无 EIP 链，正常通过
+| ✅ VM-B 正常学习物理网关 MAC
+
+| 10
+| NS 免费 ARP Req(.1→.1) 出 bridge
+| a471aa10f_o 入
+| `eip-a471aa10f_o-gw` dnat src=.1 → 只到 VM-A（无害）
+| ✅ 不泄漏到其他 VM
+
+| 11
+| NS 免费 ARP Reply(.1→.1) 出 bridge
+| a471aa10f_o 入
+| `eip-a471aa10f_o-gw` dnat src=.1 → 只到 VM-A（无害）
+| ✅ 不泄漏到其他 VM
+|===
+
+=== Namespace 隔离
+
+[cols="1,3,3,3,1",options="header"]
+|===
+| # | 场景 | 包路径 | 命中规则 | 结果
+
+| 12
+| VM-B 请求 .1 → 到达 NS
+| 广播 → 出 a471aa10f_o
+| `eip-a471aa10f_o-arp` mac ≠ VM-A → DROP
+| ✅ 不到达 NS
+
+| 13
+| NS 回复 VM-A 的 ARP
+| a471aa10f_o 入
+| `eip-a471aa10f_o-gw` dnat src=.1 → 目标 MAC 改为 VM-A
+| ✅ 正常到达
+
+| 14
+| NS 回复 VM-B 的 ARP(.1→.243)
+| a471aa10f_o 入
+| `eip-a471aa10f_o-gw` dnat src=.1 → 目标 MAC 改为 VM-A（VM-B 收不到）
+| ✅ VM-B 不会学到 NS MAC
+|===
+
+=== 物理网关直通与跨 Namespace
+
+[cols="1,3,3,3,1",options="header"]
+|===
+| # | 场景 | 包路径 | 命中规则 | 结果
+
+| 15
+| 物理网关(.1, GW_MAC) 请求 VM-A(.242)
+| 上行口入 → 出 vnic1.0
+| `eip-vnic1.0-arp` src=.1, mac=GW_MAC ≠ NS → DROP
+| ⚠️ 不可达（设计取舍）
+
+| 16
+| 另一 NS(.1, NS2_MAC) ARP 广播 → VM-A
+| NS2 外侧口入 → 广播 → 出 vnic1.0
+| `eip-vnic1.0-arp` src=.1, mac=NS2 ≠ NS → DROP
+| ✅ VM-A 不会学到其他 NS 的 MAC
+|===
+
+**场景 15 说明**：物理网关（IP=.1, MAC=GW_MAC）直接对有 EIP 的 VM 发 ARP Request 会被 `eip-vnic1.0-arp` 拦截，因为物理网关的 MAC 不等于 namespace MAC。这是 EIP 架构的**设计取舍** —— 有 EIP 的 VM 的网关是 namespace，物理网关无法通过私网 IP 直接 L2 访问该 VM。外部访问走 EIP 公网 IP → namespace 转发；同网段其他 VM 或物理机（src-ip ≠ .1）的 ARP 不受影响。
+
+**场景 16 说明**：同一 bridge 上另一个 EIP namespace（NS2）的 ARP（src-ip=.1, src-mac=NS2_MAC）理论上不会到达 bridge 广播（被 NS2 自身 PREROUTING 链 `eip-{NS2_o}-gw` DROP），此处 `eip-vnic1.0-arp` 提供纵深防御，确保 VM-A 不会误学到 NS2 的 MAC。
+
+=== Anti-spoof 配合
+
+[cols="1,3,3,3,1",options="header"]
+|===
+| # | 场景 | 包路径 | 命中规则 | 结果
+
+| 17
+| VM-A 伪造 src 请求网关 .1
+| vnic1.0 入
+| `-p ARP` 进入 `eip-vnic1.0-gw` → arpreply 消费
+| ⚠️ 伪造包不广播，仅得到网关 MAC
+
+| 18
+| VM-A 伪造 src 请求 .243
+| vnic1.0 入
+| `-p ARP` 进入 `eip-vnic1.0-gw` dst 不匹配 → RETURN → libvirt DROP
+| ✅ 被拦截
+
+| 19
+| VM-A 正常请求 .243
+| vnic1.0 入
+| `-p ARP` 进入 `eip-vnic1.0-gw` RETURN → libvirt 放行
+| ✅ 正常广播
+
+| 20
+| VM-A 发送非 ARP 帧
+| vnic1.0 入 → PREROUTING
+| `-p ARP` 不匹配 → 跳过 EIP 链 → libvirt anti-spoof
+| ✅ 零开销通过
+|===

--- a/installation/install.sh
+++ b/installation/install.sh
@@ -1094,7 +1094,7 @@ do_check_system(){
 
         # kill zstack if it's still running
         ZSTACK_PID=`ps aux | grep 'appName=zstack' | grep -v 'grep' | awk '{ print $2 }'`
-        [ ! -z $ZSTACK_PID ] && pkill -9 $ZSTACK_PID
+        [ ! -z "$ZSTACK_PID" ] && kill -9 $ZSTACK_PID
     elif [ ! -d $ZSTACK_INSTALL_ROOT -a ! -f $ZSTACK_INSTALL_ROOT ]; then
         fail "$ZSTACK_INSTALL_ROOT does not exist, maybe you need to install a new ${PRODUCT_NAME} instead of upgrading an old one."
     fi
@@ -4684,6 +4684,10 @@ setup_install_param
 
 #Delete old monitoring data if NEED_DROP_DB
 if [ -n "$NEED_DROP_DB" ]; then
+  # Stop mn process before dropping DB to avoid DB operation failures
+  zstack-ctl stop_node 2>/dev/null || true
+  ZSTACK_PID=`ps aux | grep 'appName=zstack' | grep -v 'grep' | awk '{ print $2 }'`
+  [ -n "$ZSTACK_PID" ] && kill -9 $ZSTACK_PID 2>/dev/null || true
   kill -9 `ps aux | grep "/var/lib/zstack/prometheus/data" | grep -v 'grep' | awk -F ' ' '{ print $2 }'` 2>/dev/null
   pkill -9 influxd 2>/dev/null
   rm -rf /var/lib/zstack/prometheus/data/*

--- a/kvmagent/ansible/kvm.py
+++ b/kvmagent/ansible/kvm.py
@@ -214,12 +214,12 @@ def install_kvm_pkg():
 
         releasever_mapping = {
             'c74': 'qemu-kvm',
-            'c76': 'qemu-kvm libvirt-admin seabios-bin nping elfutils-libelf-devel freeipmi',
-            'c79': 'qemu-kvm libvirt-admin seabios-bin nping elfutils-libelf-devel freeipmi',
+            'c76': 'qemu-kvm libvirt-admin seabios-bin nping elfutils-libelf-devel freeipmi collectd-disk',
+            'c79': 'qemu-kvm libvirt-admin seabios-bin nping elfutils-libelf-devel freeipmi collectd-disk',
             'h76c': ('%s qemu-kvm libvirt-admin seabios-bin nping freeipmi '
-                     'elfutils-libelf-devel vconfig OVMF libicu') % helix_rhel_rpms,
+                     'elfutils-libelf-devel vconfig OVMF libicu collectd-disk') % helix_rhel_rpms,
             'h79c': ('%s qemu-kvm libvirt-admin seabios-bin nping freeipmi '
-                     'elfutils-libelf-devel vconfig OVMF libicu') % helix_rhel_rpms,
+                     'elfutils-libelf-devel vconfig OVMF libicu collectd-disk') % helix_rhel_rpms,
             'h84r': ('%s qemu-kvm libvirt-daemon libvirt-daemon-kvm freeipmi '
                      'seabios-bin elfutils-libelf-devel collectd-disk lldpd tcpdump') % helix_rhel_rpms,
             'uos20r': ('%s qemu-kvm libvirt-daemon libvirt-daemon-kvm freeipmi '

--- a/kvmagent/docs/flat-eip-ebtables-fix.md
+++ b/kvmagent/docs/flat-eip-ebtables-fix.md
@@ -1,0 +1,377 @@
+# 扁平网络 EIP ebtables 规则问题分析与修复方案
+
+## 1. 网络拓扑
+
+```text
+                    [物理交换机 / 物理网关 GW_MAC=xx:xx, IP=192.168.2.1]
+                              |
+                         [上行口 vxlan489]
+                              |
+                    =====[br_vx_489 (扁平网络 bridge)]==============================
+                    |              |              |              |
+                 vnic1.0        vnic2.0        vnic3.0       a471aa10f_o
+                 (VM-A)         (VM-B)         (VM-C)        (NS私网外侧)
+                 有EIP          无EIP          无EIP              |
+                 .242           .243           .244          a471aa10f_i
+                 网关=.1        网关=.1        网关=.1        (NS网关接口 .1)
+                                                                  |
+                                                             a471aa10f_ei (EIP .210)
+                                                                  |
+                                                             a471aa10f_eo
+                                                                  |
+                                                            [br_zsn0_31 公网bridge]
+```
+
+关键约束：**所有 VM 的网关都是 192.168.2.1**。有 EIP 的 VM 需要解析到 namespace MAC，无 EIP 的 VM 需要解析到物理网关 MAC。同一个 bridge 上，同一个网关 IP，不同 VM 需要不同的 MAC。
+
+同网段还有物理服务器等非虚拟化设备直连物理交换机，必须能与所有 VM 正常通信。
+
+---
+
+## 2. 发现的问题
+
+### 问题 #1：libvirt anti-spoof 规则顺序导致 EIP 的 ARP 拦截失效
+
+**文件**：`kvmagent/kvmagent/plugins/deip.py` 第 365 行
+
+**现象**：`set_gateway_arp_if_needed()` 使用 `-A`（append）将 EIP 的 PREROUTING 规则追加到链尾，排在 libvirt anti-spoof 规则之后：
+
+```text
+-A PREROUTING -i vnic1.0 -j libvirt-I-vnic1.0   ← libvirt 先加，排在前面
+-A PREROUTING -i vnic1.0 -j vnic1.0-gw           ← EIP 后加，排在后面
+```
+
+libvirt 链末尾有 `-p ARP -j ACCEPT`，ARP 包在 libvirt 链里就被 ACCEPT，永远到不了 EIP 的 `vnic1.0-gw` 链。
+
+**后果**：
+- VM-A 请求网关 .1 的 ARP 不会被 arpreply 拦截，而是正常广播
+- 物理网关回复自己的 MAC，VM-A 学到错误的网关 MAC，流量不走 namespace
+- 原始 ARP Request 广播到 bridge 所有端口，包括上行口和其他 namespace
+
+**对比**：IPv6 版本 `set_gateway_arp_if_needed_v6()`（第 396 行）已经使用 `at_head=True`，IPv4 版本漏掉了。
+
+### 问题 #2：kvmagent 重启删除 EIP ebtables 规则
+
+**文件**：`kvmagent/kvmagent/plugins/mevoco.py` 第 1460 行
+
+**现象**：`connect()` 方法（kvmagent 重连 MN 时调用）调用 `restore_ebtables_chain_except_kvmagent()`，该函数只保留匹配以下模式的链：
+
+```python
+patterns={"nat":["libvirt","(^z|^s)[0-9]*_"], "filter":["(^z|^s)[0-9]*_|^vr"]}
+```
+
+EIP 创建的链名（`vnic31.0-gw`、`a471aa10f_o-gw`、`a471aa10f_o-arp` 等）不匹配任何模式，全部被清除。
+
+**后果**：每次 kvmagent 重连 MN，EIP 的所有 ebtables 规则被清空。虽然 MN 会重新下发 EIP 配置，但中间存在规则空窗期，导致网络中断。
+
+### 问题 #3：缺少 ARP Reply 过滤（含免费 ARP）
+
+**文件**：`kvmagent/kvmagent/plugins/deip.py`
+
+**现象**：当前所有 POSTROUTING 和 PREROUTING 过滤规则只匹配 `--arp-op Request`，不匹配 `--arp-op Reply`。
+
+**后果 3a — 冒充网关的免费 ARP Reply 穿透到有 EIP 的 VM**：
+
+物理网络上有设备冒充 192.168.2.1 发送免费 ARP Reply（op=2），`vnic1.0-arp` 链只检查 `--arp-op Request`，Reply 不匹配，直接到达 VM-A，污染其 ARP 表。
+
+**后果 3b — namespace 的免费 ARP Reply 泄漏到 bridge**：
+
+namespace 接口 up 时内核可能发免费 ARP Reply（src-ip=.1, dst-ip=.1）。`a471aa10f_o-gw` 链只 DROP `--arp-op Request`，Reply 穿透到 bridge 广播到所有端口。VM-B/C 收到后可能把 .1 的 MAC 更新为 namespace MAC，导致跨网段流量走错路。
+
+**后果 3c — namespace 回复非对应 VM 的 ARP**：
+
+VM-B 广播请求 .1 的 ARP，请求到达 namespace，namespace 内核回复 ARP Reply（dst=.243）。`a471aa10f_o-gw` 链不过滤 Reply，回复穿透到 bridge，VM-B 学到 namespace 的 MAC 而非物理网关的 MAC。
+
+### 问题 #4：EIP arpreply 规则绕过 libvirt anti-spoof 检查
+
+**现象**：修复问题 #1 后，EIP 链排在 libvirt 前面。`eip-vnic1.0-gw` 链的 arpreply 规则只检查 `--arp-ip-dst`（目标 IP），不检查源 MAC 和源 IP：
+
+```text
+-A eip-vnic1.0-gw -p ARP --arp-op Request --arp-ip-dst 192.168.2.1 -j arpreply --arpreply-mac ...
+```
+
+VM 内部伪造 ARP（假 src-mac/src-ip，dst-ip=网关），arpreply 匹配并消费了包，libvirt anti-spoof 没有机会检查。
+
+**决策：不修复**。原因：
+1. **实际影响极小**：arpreply 消费了原始包，伪造的 ARP 不会广播到网络上，VM 得到的只是网关 MAC（本来就应该知道的信息）。
+2. **添加源检查会破坏无反欺诈场景**：如果 arpreply 规则加上 `--arp-mac-src` 和 `--arp-ip-src`，当关闭 libvirt anti-spoof 时，云主机修改了 MAC 或 IP 后将无法解析网关，导致 EIP 不可用。
+
+### 问题 #5：ebtables 用户自定义链默认策略为 ACCEPT，导致 libvirt anti-spoof 被绕过
+
+**文件**：`kvmagent/kvmagent/plugins/deip.py`
+
+**现象**：ebtables 与 iptables 不同，用户自定义链（通过 `-N` 创建）的默认策略是 **ACCEPT** 而非隐式 RETURN。代码中所有 EIP 链只做了 `-N` 创建，未设置策略。
+
+以 `eip-vnic1.0-gw` 为例，修复 #1 后该链排在 libvirt 前面，且跳转规则不限协议：
+
+```text
+-I PREROUTING -i vnic1.0 -j eip-vnic1.0-gw       ← 所有帧都进入
+  eip-vnic1.0-gw (policy: ACCEPT)                  ← 不匹配的包直接 ACCEPT
+    -p ARP --arp-op Request ... -j arpreply         ← 只有一条规则
+```
+
+**后果**：所有从 vnic1.0 进入的非 ARP 帧（IP 数据包等）以及不匹配 arpreply 的 ARP 包，全部命中默认策略 ACCEPT，**libvirt anti-spoof 链完全被绕过**。VM 可以任意伪造 MAC/IP 发送流量。
+
+**影响范围**：5 条 EIP 用户自定义链全部受影响，但 `eip-vnic1.0-gw` 是唯一**必须修复**的（后面有 libvirt 链需要检查），其余 4 条后面无 libvirt 链，功能上 ACCEPT 和 RETURN 等价。
+
+---
+
+## 3. 修复方案
+
+### 修复 #1：PREROUTING 插入顺序 + 跳转限定 ARP + 链策略 RETURN
+
+**文件**：`deip.py` `set_gateway_arp_if_needed()` 函数
+
+**改动 1a**：PREROUTING 跳转规则加 `at_head=True` + 限定 `-p ARP`：
+
+```python
+# 修改前：
+create_ebtable_rule_if_needed('nat', 'PREROUTING', '-i {{NIC_NAME}} -j {{CHAIN_NAME}}')
+
+# 修改后：
+create_ebtable_rule_if_needed('nat', 'PREROUTING', '-p ARP -i {{NIC_NAME}} -j {{CHAIN_NAME}}', at_head=True)
+```
+
+`-p ARP` 确保非 ARP 帧根本不进 EIP 链，直接到 libvirt 做 anti-spoof 检查。与 POSTROUTING 的 3 条跳转（已带 `-p ARP`）风格统一。
+
+**改动 1b**：链创建后立即设置策略为 RETURN：
+
+```python
+if bash_r(EBTABLES_CMD + ' -t nat -L {{CHAIN_NAME}} > /dev/null 2>&1') != 0:
+    bash_errorout(EBTABLES_CMD + ' -t nat -N {{CHAIN_NAME}}')
+bash_errorout(EBTABLES_CMD + ' -t nat -P {{CHAIN_NAME}} RETURN')
+```
+
+双重保险：即使 `-p ARP` 被绕过（不会发生），RETURN 策略也保证不匹配的包返回 PREROUTING 继续处理。所有 5 条 EIP 链统一设为 RETURN。
+
+**设计原理**：EIP 链和 libvirt anti-spoof 链通过两层机制串联配合：
+
+```text
+PREROUTING 处理流程:
+
+  -p ARP -i vnic1.0 -j eip-vnic1.0-gw  （只有 ARP 进入）
+    eip-vnic1.0-gw (policy: RETURN)
+      职责：只做一件事 — 请求网关 → arpreply
+      不匹配的 ARP → 命中 RETURN 策略 → 回到 PREROUTING 继续
+         ↓
+  非 ARP 帧不匹配 -p ARP，直接到下一条:
+  -i vnic1.0 -j libvirt-I-vnic1.0  （anti-spoof 链）
+    职责：验证源 MAC 和源 IP 合法性
+    不合法 → DROP
+    合法 → RETURN
+         ↓
+  PREROUTING policy ACCEPT
+```
+
+两个链零耦合。`-p ARP` 过滤 + RETURN 策略是双重保险，任意一层都足以防止绕过 libvirt。
+
+### 修复 #2：EIP 链统一前缀 + restore 保留
+
+**涉及文件**：`deip.py`（链名加前缀）、`mevoco.py`（patterns 加匹配）
+
+**改动 2a**：`deip.py` 中所有 EIP ebtables 链名加 `eip-` 前缀：
+
+| 当前链名 | 重命名后 |
+|---|---|
+| `{NIC_NAME}-gw` | `eip-{NIC_NAME}-gw` |
+| `{PRI_ODEV}-gw` | `eip-{PRI_ODEV}-gw` |
+| `{PRI_ODEV}-arp` | `eip-{PRI_ODEV}-arp` |
+| `{PUB_ODEV}-arp` | `eip-{PUB_ODEV}-arp` |
+| `{NIC_NAME}-arp` | `eip-{NIC_NAME}-arp` |
+
+最长链名 `eip-a471aa10f_eo-arp` = 23 字符，在 ebtables 31 字符限制内。
+
+需要修改的函数：
+- `set_gateway_arp_if_needed()`：`CHAIN_NAME`、`BLOCK_CHAIN_NAME` 构造
+- `set_gateway_arp_if_needed_v6()`：`CHAIN_NAME` 构造
+- `add_filter_to_prevent_namespace_arp_request()`：`PRI_ODEV_CHAIN` 构造
+- `delete_arp_rules()`：`CHAIN_NAME`、`PRI_ODEV_CHAIN`、`BLOCK_CHAIN_NAME` 构造
+
+**改动 2b**：`mevoco.py` 第 1460 行，patterns 增加 `"^eip-"`：
+
+```python
+# 修改前：
+patterns={"nat":["libvirt","(^z|^s)[0-9]*_"], "filter":["(^z|^s)[0-9]*_|^vr"]}
+
+# 修改后：
+patterns={"nat":["libvirt","(^z|^s)[0-9]*_","^eip-"], "filter":["(^z|^s)[0-9]*_|^vr"]}
+```
+
+**选择统一前缀而非正则匹配现有名称的理由**：
+- 与代码库现有约定一致（`USERDATA-` 前缀、`libvirt` 前缀、`z/s` 前缀）
+- 消除 deip.py 和 mevoco.py 之间的隐式耦合，建立显式契约
+- 未来 EIP 新增任何链，只要用 `eip-` 前缀就自动被保留
+- 正则简单不可能写错：`"^eip-"` vs `"^[0-9a-f]+_(e?o)-(gw|arp)$"`
+
+**升级兼容**：无需额外迁移逻辑。kvmagent 升级重启时，`restore_ebtables_chain_except_kvmagent()` 清理旧链（旧链名无前缀，不匹配任何保留模式），MN 重新下发 EIP 配置后 `apply_eip()` 用新前缀重建所有链。
+
+### 修复 #3：增加 ARP Reply 过滤
+
+**文件**：`deip.py`
+
+**改动 3a**：`set_gateway_arp_if_needed()` 函数，`vnic1.0-arp` 链增加 Reply 过滤：
+
+```python
+# 现有规则（拦截冒充网关的 ARP Request）：
+create_ebtable_rule_if_needed('nat', BLOCK_CHAIN_NAME,
+    "-p ARP -o {{NIC_NAME}} --arp-op Request --arp-ip-src {{NIC_GATEWAY}} --arp-mac-src ! {{GATEWAY_MAC}} -j DROP")
+
+# 新增规则（拦截冒充网关的 ARP Reply，含免费 ARP Reply）：
+create_ebtable_rule_if_needed('nat', BLOCK_CHAIN_NAME,
+    "-p ARP -o {{NIC_NAME}} --arp-op Reply --arp-ip-src {{NIC_GATEWAY}} --arp-mac-src ! {{GATEWAY_MAC}} -j DROP")
+```
+
+**改动 3b**：`add_filter_to_prevent_namespace_arp_request()` 函数，跳转限定 `-p ARP` + 链策略 RETURN + `a471aa10f_o-gw` 链增加 Reply 过滤：
+
+```python
+# 跳转规则加 -p ARP：
+create_ebtable_rule_if_needed('nat', 'PREROUTING', '-p ARP -i {{PRI_ODEV}} -j {{PRI_ODEV_CHAIN}}')
+
+# 链创建后设策略 RETURN：
+bash_errorout(EBTABLES_CMD + ' -t nat -P {{PRI_ODEV_CHAIN}} RETURN')
+
+# 现有规则：
+create_ebtable_rule_if_needed('nat', PRI_ODEV_CHAIN,
+    "-p ARP --arp-op Request --arp-ip-dst {{NIC_IP}} -j arpreply --arpreply-mac {{NIC_MAC_IN_EBTALES}}", True)
+create_ebtable_rule_if_needed('nat', PRI_ODEV_CHAIN,
+    "-p ARP --arp-ip-src {{NIC_GATEWAY}} -j dnat --to-destination {{NIC_MAC}}")
+
+# 兜底 DROP 所有未匹配 ARP（dnat 规则已隐式处理 namespace 回复对应 VM 的 Reply）：
+create_ebtable_rule_if_needed('nat', PRI_ODEV_CHAIN, "-p ARP -j DROP")
+```
+
+---
+
+## 4. 修复后完整 ebtables 规则表
+
+以 VM-A（vnic1.0, .242, 有EIP）为例，所有链名已加 `eip-` 前缀：
+
+```text
+*nat
+:PREROUTING ACCEPT
+:OUTPUT ACCEPT
+:POSTROUTING ACCEPT
+
+# ==================== PREROUTING ====================
+
+# EIP 链（-I 插入链头，排在 libvirt 前面）
+# jump 时加 -p ARP：非 ARP 不进入链，直接 PREROUTING 下一条（libvirt）
+-I PREROUTING -p ARP -i vnic1.0 -j eip-vnic1.0-gw
+
+# libvirt anti-spoof（已存在，不修改）:
+# -A PREROUTING -i vnic1.0 -j libvirt-I-vnic1.0
+
+# namespace 私网外侧入口（同样加 -p ARP）
+-A PREROUTING -p ARP -i a471aa10f_o -j eip-a471aa10f_o-gw
+
+# --- eip-vnic1.0-gw (policy: RETURN) ---
+# 请求网关 → arpreply 回复 namespace MAC（不检查源，见问题#4 决策说明）
+# 不匹配 → RETURN 回 PREROUTING → libvirt anti-spoof 继续检查
+-A eip-vnic1.0-gw -p ARP --arp-op Request \
+   --arp-ip-dst 192.168.2.1 \
+   -j arpreply --arpreply-mac f6:dc:24:e8:92:6e
+
+# --- eip-a471aa10f_o-gw (policy: RETURN) ---
+# namespace 请求 VM-A IP → arpreply 回复 VM-A MAC
+-I eip-a471aa10f_o-gw -p ARP --arp-op Request --arp-ip-dst 192.168.2.242 \
+   -j arpreply --arpreply-mac fa:3a:a0:c5:74:0
+# namespace 网关 IP 的 ARP（含 Reply、免费 ARP）→ dnat 修改目标 MAC → VM-A 收到
+-A eip-a471aa10f_o-gw -p ARP --arp-ip-src 192.168.2.1 \
+   -j dnat --to-dst fa:3a:a0:c5:74:0
+# 其他所有 ARP → DROP
+-A eip-a471aa10f_o-gw -p ARP -j DROP
+
+# ==================== POSTROUTING ====================
+
+# 规则通过“先删后插头（-I）”保证最终位于 POSTROUTING 最前，避免被其他规则抢先命中
+-I POSTROUTING -p ARP -o vnic1.0 -j eip-vnic1.0-arp
+-I POSTROUTING -p ARP -o a471aa10f_o -j eip-a471aa10f_o-arp
+-I POSTROUTING -p ARP -o a471aa10f_eo -j eip-a471aa10f_eo-arp
+
+# --- eip-vnic1.0-arp (policy: RETURN) ---
+# 拦截发往 VM-A 的冒充网关 .1 的 ARP（物理网关的 .1 ARP 也被拦截）
+-A eip-vnic1.0-arp -p ARP -o vnic1.0 --arp-op Request \
+   --arp-ip-src 192.168.2.1 --arp-mac-src ! f6:dc:24:e8:92:6e -j DROP
+-A eip-vnic1.0-arp -p ARP -o vnic1.0 --arp-op Reply \
+   --arp-ip-src 192.168.2.1 --arp-mac-src ! f6:dc:24:e8:92:6e -j DROP
+
+# --- eip-a471aa10f_o-arp (policy: RETURN) ---
+# 阻止非 VM-A 的网关 ARP 请求到达 namespace
+-A eip-a471aa10f_o-arp -p ARP -o a471aa10f_o --arp-op Request \
+   --arp-ip-dst 192.168.2.1 --arp-mac-src ! fa:3a:a0:c5:74:0 -j DROP
+
+# --- eip-a471aa10f_eo-arp (policy: RETURN) ---
+-A eip-a471aa10f_eo-arp -p ARP -o a471aa10f_eo --arp-op Request \
+   --arp-ip-dst 192.168.2.1 --arp-mac-src ! fa:3a:a0:c5:74:0 -j DROP
+```
+
+---
+
+## 5. 场景验证矩阵
+
+### 基本 ARP 解析
+
+| # | 场景 | 包路径 | 命中规则 | 结果 |
+|---|---|---|---|---|
+| 1 | VM-A(.242,有EIP) 请求网关 .1 | vnic1.0 入 → PREROUTING | `eip-vnic1.0-gw` arpreply | ✅ 得到 namespace MAC，原始包消费 |
+| 2 | VM-A 请求 VM-B(.243) | vnic1.0 入 → PREROUTING | `-p ARP` 进入 `eip-vnic1.0-gw` → 不匹配 → RETURN → libvirt 放行 | ✅ 正常广播 |
+| 3 | VM-B(.243,无EIP) 请求网关 .1 | vnic2.0 入（无EIP链）→ 广播 | 无 PREROUTING 拦截 | ✅ 物理网关回复 |
+| 4 | VM-B 请求 VM-A(.242) | vnic2.0 入 → 广播 | 无拦截 | ✅ VM-A 正常回复 |
+| 5 | NS 请求 VM-A(.242) | a471aa10f_o 入 | `eip-a471aa10f_o-gw` arpreply | ✅ 得到 VM MAC |
+| 6 | NS 请求 VM-B(.243) | a471aa10f_o 入 | `eip-a471aa10f_o-gw` dnat src=.1 → 只到VM-A（VM-B收不到） | ✅ 被阻止 |
+
+### 免费 ARP 防护
+
+| # | 场景 | 包路径 | 命中规则 | 结果 |
+|---|---|---|---|---|
+| 7 | 物理网关 .1 免费ARP Req → VM-A | 上行口入 → 出 vnic1.0 | `eip-vnic1.0-arp` mac≠namespace → DROP | ✅ VM-A 不受影响 |
+| 8 | 物理网关 .1 免费ARP Reply → VM-A | 上行口入 → 出 vnic1.0 | `eip-vnic1.0-arp` Reply 规则 DROP | ✅ VM-A 不受影响 |
+| 9 | 物理网关 .1 免费ARP → VM-B | 上行口入 → 出 vnic2.0 | 无EIP链，正常通过 | ✅ VM-B 正常学习物理网关 MAC |
+| 10 | NS 免费ARP Req(.1→.1) 出 bridge | a471aa10f_o 入 | `eip-a471aa10f_o-gw` dnat src=.1 → 只到VM-A（无害） | ✅ 不泄漏到其他VM |
+| 11 | NS 免费ARP Reply(.1→.1) 出 bridge | a471aa10f_o 入 | `eip-a471aa10f_o-gw` dnat src=.1 → 只到VM-A（无害） | ✅ 不泄漏到其他VM |
+
+### namespace 隔离
+
+| # | 场景 | 包路径 | 命中规则 | 结果 |
+|---|---|---|---|---|
+| 12 | VM-B 请求 .1 → 到达 NS | 广播 → 出 a471aa10f_o | `eip-a471aa10f_o-arp` mac≠VM-A → DROP | ✅ 不到达 NS |
+| 13 | NS 回复 VM-A 的 ARP | a471aa10f_o 入 | `eip-a471aa10f_o-gw` dnat src=.1 → 目标MAC改为VM-A | ✅ 正常到达 |
+| 14 | NS 回复 VM-B 的 ARP(.1→.243) | a471aa10f_o 入 | `eip-a471aa10f_o-gw` dnat src=.1 → 目标MAC改为VM-A（VM-B收不到） | ✅ VM-B 不会学到 NS MAC |
+
+### 物理网关直通与跨 namespace
+
+| # | 场景 | 包路径 | 命中规则 | 结果 |
+|---|---|---|---|---|
+| 15 | 物理网关(.1,GW_MAC) 请求 VM-A(.242) | 上行口入 → 出 vnic1.0 | `eip-vnic1.0-arp` src=.1, mac=GW_MAC≠NS → DROP | ⚠️ 不可达（设计取舍） |
+| 16 | 另一NS(.1,NS2_MAC) ARP广播 → VM-A | NS2外侧口入 → 广播 → 出 vnic1.0 | `eip-vnic1.0-arp` src=.1, mac=NS2≠NS → DROP | ✅ VM-A 不会学到其他NS的MAC |
+
+> **场景 15 说明**：物理网关（IP=.1, MAC=GW_MAC）直接对有 EIP 的 VM 发 ARP Request 会被 `eip-vnic1.0-arp` 拦截，因为物理网关的 MAC 不等于 namespace MAC。这是 EIP 架构的**设计取舍**——有 EIP 的 VM 的网关是 namespace，物理网关无法通过私网 IP 直接 L2 访问该 VM。外部访问走 EIP 公网 IP → namespace 转发；同网段其他 VM 或物理机（src-ip≠.1）的 ARP 不受影响。
+>
+> **场景 16 说明**：同一 bridge 上另一个 EIP namespace（NS2）的 ARP（src-ip=.1, src-mac=NS2_MAC）理论上不会到达 bridge 广播（被 NS2 自身 PREROUTING 链 `eip-{NS2_o}-gw` DROP），此处 `eip-vnic1.0-arp` 提供纵深防御，确保 VM-A 不会误学到 NS2 的 MAC。
+
+### anti-spoof 配合
+
+| # | 场景 | 包路径 | 命中规则 | 结果 |
+|---|---|---|---|---|
+| 17 | VM-A 伪造src请求网关 .1 | vnic1.0 入 | `-p ARP` 进入 `eip-vnic1.0-gw` → arpreply 消费（见问题#4） | ⚠️ 伪造包不广播，仅得到网关MAC |
+| 18 | VM-A 伪造src请求 .243 | vnic1.0 入 | `-p ARP` 进入 `eip-vnic1.0-gw` dst不匹配 → RETURN → libvirt DROP | ✅ 被拦截 |
+| 19 | VM-A 正常请求 .243 | vnic1.0 入 | `-p ARP` 进入 `eip-vnic1.0-gw` RETURN → libvirt 放行 | ✅ 正常广播 |
+| 20 | VM-A 发送非 ARP 帧 | vnic1.0 入 → PREROUTING | `-p ARP` 不匹配 → 跳过 EIP 链 → libvirt anti-spoof | ✅ 零开销通过 |
+
+---
+
+## 6. 改动清单
+
+| 文件 | 位置 | 改动内容 |
+|---|---|---|
+| `deip.py` | `set_gateway_arp_if_needed()` | PREROUTING jump 加 `-p ARP`，仅 ARP 帧进入 EIP 链 |
+| `deip.py` | `set_gateway_arp_if_needed()` | 所有 `-N` 后紧跟 `-P chain RETURN`，修复 ebtables 默认 ACCEPT 问题 |
+| `deip.py` | `set_gateway_arp_if_needed()` | POSTROUTING 三条 ARP jump 改为"先删后 `-I`"强制链头 |
+| `deip.py` | `set_gateway_arp_if_needed()` | `{NIC_NAME}-arp` 链增加 ARP Reply 过滤规则 |
+| `deip.py` | `set_gateway_arp_if_needed_v6()` | IPv6 链 `-N` 后紧跟 `-P chain RETURN` |
+| `deip.py` | `add_filter_to_prevent_namespace_arp_request()` | PREROUTING jump 加 `-p ARP`；`-N` 后设 `-P RETURN` |
+| `deip.py` | `add_filter_to_prevent_namespace_arp_request()` | `{PRI_ODEV}-gw` 链增加兜底 `-p ARP -j DROP`（dnat 规则隐式处理 Reply） |
+| `deip.py` | `delete_arp_rules()` | 兼容删除旧格式（`-i dev -j chain`）和新格式（`-p ARP -i dev -j chain`）PREROUTING 规则，改用无条件 `bash_r` |
+| `deip.py` | `delete_ipv6_rules()` | 简化为无条件 `bash_r` 删除，无需先 grep 检查 |
+| `deip.py` | 所有链名构造处（约20行） | 链名加 `eip-` 前缀 |
+| `mevoco.py` | 第738行 | patterns nat 列表已含 `"^eip-"`（无需修改） |

--- a/kvmagent/kvmagent/plugins/bmv2_gateway_agent/volume/helper.py
+++ b/kvmagent/kvmagent/plugins/bmv2_gateway_agent/volume/helper.py
@@ -34,16 +34,27 @@ class RbdImageOperator(object):
         def _install_or_upgrade_rpm(rpm_path):
             shell.call('rpm -Uvh %s' % rpm_path)
 
-        def _get_package_version(pkg_name, raise_exception=False):
+        def _get_package_version(pkg_name, fallback_pkg=None, raise_exception=False):
             _rc, version = commands.getstatusoutput('rpm -qa %s' % pkg_name)
+            actual_pkg = pkg_name
+
             if _rc or (not version and raise_exception):
-                raise exception.CephPackageNotFound(cmd=pkg_name)
-            return version
+                if fallback_pkg:
+                    logger.info("Package %s not found, trying %s..." % (pkg_name, fallback_pkg))
+                    _rc, version = commands.getstatusoutput('rpm -qa %s' % fallback_pkg)
+                    if _rc or not version:
+                        raise exception.CephPackageNotFound(cmd=fallback_pkg)
+                    else:
+                        logger.info("Found %s package, version %s" % (fallback_pkg, version))
+                        actual_pkg = fallback_pkg
+                else:
+                    raise exception.CephPackageNotFound(cmd=pkg_name)
+            return version, actual_pkg
 
-        ceph_version = _get_package_version("ceph", True)
-        current_rbd_nbd_version = _get_package_version("rbd-nbd")
+        ceph_version, ceph_pkg = _get_package_version("ceph", "ceph-common", True)
+        current_rbd_nbd_version, rbd_nbd_pkg = _get_package_version("rbd-nbd")
 
-        dest_rbd_nbd_version = ceph_version.replace("ceph", "rbd-nbd", 1)
+        dest_rbd_nbd_version = ceph_version.replace(ceph_pkg, "rbd-nbd", 1)
         _s, path = commands.getstatusoutput('find / -xdev -name \'%s\'.rpm | head -1' % dest_rbd_nbd_version)
 
         logger.info("current rbd-nbd version:%s , dest version: %s" % (current_rbd_nbd_version, dest_rbd_nbd_version))

--- a/kvmagent/kvmagent/plugins/deip.py
+++ b/kvmagent/kvmagent/plugins/deip.py
@@ -94,7 +94,7 @@ class Eip(object):
         dev_base_name = dev_base_name.replace(".", "_")
 
         NIC_NAME = nic_name
-        CHAIN_NAME = '%s-gw' % NIC_NAME
+        CHAIN_NAME = 'eip-%s-gw' % NIC_NAME
         NS_NAME = ns
         EIP_UUID = eip_uuid[-9:]
         PUB_ODEV = "%s_eo" % (EIP_UUID)
@@ -113,23 +113,25 @@ class Eip(object):
         def delete_arp_rules():
             if bash_r(EBTABLES_CMD + ' -t nat -L {{CHAIN_NAME}} >/dev/null 2>&1') == 0:
                 RULE = "-i {{NIC_NAME}} -j {{CHAIN_NAME}}"
-                if bash_r(EBTABLES_CMD + " -t nat -L PREROUTING | grep -- '{{RULE}}' > /dev/null") == 0:
-                    bash_errorout(EBTABLES_CMD + ' -t nat -D PREROUTING {{RULE}}')
+                bash_r(EBTABLES_CMD + " -t nat -D PREROUTING {{RULE}}")
+                RULE_ARP = "-p ARP -i {{NIC_NAME}} -j {{CHAIN_NAME}}"
+                bash_r(EBTABLES_CMD + " -t nat -D PREROUTING {{RULE_ARP}}")
 
                 bash_errorout(EBTABLES_CMD + ' -t nat -F {{CHAIN_NAME}}')
                 bash_errorout(EBTABLES_CMD + ' -t nat -X {{CHAIN_NAME}}')
 
-            PRI_ODEV_CHAIN = "{{PRI_ODEV}}-gw"
+            PRI_ODEV_CHAIN = "eip-{{PRI_ODEV}}-gw"
             if bash_r(EBTABLES_CMD + ' -t nat -L {{PRI_ODEV_CHAIN}} >/dev/null 2>&1') == 0:
                 RULE = "-i {{PRI_ODEV}} -j {{PRI_ODEV_CHAIN}}"
-                if bash_r(EBTABLES_CMD + " -t nat -L PREROUTING | grep -- '{{RULE}}' > /dev/null") == 0:
-                    bash_errorout(EBTABLES_CMD + ' -t nat -D PREROUTING {{RULE}}')
+                bash_r(EBTABLES_CMD + " -t nat -D PREROUTING {{RULE}}")
+                RULE_ARP = "-p ARP -i {{PRI_ODEV}} -j {{PRI_ODEV_CHAIN}}"
+                bash_r(EBTABLES_CMD + " -t nat -D PREROUTING {{RULE_ARP}}")
 
                 bash_errorout(EBTABLES_CMD + ' -t nat -F {{PRI_ODEV_CHAIN}}')
                 bash_errorout(EBTABLES_CMD + ' -t nat -X {{PRI_ODEV_CHAIN}}')
 
             for BLOCK_DEV in [PRI_ODEV, PUB_ODEV, NIC_NAME]:
-                BLOCK_CHAIN_NAME = '{{BLOCK_DEV}}-arp'
+                BLOCK_CHAIN_NAME = 'eip-{{BLOCK_DEV}}-arp'
 
                 if bash_r(EBTABLES_CMD + ' -t nat -L {{BLOCK_CHAIN_NAME}} > /dev/null 2>&1') == 0:
                     RULE = '-p ARP -o {{BLOCK_DEV}} -j {{BLOCK_CHAIN_NAME}}'
@@ -139,15 +141,48 @@ class Eip(object):
                     bash_errorout(EBTABLES_CMD + ' -t nat -F {{BLOCK_CHAIN_NAME}}')
                     bash_errorout(EBTABLES_CMD + ' -t nat -X {{BLOCK_CHAIN_NAME}}')
 
+            # cleanup legacy chain names (without eip- prefix)
+            OLD_CHAIN_NAME = '{{NIC_NAME}}-gw'
+            if bash_r(EBTABLES_CMD + ' -t nat -L {{OLD_CHAIN_NAME}} >/dev/null 2>&1') == 0:
+                OLD_RULE = "-i {{NIC_NAME}} -j {{OLD_CHAIN_NAME}}"
+                if bash_r(EBTABLES_CMD + " -t nat -L PREROUTING | grep -- '{{OLD_RULE}}' > /dev/null") == 0:
+                    bash_r(EBTABLES_CMD + ' -t nat -D PREROUTING {{OLD_RULE}}')
+                bash_r(EBTABLES_CMD + ' -t nat -F {{OLD_CHAIN_NAME}}')
+                bash_r(EBTABLES_CMD + ' -t nat -X {{OLD_CHAIN_NAME}}')
+
+            OLD_PRI_ODEV_CHAIN = "{{PRI_ODEV}}-gw"
+            if bash_r(EBTABLES_CMD + ' -t nat -L {{OLD_PRI_ODEV_CHAIN}} >/dev/null 2>&1') == 0:
+                OLD_RULE = "-i {{PRI_ODEV}} -j {{OLD_PRI_ODEV_CHAIN}}"
+                if bash_r(EBTABLES_CMD + " -t nat -L PREROUTING | grep -- '{{OLD_RULE}}' > /dev/null") == 0:
+                    bash_r(EBTABLES_CMD + ' -t nat -D PREROUTING {{OLD_RULE}}')
+                bash_r(EBTABLES_CMD + ' -t nat -F {{OLD_PRI_ODEV_CHAIN}}')
+                bash_r(EBTABLES_CMD + ' -t nat -X {{OLD_PRI_ODEV_CHAIN}}')
+
+            for BLOCK_DEV in [PRI_ODEV, PUB_ODEV, NIC_NAME]:
+                OLD_BLOCK_CHAIN = '{{BLOCK_DEV}}-arp'
+                if bash_r(EBTABLES_CMD + ' -t nat -L {{OLD_BLOCK_CHAIN}} > /dev/null 2>&1') == 0:
+                    OLD_RULE = '-p ARP -o {{BLOCK_DEV}} -j {{OLD_BLOCK_CHAIN}}'
+                    if bash_r(EBTABLES_CMD + " -t nat -L POSTROUTING | grep -- '{{OLD_RULE}}' > /dev/null") == 0:
+                        bash_r(EBTABLES_CMD + ' -t nat -D POSTROUTING {{OLD_RULE}}')
+                    bash_r(EBTABLES_CMD + ' -t nat -F {{OLD_BLOCK_CHAIN}}')
+                    bash_r(EBTABLES_CMD + ' -t nat -X {{OLD_BLOCK_CHAIN}}')
+
         @bash.in_bash
         def delete_ipv6_rules():
             if bash_r(EBTABLES_CMD + ' -t nat -L {{CHAIN_NAME}} >/dev/null 2>&1') == 0:
                 RULE = "-i {{NIC_NAME}} -j {{CHAIN_NAME}}"
-                if bash_r(EBTABLES_CMD + " -t nat -L PREROUTING | grep -- '{{RULE}}' > /dev/null") == 0:
-                    bash_errorout(EBTABLES_CMD + ' -t nat -D PREROUTING {{RULE}}')
+                bash_r(EBTABLES_CMD + ' -t nat -D PREROUTING {{RULE}}')
 
                 bash_errorout(EBTABLES_CMD + ' -t nat -F {{CHAIN_NAME}}')
                 bash_errorout(EBTABLES_CMD + ' -t nat -X {{CHAIN_NAME}}')
+            # cleanup legacy chain name (without eip- prefix)
+            OLD_CHAIN_NAME = '{{NIC_NAME}}-gw'
+            if bash_r(EBTABLES_CMD + ' -t nat -L {{OLD_CHAIN_NAME}} >/dev/null 2>&1') == 0:
+                OLD_RULE = "-i {{NIC_NAME}} -j {{OLD_CHAIN_NAME}}"
+                if bash_r(EBTABLES_CMD + " -t nat -L PREROUTING | grep -- '{{OLD_RULE}}' > /dev/null") == 0:
+                    bash_r(EBTABLES_CMD + ' -t nat -D PREROUTING {{OLD_RULE}}')
+                bash_r(EBTABLES_CMD + ' -t nat -F {{OLD_CHAIN_NAME}}')
+                bash_r(EBTABLES_CMD + ' -t nat -X {{OLD_CHAIN_NAME}}')
 
         delete_namespace()
         delete_outer_dev()
@@ -301,6 +336,37 @@ class Eip(object):
                     bash_errorout(EBTABLES_CMD + ' -t {{table}} -A {{chain}} {{rule}}')
 
         @bash.in_bash
+        def ensure_ebtable_rule_at_head(table, chain, rule):
+            if bash_r(EBTABLES_CMD + " -t {{table}} -L {{chain}} | grep -- '{{rule}}' > /dev/null") == 0:
+                bash_errorout(EBTABLES_CMD + " -t {{table}} -D {{chain}} {{rule}}")
+            bash_errorout(EBTABLES_CMD + ' -t {{table}} -I {{chain}} {{rule}}')
+
+        @bash.in_bash
+        def delete_ebtables_chain_if_exists(table, chain):
+            """Delete a legacy ebtables chain: remove jump rules from built-in chains, flush and delete."""
+            if bash_r(EBTABLES_CMD + ' -t {{table}} -L {{chain}} > /dev/null 2>&1') != 0:
+                return
+            # remove jump rules from PREROUTING
+            RULE = bash_o(EBTABLES_CMD + " -t {{table}} -L PREROUTING --Lx 2>/dev/null | grep -F -- '-j {{chain}}'").strip()
+            if RULE:
+                for line in RULE.splitlines():
+                    line = line.strip()
+                    if line:
+                        # line is like: -A PREROUTING ... -j chain
+                        rule_part = line.replace('-A PREROUTING ', '', 1)
+                        bash_r(EBTABLES_CMD + ' -t {{table}} -D PREROUTING ' + rule_part)
+            # remove jump rules from POSTROUTING
+            RULE = bash_o(EBTABLES_CMD + " -t {{table}} -L POSTROUTING --Lx 2>/dev/null | grep -F -- '-j {{chain}}'").strip()
+            if RULE:
+                for line in RULE.splitlines():
+                    line = line.strip()
+                    if line:
+                        rule_part = line.replace('-A POSTROUTING ', '', 1)
+                        bash_r(EBTABLES_CMD + ' -t {{table}} -D POSTROUTING ' + rule_part)
+            bash_r(EBTABLES_CMD + ' -t {{table}} -F {{chain}}')
+            bash_r(EBTABLES_CMD + ' -t {{table}} -X {{chain}}')
+
+        @bash.in_bash
         def set_eip_rules():
             DNAT_NAME = "DNAT-{{VIP}}"
             if bash_r('eval {{NS}} iptables-save | grep -w ":{{DNAT_NAME}}" > /dev/null') != 0:
@@ -357,12 +423,13 @@ class Eip(object):
 
         @bash.in_bash
         def set_gateway_arp_if_needed():
-            CHAIN_NAME = "{{NIC_NAME}}-gw"
+            CHAIN_NAME = "eip-{{NIC_NAME}}-gw"
 
             if bash_r(EBTABLES_CMD + ' -t nat -L {{CHAIN_NAME}} > /dev/null 2>&1') != 0:
                 bash_errorout(EBTABLES_CMD + ' -t nat -N {{CHAIN_NAME}}')
+            bash_errorout(EBTABLES_CMD + ' -t nat -P {{CHAIN_NAME}} RETURN')
 
-            create_ebtable_rule_if_needed('nat', 'PREROUTING', '-i {{NIC_NAME}} -j {{CHAIN_NAME}}')
+            ensure_ebtable_rule_at_head('nat', 'PREROUTING', '-p ARP -i {{NIC_NAME}} -j {{CHAIN_NAME}}')
             GATEWAY_MAC = bash_o("eval {{NS}} ip link show {{PRI_IDEV}} | awk '/link\/ether/{print $2}'").strip()
             if not GATEWAY_MAC:
                 raise Exception('cannot find the device[%s] in the namespace[%s]' % (PRI_IDEV, NS_NAME))
@@ -371,29 +438,40 @@ class Eip(object):
             create_ebtable_rule_if_needed('nat', CHAIN_NAME, "-p ARP --arp-op Request --arp-ip-dst {{NIC_GATEWAY}} -j arpreply --arpreply-mac {{GATEWAY_MAC}}")
 
             for BLOCK_DEV in [PRI_ODEV, PUB_ODEV]:
-                BLOCK_CHAIN_NAME = '{{BLOCK_DEV}}-arp'
+                BLOCK_CHAIN_NAME = 'eip-{{BLOCK_DEV}}-arp'
                 if bash_r(EBTABLES_CMD + ' -t nat -L {{BLOCK_CHAIN_NAME}} > /dev/null 2>&1') != 0:
                     bash_errorout(EBTABLES_CMD + ' -t nat -N {{BLOCK_CHAIN_NAME}}')
+                bash_errorout(EBTABLES_CMD + ' -t nat -P {{BLOCK_CHAIN_NAME}} RETURN')
 
-                create_ebtable_rule_if_needed('nat', 'POSTROUTING', "-p ARP -o {{BLOCK_DEV}} -j {{BLOCK_CHAIN_NAME}}")
+                ensure_ebtable_rule_at_head('nat', 'POSTROUTING', "-p ARP -o {{BLOCK_DEV}} -j {{BLOCK_CHAIN_NAME}}")
                 create_ebtable_rule_if_needed('nat', BLOCK_CHAIN_NAME, "-p ARP -o {{BLOCK_DEV}} --arp-op Request --arp-ip-dst {{NIC_GATEWAY}} --arp-mac-src ! {{NIC_MAC_IN_EBTALES}} -j DROP")
 
-            BLOCK_CHAIN_NAME = '{{NIC_NAME}}-arp'
+            BLOCK_CHAIN_NAME = 'eip-{{NIC_NAME}}-arp'
             if bash_r(EBTABLES_CMD + ' -t nat -L {{BLOCK_CHAIN_NAME}} > /dev/null 2>&1') != 0:
                 bash_errorout(EBTABLES_CMD + ' -t nat -N {{BLOCK_CHAIN_NAME}}')
+            bash_errorout(EBTABLES_CMD + ' -t nat -P {{BLOCK_CHAIN_NAME}} RETURN')
 
-            create_ebtable_rule_if_needed('nat', 'POSTROUTING', "-p ARP -o {{NIC_NAME}} -j {{BLOCK_CHAIN_NAME}}")
+            ensure_ebtable_rule_at_head('nat', 'POSTROUTING', "-p ARP -o {{NIC_NAME}} -j {{BLOCK_CHAIN_NAME}}")
             create_ebtable_rule_if_needed('nat', BLOCK_CHAIN_NAME,
                                           "-p ARP -o {{NIC_NAME}} --arp-op Request --arp-ip-src {{NIC_GATEWAY}} --arp-mac-src ! {{GATEWAY_MAC}} -j DROP")
+            create_ebtable_rule_if_needed('nat', BLOCK_CHAIN_NAME,
+                                          "-p ARP -o {{NIC_NAME}} --arp-op Reply --arp-ip-src {{NIC_GATEWAY}} --arp-mac-src ! {{GATEWAY_MAC}} -j DROP")
+
+            # cleanup legacy chain names (without eip- prefix)
+            delete_ebtables_chain_if_exists('nat', '{{NIC_NAME}}-gw')
+            for BLOCK_DEV in [PRI_ODEV, PUB_ODEV]:
+                delete_ebtables_chain_if_exists('nat', '{{BLOCK_DEV}}-arp')
+            delete_ebtables_chain_if_exists('nat', '{{NIC_NAME}}-arp')
 
         @bash.in_bash
         def set_gateway_arp_if_needed_v6():
-            CHAIN_NAME = "{{NIC_NAME}}-gw"
+            CHAIN_NAME = "eip-{{NIC_NAME}}-gw"
 
             if bash_r(EBTABLES_CMD + ' -t nat -L {{CHAIN_NAME}} > /dev/null 2>&1') != 0:
                 bash_errorout(EBTABLES_CMD + ' -t nat -N {{CHAIN_NAME}}')
+            bash_errorout(EBTABLES_CMD + ' -t nat -P {{CHAIN_NAME}} RETURN')
 
-            create_ebtable_rule_if_needed('nat', 'PREROUTING', '-i {{NIC_NAME}} -j {{CHAIN_NAME}}', at_head=True)
+            ensure_ebtable_rule_at_head('nat', 'PREROUTING', '-i {{NIC_NAME}} -j {{CHAIN_NAME}}')
             GATEWAY_MAC = bash_o("eval {{NS}} ip link show {{PRI_IDEV}} | awk '/link\/ether/{print $2}'").strip()
             if not GATEWAY_MAC:
                 raise Exception('cannot find the device[%s] in the namespace[%s]' % (PRI_IDEV, NS_NAME))
@@ -408,6 +486,8 @@ class Eip(object):
                                           "-p IPv6 --ip6-destination ff00::/8 -j ACCEPT")
             create_ebtable_rule_if_needed('nat', CHAIN_NAME,
                                           "-p IPv6 -j dnat --to-destination {{GATEWAY_MAC}}")
+            # cleanup legacy chain name (without eip- prefix)
+            delete_ebtables_chain_if_exists('nat', '{{NIC_NAME}}-gw')
 
         @bash.in_bash
         def enable_ipv6_forwarding():
@@ -469,15 +549,21 @@ class Eip(object):
             bash_r('ip netns exec {{NS_NAME}} ip neighbor add {{NIC_IP}} lladdr {{NIC_MAC}} dev {{PRI_IDEV}}')
 
             # add ebtales to prevent eip namaespace send arp request
-            PRI_ODEV_CHAIN = "{{PRI_ODEV}}-gw"
+            PRI_ODEV_CHAIN = "eip-{{PRI_ODEV}}-gw"
 
             if bash_r(EBTABLES_CMD + ' -t nat -L {{PRI_ODEV_CHAIN}} > /dev/null 2>&1') != 0:
                 bash_errorout(EBTABLES_CMD + ' -t nat -N {{PRI_ODEV_CHAIN}}')
+            bash_errorout(EBTABLES_CMD + ' -t nat -P {{PRI_ODEV_CHAIN}} RETURN')
 
-            create_ebtable_rule_if_needed('nat', 'PREROUTING', '-i {{PRI_ODEV}} -j {{PRI_ODEV_CHAIN}}')
+            create_ebtable_rule_if_needed('nat', 'PREROUTING', '-p ARP -i {{PRI_ODEV}} -j {{PRI_ODEV_CHAIN}}')
             create_ebtable_rule_if_needed('nat', PRI_ODEV_CHAIN,
                                           "-p ARP --arp-op Request --arp-ip-dst {{NIC_IP}} -j arpreply --arpreply-mac {{NIC_MAC_IN_EBTALES}}", True)
-            create_ebtable_rule_if_needed('nat', PRI_ODEV_CHAIN, "-p ARP --arp-op Request -j DROP")
+            create_ebtable_rule_if_needed('nat', PRI_ODEV_CHAIN, "-p ARP --arp-ip-src {{NIC_GATEWAY}} -j dnat --to-destination {{NIC_MAC}}")
+            create_ebtable_rule_if_needed('nat', PRI_ODEV_CHAIN, "-p ARP -j DROP")
+
+            # cleanup legacy chain name (without eip- prefix)
+            OLD_PRI_ODEV_CHAIN = "{{PRI_ODEV}}-gw"
+            delete_ebtables_chain_if_exists('nat', OLD_PRI_ODEV_CHAIN)
 
         newCreated = False
 
@@ -521,6 +607,9 @@ class Eip(object):
             # ping VIP gateway
             bash_r('eval {{NS}} arping -q -A -w 2 -c 3 -I {{PUB_IDEV}} {{VIP}} > /dev/null')
             set_gateway_arp_if_needed()
+            # send gratuitous ARP to update VM's gateway MAC cache,
+            # because the VM may have learned the physical gateway's MAC before EIP was applied
+            bash_r('eval {{NS}} arping -q -U -w 2 -c 3 -I {{PRI_IDEV}} {{NIC_GATEWAY}} > /dev/null')
             set_eip_rules()
             set_default_route_if_needed("ip")
             create_perf_monitor()

--- a/kvmagent/kvmagent/plugins/deip.py
+++ b/kvmagent/kvmagent/plugins/deip.py
@@ -4,6 +4,7 @@ from kvmagent import kvmagent
 from zstacklib.utils import http
 from zstacklib.utils import ip
 from zstacklib.utils import iproute
+from zstacklib.utils.iproute import NoSuchNamespace
 from zstacklib.utils import iptables
 from zstacklib.utils import jsonobject
 from zstacklib.utils import lock
@@ -102,7 +103,22 @@ class Eip(object):
 
         @bash.in_bash
         def delete_namespace():
-            iproute.IpNetnsShell(NS_NAME).del_netns()
+            def is_missing_namespace_error(err):
+                err_msg = str(err)
+                return (
+                    isinstance(err, NoSuchNamespace) or
+                    "No such file" in err_msg or
+                    "No such file or directory" in err_msg or
+                    "could not be found" in err_msg or
+                    "does not exist" in err_msg
+                )
+
+            try:
+                iproute.IpNetnsShell(NS_NAME).del_netns()
+            except Exception as err:
+                if is_missing_namespace_error(err):
+                    return
+                raise
 
         @bash.in_bash
         def delete_outer_dev():
@@ -117,8 +133,8 @@ class Eip(object):
                 RULE_ARP = "-p ARP -i {{NIC_NAME}} -j {{CHAIN_NAME}}"
                 bash_r(EBTABLES_CMD + " -t nat -D PREROUTING {{RULE_ARP}}")
 
-                bash_errorout(EBTABLES_CMD + ' -t nat -F {{CHAIN_NAME}}')
-                bash_errorout(EBTABLES_CMD + ' -t nat -X {{CHAIN_NAME}}')
+                bash_r(EBTABLES_CMD + ' -t nat -F {{CHAIN_NAME}}')
+                bash_r(EBTABLES_CMD + ' -t nat -X {{CHAIN_NAME}}')
 
             PRI_ODEV_CHAIN = "eip-{{PRI_ODEV}}-gw"
             if bash_r(EBTABLES_CMD + ' -t nat -L {{PRI_ODEV_CHAIN}} >/dev/null 2>&1') == 0:
@@ -127,8 +143,8 @@ class Eip(object):
                 RULE_ARP = "-p ARP -i {{PRI_ODEV}} -j {{PRI_ODEV_CHAIN}}"
                 bash_r(EBTABLES_CMD + " -t nat -D PREROUTING {{RULE_ARP}}")
 
-                bash_errorout(EBTABLES_CMD + ' -t nat -F {{PRI_ODEV_CHAIN}}')
-                bash_errorout(EBTABLES_CMD + ' -t nat -X {{PRI_ODEV_CHAIN}}')
+                bash_r(EBTABLES_CMD + ' -t nat -F {{PRI_ODEV_CHAIN}}')
+                bash_r(EBTABLES_CMD + ' -t nat -X {{PRI_ODEV_CHAIN}}')
 
             for BLOCK_DEV in [PRI_ODEV, PUB_ODEV, NIC_NAME]:
                 BLOCK_CHAIN_NAME = 'eip-{{BLOCK_DEV}}-arp'
@@ -136,10 +152,10 @@ class Eip(object):
                 if bash_r(EBTABLES_CMD + ' -t nat -L {{BLOCK_CHAIN_NAME}} > /dev/null 2>&1') == 0:
                     RULE = '-p ARP -o {{BLOCK_DEV}} -j {{BLOCK_CHAIN_NAME}}'
                     if bash_r(EBTABLES_CMD + " -t nat -L POSTROUTING | grep -- '{{RULE}}' > /dev/null") == 0:
-                        bash_errorout(EBTABLES_CMD + ' -t nat -D POSTROUTING {{RULE}}')
+                        bash_r(EBTABLES_CMD + ' -t nat -D POSTROUTING {{RULE}}')
 
-                    bash_errorout(EBTABLES_CMD + ' -t nat -F {{BLOCK_CHAIN_NAME}}')
-                    bash_errorout(EBTABLES_CMD + ' -t nat -X {{BLOCK_CHAIN_NAME}}')
+                    bash_r(EBTABLES_CMD + ' -t nat -F {{BLOCK_CHAIN_NAME}}')
+                    bash_r(EBTABLES_CMD + ' -t nat -X {{BLOCK_CHAIN_NAME}}')
 
             # cleanup legacy chain names (without eip- prefix)
             OLD_CHAIN_NAME = '{{NIC_NAME}}-gw'
@@ -173,8 +189,8 @@ class Eip(object):
                 RULE = "-i {{NIC_NAME}} -j {{CHAIN_NAME}}"
                 bash_r(EBTABLES_CMD + ' -t nat -D PREROUTING {{RULE}}')
 
-                bash_errorout(EBTABLES_CMD + ' -t nat -F {{CHAIN_NAME}}')
-                bash_errorout(EBTABLES_CMD + ' -t nat -X {{CHAIN_NAME}}')
+                bash_r(EBTABLES_CMD + ' -t nat -F {{CHAIN_NAME}}')
+                bash_r(EBTABLES_CMD + ' -t nat -X {{CHAIN_NAME}}')
             # cleanup legacy chain name (without eip- prefix)
             OLD_CHAIN_NAME = '{{NIC_NAME}}-gw'
             if bash_r(EBTABLES_CMD + ' -t nat -L {{OLD_CHAIN_NAME}} >/dev/null 2>&1') == 0:

--- a/kvmagent/kvmagent/plugins/ha_plugin.py
+++ b/kvmagent/kvmagent/plugins/ha_plugin.py
@@ -1530,7 +1530,7 @@ def get_runnning_vm_root_volume_on_ps(maxAttempts, strategy, mountPath, isFlushb
             continue
 
         on_storage_vm_uuids.append(vm.uuid)
-        if is_allow_fencer(host_storage_name, vm.uuid):
+        if not_exec_kill_vm(strategy, vm.uuid, host_storage_name):
             logger.debug("fencer detect ha strategy is %s skip fence vm[uuid:%s]" % (strategy, vm.uuid))
             continue
 

--- a/kvmagent/kvmagent/plugins/ha_plugin.py
+++ b/kvmagent/kvmagent/plugins/ha_plugin.py
@@ -902,17 +902,10 @@ class FileSystemHeartbeatController(AbstractStorageFencer):
                          (current_read_heartbeat_time[0], current_vm_uuids[0]))
             return current_read_heartbeat_time[0], current_vm_uuids[0]
 
-    def kill_vm(self):
-        r = bash.bash_r("timeout 5 virsh list")
-        if r == 0:
-            return kill_vm(self.max_attempts, self.strategy, [self.mount_path], True)
-        else:
-            return kill_vm_by_xml(self.max_attempts, self.strategy, self.mount_path, True)
-
     def check_storage_heartbeat(self):
         if self.write_fencer_heartbeat() is False:
             self.fencer_triggered_callback([self.ps_uuid], 'Disconnected')
-            killed_vms, on_storage_vm_uuids = self.kill_vm()
+            killed_vms, on_storage_vm_uuids = kill_vm_by_xml(self.max_attempts, self.strategy, self.mount_path, True)
 
             if len(killed_vms) != 0:
                 self.fencer_triggered_callback([self.ps_uuid], ','.join(killed_vms.keys()))
@@ -1001,7 +994,7 @@ class CephHeartbeatController(AbstractStorageFencer):
                 # for example, pool name is aaa
                 # add slash to confirm kill_vm matches vm with volume aaa/volume_path
                 # but not aaa_suffix/volume_path
-                vm_uuids, _ = kill_vm(self.max_attempts, self.strategy, ['%s/' % self.pool_name], False)
+                vm_uuids, _ = kill_vm_by_xml(self.max_attempts, self.strategy, '%s/' % self.pool_name, False)
                 if self.strategy == 'Permissive':
                     self.reset_failure_count()
 
@@ -1528,6 +1521,7 @@ def get_runnning_vm_root_volume_on_ps(maxAttempts, strategy, mountPath, isFlushb
 
         vm = linux.VmStruct()
         vm.uuid = xs[0]
+        vm.load_from_xml(xml)
         if not vm.root_volume:
             logger.warn("found strange vm[pid: %s, uuid: %s], can not find boot volume" % (vm.pid, vm.uuid))
             continue

--- a/kvmagent/kvmagent/plugins/ha_plugin.py
+++ b/kvmagent/kvmagent/plugins/ha_plugin.py
@@ -816,6 +816,7 @@ class FileSystemHeartbeatController(AbstractStorageFencer):
         self.fencer_triggered_callback = None
         self.try_remount_fs_callback = None
         self.created_time = None
+        self._writing_vm_uuid = False
 
     def prepare_dir(self, dir_path):
         if not self.mounted_by_zstack or linux.is_mounted(self.mount_path):
@@ -848,24 +849,31 @@ class FileSystemHeartbeatController(AbstractStorageFencer):
     def update_heartbeat_file(self):
         if self.touch_heartbeat_file() is False:
             return False
-        self.write_vm_uuid()
+        if not self._writing_vm_uuid:
+            self.write_vm_uuid()
         return True
 
     @thread.AsyncThread
     def write_vm_uuid(self):
-        heartbeat_file_path = self.get_heartbeat_file_path()
+        if self._writing_vm_uuid:
+            return
+        self._writing_vm_uuid = True
+        try:
+            heartbeat_file_path = self.get_heartbeat_file_path()
 
-        r = bash.bash_r("timeout 5 virsh list")
-        if r == 0:
-            vm_uuids = find_ps_running_vm(self.ps_uuid)
-        else:
-            _, vm_uuids = get_runnning_vm_root_volume_on_ps(self.max_attempts, self.strategy, self.mount_path, isFlushbufs=False, vm_uuid_only=True)
+            r = bash.bash_r("timeout 5 virsh list")
+            if r == 0:
+                vm_uuids = find_ps_running_vm(self.ps_uuid)
+            else:
+                _, vm_uuids = get_runnning_vm_root_volume_on_ps(self.max_attempts, self.strategy, self.mount_path, isFlushbufs=False, vm_uuid_only=True)
 
-        content = {"heartbeat_time": time.time(),
-                   "vm_uuids": None if len(vm_uuids) == 0 else ','.join(str(x) for x in vm_uuids)}
+            content = {"heartbeat_time": time.time(),
+                       "vm_uuids": None if len(vm_uuids) == 0 else ','.join(str(x) for x in vm_uuids)}
 
-        with open(heartbeat_file_path, 'w') as f:
-            f.write(json.dumps(content))
+            with open(heartbeat_file_path, 'w') as f:
+                f.write(json.dumps(content))
+        finally:
+            self._writing_vm_uuid = False
 
     def write_fencer_heartbeat(self):
         success_heartbeat = True

--- a/kvmagent/kvmagent/plugins/mevoco.py
+++ b/kvmagent/kvmagent/plugins/mevoco.py
@@ -1457,7 +1457,7 @@ tag:{{TAG}},option:dns-server,{{DNS}}
         ebtables_obj = EbtablesRules()
         fd, path = tempfile.mkstemp(".ebtables.dump")
         #ZSTAC-24684 restore the rule created by libvirt & zsn
-        patterns={"nat":["libvirt","(^z|^s)[0-9]*_"], "filter":["(^z|^s)[0-9]*_|^vr"]}
+        patterns={"nat":["libvirt","(^z|^s)[0-9]*_","^eip-"], "filter":["(^z|^s)[0-9]*_|^vr"]}
         restore_data = "\n".join(ebtables_obj.get_related_rules_re(patterns)) + "\n"
         logger.debug("restore ebtables: %s" % restore_data)
         with os.fdopen(fd, 'w') as fs:

--- a/kvmagent/kvmagent/plugins/mevoco.py
+++ b/kvmagent/kvmagent/plugins/mevoco.py
@@ -775,6 +775,46 @@ def getDhcpEbtableChainName(dhcpIp):
     else:
         return "ZSTACK-%s" % dhcpIp
 
+
+def get_ebtables_userdata_chain_name(br_name, l3_network_uuid):
+    # Note: In ebtables v1.8 and above, the maximum allowed length for certain string fields
+    # (e.g., --comment, --set-mark, custom chain names) is limited to 28 characters.
+    if is_ebtables_nf_tables():
+        max_chain_name_len = 28
+        prefix = "UD"
+        uuid_len = 8
+        separator_len = 2  # two '-' characters
+        max_br_len = max_chain_name_len - len(prefix) - separator_len - uuid_len
+        return "%s-%s-%s" % (prefix, br_name[-max_br_len:], l3_network_uuid[:uuid_len])
+    else:
+        return "USERDATA-%s-%s" % (br_name[-12:], l3_network_uuid[:8])
+
+def is_ebtables_nf_tables():
+    r, o, e = bash_roe(get_ebtables_cmd() + ' --version')
+    if r != 0:
+        raise Exception('Failed to get ebtables version')
+    return "nf_tables" in o
+
+
+def ensure_userdata_veth_pair(namespace_name, outer_dev, inner_dev, mtu):
+    outer_exist = linux.is_network_device_existing(outer_dev)
+    ns_shell = iproute.IpNetnsShell(namespace_name)
+    inner_exist = ns_shell.get_mac(inner_dev) is not None
+
+    if outer_exist != inner_exist:
+        if outer_exist:
+            iproute.delete_link_no_error(outer_dev)
+        if inner_exist:
+            ns_shell.del_link(inner_dev)
+        outer_exist = False
+        inner_exist = False
+
+    if not outer_exist and not inner_exist:
+        iproute.add_link(outer_dev, 'veth', peer=inner_dev)
+        iproute.set_link_attribute(outer_dev, mtu=mtu)
+        iproute.set_link_attribute(inner_dev, mtu=mtu)
+
+
 class UserDataEnv(object):
     def __init__(self, bridge_name, namespace_name, vlan_id):
         self.bridge_name = bridge_name
@@ -1599,10 +1639,7 @@ tag:{{TAG}},option:dns-server,{{DNS}}
             userdata_br_inner_dev = "ud_" + ns_inner_dev
             MAX_MTU = linux.MAX_MTU_OF_VNIC
 
-            if not linux.is_network_device_existing(userdata_br_outer_dev):
-                iproute.add_link(userdata_br_outer_dev, 'veth', peer=userdata_br_inner_dev)
-                iproute.set_link_attribute(userdata_br_outer_dev, mtu=MAX_MTU)
-                iproute.set_link_attribute(userdata_br_inner_dev, mtu=MAX_MTU)
+            ensure_userdata_veth_pair(ns, userdata_br_outer_dev, userdata_br_inner_dev, MAX_MTU)
 
             iproute.set_link_up(userdata_br_outer_dev)
 

--- a/kvmagent/kvmagent/plugins/prometheus.py
+++ b/kvmagent/kvmagent/plugins/prometheus.py
@@ -2792,7 +2792,8 @@ modules:
         if cmd.vlanId is not None and cmd.vlanId is not 0:
             dev_name = '%s.%s' % (cmd.interfaceName, cmd.vlanId)
 
-        register_service_type(dev_name, cmd.serviceType)
+        serviceType = [] if cmd.serviceType is None else cmd.serviceType
+        register_service_type(dev_name, serviceType)
         rsp.success = True
 
         return jsonobject.dumps(rsp)

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -1347,6 +1347,11 @@ def e(parent, tag, value=None, attrib=None, usenamesapce = False):
     return el
 
 
+def make_pmu_feature(cmd, features):
+    if hasattr(cmd, 'pmu') and cmd.pmu is False:
+        e(features, "pmu", attrib={'state': 'off'})
+
+
 def find_namespace_node(root, path, name):
     ns = {'zs': ZS_XML_NAMESPACE}
 
@@ -5424,6 +5429,8 @@ class Vm(object):
 
             if get_gic_version(cmd.cpuNum) == 2:
                 e(features, "gic", attrib={'version': '2'})
+
+            make_pmu_feature(cmd, features)
 
 
         def make_qemu_commandline():

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -2484,6 +2484,76 @@ def transform_to_tf_uuid(src):
     tmp = [src[:8], src[8:12], src[12:16], src[16:20], src[20:]]
     return '-'.join(tmp)
 
+
+def _make_usb_redirect_xml(devices, cmd, dist_name, host_arch):
+    """Build USB controllers and (optionally) redirdev XML on `devices`.
+
+    Extracted from ``Vm.to_xmlobject`` so the control flow can be
+    unit-tested without a full VM bring-up. ``dist_name`` and
+    ``host_arch`` are passed explicitly (rather than read from module
+    globals) so tests can drive the legacy aarch64 RPM-based branch.
+    """
+    e(devices, 'controller', None, {'type': 'usb', 'index': '0'})
+
+    # make sure there are three usb controllers, each for USB 1.1/2.0/3.0
+    @linux.on_redhat_based(dist_name)
+    @linux.with_arch(todo_list=['aarch64'], host_arch=host_arch)
+    def set_default():
+        # Old aarch64 RPM stacks (e.g. centos + qemu 2.12_0-18) only
+        # support default qemu-xhci 3.0 controllers; keep that layout
+        # as the safe baseline for the legacy combination.
+        e(devices, 'controller', None, {'type': 'usb', 'index': '1'})
+        e(devices, 'controller', None, {'type': 'usb', 'index': '2'})
+        return True
+
+    def set_usb2_3():
+        if host_arch == 'loongarch64':
+            e(devices, 'controller', None, {'type': 'usb', 'index': '1', 'model': 'nec-xhci'})
+        else:
+            e(devices, 'controller', None, {'type': 'usb', 'index': '1', 'model': 'ehci'})
+        e(devices, 'controller', None, {'type': 'usb', 'index': '2', 'model': 'nec-xhci'})
+
+        # USB2.0 Controller for redirect
+        if host_arch == 'loongarch64':
+            e(devices, 'controller', None, {'type': 'usb', 'index': '3', 'model': 'nec-xhci'})
+        else:
+            e(devices, 'controller', None, {'type': 'usb', 'index': '3', 'model': 'ehci'})
+        e(devices, 'controller', None, {'type': 'usb', 'index': '4', 'model': 'nec-xhci'})
+
+    def set_redirdev():
+        chan = e(devices, 'channel', None, {'type': 'spicevmc'})
+        e(chan, 'target', None, {'type': 'virtio', 'name': 'com.redhat.spice.0'})
+        e(chan, 'address', None, {'type': 'virtio-serial'})
+
+        redirdev1 = e(devices, 'redirdev', None, {'type': 'spicevmc', 'bus': 'usb'})
+        e(redirdev1, 'address', None, {'type': 'usb', 'bus': '3', 'port': '1'})
+        redirdev2 = e(devices, 'redirdev', None, {'type': 'spicevmc', 'bus': 'usb'})
+        e(redirdev2, 'address', None, {'type': 'usb', 'bus': '3', 'port': '2'})
+        redirdev3 = e(devices, 'redirdev', None, {'type': 'spicevmc', 'bus': 'usb'})
+        e(redirdev3, 'address', None, {'type': 'usb', 'bus': '4', 'port': '1'})
+        redirdev4 = e(devices, 'redirdev', None, {'type': 'spicevmc', 'bus': 'usb'})
+        e(redirdev4, 'address', None, {'type': 'usb', 'bus': '4', 'port': '2'})
+
+    not_colo_vm = not cmd.coloPrimary and not cmd.coloSecondary and not cmd.useColoBinary
+    need_redirdev = cmd.usbRedirect and not_colo_vm
+
+    if set_default():
+        if need_redirdev:
+            # set_default() only adds USB controllers 0/1/2 on the
+            # aarch64 RPM-based path. set_redirdev() addresses bus=3/4,
+            # so attach two more controllers using libvirt's default
+            # qemu-xhci -- modern aarch64 qemu (>= 6.2) supports
+            # usb-redir on it, and the default model avoids ehci /
+            # nec-xhci availability differences across aarch64 builds.
+            e(devices, 'controller', None, {'type': 'usb', 'index': '3'})
+            e(devices, 'controller', None, {'type': 'usb', 'index': '4'})
+            set_redirdev()
+        return
+    set_usb2_3()
+    if need_redirdev:
+        set_redirdev()
+
+
 class Vm(object):
     VIR_DOMAIN_NOSTATE = 0
     VIR_DOMAIN_RUNNING = 1
@@ -6209,52 +6279,7 @@ class Vm(object):
             e(chan, 'target', None, {'type': 'virtio', 'name': 'org.spice-space.webdav.0'})
 
         def make_usb_redirect():
-            devices = elements['devices']
-            e(devices, 'controller', None, {'type': 'usb', 'index': '0'})
-            # make sure there are three usb controllers, each for USB 1.1/2.0/3.0
-            @linux.on_redhat_based(DIST_NAME)
-            @linux.with_arch(todo_list=['aarch64'])
-            def set_default():
-                # for aarch64 centos, only support default controller(qemu-xhci 3.0) on current qemu version(2.12_0-18)
-                e(devices, 'controller', None, {'type': 'usb', 'index': '1'})
-                e(devices, 'controller', None, {'type': 'usb', 'index': '2'})
-                return True
-
-
-            def set_usb2_3():
-                if HOST_ARCH == 'loongarch64':
-                    e(devices, 'controller', None, {'type': 'usb', 'index': '1', 'model': 'nec-xhci'})
-                else:
-                    e(devices, 'controller', None, {'type': 'usb', 'index': '1', 'model': 'ehci'})
-                e(devices, 'controller', None, {'type': 'usb', 'index': '2', 'model': 'nec-xhci'})
-
-                # USB2.0 Controller for redirect
-                if HOST_ARCH == 'loongarch64':
-                    e(devices, 'controller', None, {'type': 'usb', 'index': '3', 'model': 'nec-xhci'})
-                else:
-                    e(devices, 'controller', None, {'type': 'usb', 'index': '3', 'model': 'ehci'})
-                e(devices, 'controller', None, {'type': 'usb', 'index': '4', 'model': 'nec-xhci'})
-
-            def set_redirdev():
-                chan = e(devices, 'channel', None, {'type': 'spicevmc'})
-                e(chan, 'target', None, {'type': 'virtio', 'name': 'com.redhat.spice.0'})
-                e(chan, 'address', None, {'type': 'virtio-serial'})
-
-                redirdev1 = e(devices, 'redirdev', None, {'type': 'spicevmc', 'bus': 'usb'})
-                e(redirdev1, 'address', None, {'type': 'usb', 'bus': '3', 'port': '1'})
-                redirdev2 = e(devices, 'redirdev', None, {'type': 'spicevmc', 'bus': 'usb'})
-                e(redirdev2, 'address', None, {'type': 'usb', 'bus': '3', 'port': '2'})
-                redirdev3 = e(devices, 'redirdev', None, {'type': 'spicevmc', 'bus': 'usb'})
-                e(redirdev3, 'address', None, {'type': 'usb', 'bus': '4', 'port': '1'})
-                redirdev4 = e(devices, 'redirdev', None, {'type': 'spicevmc', 'bus': 'usb'})
-                e(redirdev4, 'address', None, {'type': 'usb', 'bus': '4', 'port': '2'})
-
-            if set_default():
-                return
-            set_usb2_3()
-            not_colo_vm = not cmd.coloPrimary and not cmd.coloSecondary and not cmd.useColoBinary
-            if cmd.usbRedirect and not_colo_vm:
-                set_redirdev()
+            _make_usb_redirect_xml(elements['devices'], cmd, DIST_NAME, HOST_ARCH)
 
         def make_video():
             devices = elements['devices']

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -4111,8 +4111,8 @@ class Vm(object):
             _, disk_name = self._get_target_disk_by_path(oldpath)
             migrate_disks[disk_name] = volume
 
-        xml_changed = False
         tree = etree.ElementTree(etree.fromstring(self.get_migratable_xml()))
+        xml_changed = self._split_legacy_rbd_snapshot(tree.getroot())
         devices = tree.getroot().find('devices')
         for disk in tree.iterfind('devices/disk'):
             dev = disk.find('target').attrib['dev']
@@ -4127,6 +4127,32 @@ class Vm(object):
             return migrate_disks.keys(), etree.tostring(tree.getroot())
         else:
             return None, None
+
+    @staticmethod
+    def _split_legacy_rbd_snapshot(root):
+        xml_changed = False
+        for disk in root.iterfind('devices/disk'):
+            if disk.get('type') != 'network':
+                continue
+
+            source = disk.find('source')
+            if source is None or source.get('protocol') != 'rbd':
+                continue
+
+            name = source.get('name')
+            if not name or '@' not in name:
+                continue
+
+            image_name, snapshot_name = name.rsplit('@', 1)
+            if not image_name or not snapshot_name:
+                continue
+
+            source.set('name', image_name)
+            if source.find('snapshot') is None:
+                etree.SubElement(source, 'snapshot', {'name': snapshot_name})
+            xml_changed = True
+
+        return xml_changed
 
     MIGRATE_VM_TASK_NAME = "MigrateVm"
     @staticmethod

--- a/kvmagent/kvmagent/test/localstorage_testsuite/test_data_volume_with_iothreadpin.py
+++ b/kvmagent/kvmagent/test/localstorage_testsuite/test_data_volume_with_iothreadpin.py
@@ -29,6 +29,16 @@ class TestVolumeWithIoThreadPin(TestCase, vm_utils.VmPluginTestStub):
     def setUpClass(cls):
         network_utils.create_default_bridge_if_not_exist()
 
+    def tearDown(self):
+        # Clean up VM resources to avoid polluting subsequent test runs
+        if self.vm_uuid:
+            try:
+                pid = linux.find_vm_pid_by_uuid(self.vm_uuid)
+                if pid:
+                    vm_utils.destroy_vm(self.vm_uuid)
+            except Exception as e:
+                logger.warning("tearDown cleanup failed for vm[%s]: %s", self.vm_uuid, str(e))
+
     @pytest.mark.run(order=1)
     @pytest_utils.ztest_decorater
     def test_virtio_volum(self):
@@ -181,29 +191,27 @@ class TestVolumeWithIoThreadPin(TestCase, vm_utils.VmPluginTestStub):
         virtio_scsi_vol_iothread_pin = "1"
         virtio_scsi_vol_uuid, virtio_scsi_vol_path = volume_utils.create_empty_volume()
 
-        vm_uuid, vm = self._create_vm()
+        self.vm_uuid, vm = self._create_vm()
 
-
-
-        _, virtio_vol = vm_utils.attach_iothreadpin_volume_to_vm(vm_uuid,
+        _, virtio_vol = vm_utils.attach_iothreadpin_volume_to_vm(self.vm_uuid,
                                                                  virtio_vol_uuid,
                                                                  virtio_vol_path,
                                                                  virtio_vol_iothread_id,
                                                                  virtio_vol_iothread_pin)
-        _, virtio_scsi_vol = vm_utils.attach_virtio_scsi_iothread_volume_to_vm(vm_uuid,
+        _, virtio_scsi_vol = vm_utils.attach_virtio_scsi_iothread_volume_to_vm(self.vm_uuid,
                                                                                virtio_scsi_vol_uuid,
                                                                                virtio_scsi_vol_path,
                                                                                virtio_scsi_vol_iothread_id,
                                                                                virtio_scsi_vol_iothread_pin)
 
-        rsp = vm_utils.check_volume(vm_uuid, [virtio_vol, virtio_scsi_vol])
+        rsp = vm_utils.check_volume(self.vm_uuid, [virtio_vol, virtio_scsi_vol])
         self.assertTrue(rsp.success)
-        self.check_volume_iothread_pin(vm_uuid, virtio_vol_path, virtio_vol_iothread_id)
-        self.check_virtio_scsi_volume_config(vm_uuid, virtio_scsi_vol_path, virtio_scsi_vol_iothread_id)
+        self.check_volume_iothread_pin(self.vm_uuid, virtio_vol_path, virtio_vol_iothread_id)
+        self.check_virtio_scsi_volume_config(self.vm_uuid, virtio_scsi_vol_path, virtio_scsi_vol_iothread_id)
 
-        vm_utils.stop_vm(vm_uuid)
-        pid = linux.find_vm_pid_by_uuid(vm_uuid)
-        self.assertTrue(not pid, 'vm[%s] vm still running' % vm_uuid)
+        vm_utils.stop_vm(self.vm_uuid)
+        pid = linux.find_vm_pid_by_uuid(self.vm_uuid)
+        self.assertTrue(not pid, 'vm[%s] vm still running' % self.vm_uuid)
 
         controller_index = "2"
         virtio_vol_body, virtio_pin = vm_utils.build_virtio_vol_with_iothreadpin(virtio_vol_uuid, virtio_vol_path, virtio_vol_iothread_id, virtio_vol_iothread_pin)
@@ -212,34 +220,34 @@ class TestVolumeWithIoThreadPin(TestCase, vm_utils.VmPluginTestStub):
         vm = vm_utils.create_vm_with_vols([virtio_vol_body, virtio_scsi_vol_body], [virtio_pin, virtio_scsi_pin])
         vm_utils.create_vm(vm)
         self.vm_uuid = vm.vmInstanceUuid
-        pid = linux.find_vm_pid_by_uuid(vm_uuid)
-        self.assertFalse(not pid, 'cannot find pid of vm[%s]' % vm_uuid)
+        pid = linux.find_vm_pid_by_uuid(self.vm_uuid)
+        self.assertFalse(not pid, 'cannot find pid of vm[%s]' % self.vm_uuid)
 
-        rsp = vm_utils.check_volume(vm_uuid, [virtio_vol, virtio_scsi_vol])
+        rsp = vm_utils.check_volume(self.vm_uuid, [virtio_vol, virtio_scsi_vol])
         self.assertTrue(rsp.success)
-        self.check_volume_iothread_pin(vm_uuid, virtio_vol_path, virtio_vol_iothread_id)
-        self.check_virtio_scsi_volume_config(vm_uuid, virtio_scsi_vol_path, virtio_scsi_vol_iothread_id)
+        self.check_volume_iothread_pin(self.vm_uuid, virtio_vol_path, virtio_vol_iothread_id)
+        self.check_virtio_scsi_volume_config(self.vm_uuid, virtio_scsi_vol_path, virtio_scsi_vol_iothread_id)
 
-        rsp = vm_utils.detach_volume_from_vm(vm_uuid, virtio_vol)
+        rsp = vm_utils.detach_volume_from_vm(self.vm_uuid, virtio_vol)
         self.assertTrue(rsp.success)
-        xml = vm_utils.get_vm_xmlobject_from_virsh_dump(vm_uuid)
+        xml = vm_utils.get_vm_xmlobject_from_virsh_dump(self.vm_uuid)
         vol_xml = volume_utils.find_volume_in_vm_xml_by_path(xml, virtio_vol_path)
         self.assertIsNone(vol_xml)
 
-        rsp = vm_utils.detach_volume_from_vm(vm_uuid, virtio_scsi_vol)
+        rsp = vm_utils.detach_volume_from_vm(self.vm_uuid, virtio_scsi_vol)
         self.assertTrue(rsp.success)
-        xml = vm_utils.get_vm_xmlobject_from_virsh_dump(vm_uuid)
+        xml = vm_utils.get_vm_xmlobject_from_virsh_dump(self.vm_uuid)
         vol_xml = volume_utils.find_volume_in_vm_xml_by_path(xml, virtio_scsi_vol_path)
         self.assertIsNone(vol_xml)
 
-        vm_utils.del_vm_scsi_controller(vm_uuid, virtio_scsi_vol_iothread_id)
-        vm_utils.del_iothread_pin(vm_uuid, virtio_scsi_vol_iothread_id)
-        vm_utils.del_iothread_pin(vm_uuid, virtio_vol_iothread_id)
+        vm_utils.del_vm_scsi_controller(self.vm_uuid, virtio_scsi_vol_iothread_id)
+        vm_utils.del_iothread_pin(self.vm_uuid, virtio_scsi_vol_iothread_id)
+        vm_utils.del_iothread_pin(self.vm_uuid, virtio_vol_iothread_id)
 
-        rsp = vm_utils.check_volume(vm_uuid, [virtio_vol, virtio_scsi_vol])
+        rsp = vm_utils.check_volume(self.vm_uuid, [virtio_vol, virtio_scsi_vol])
         self.assertFalse(rsp.success)
 
-        vm_utils.destroy_vm(vm_uuid)
-        pid = linux.find_vm_pid_by_uuid(vm_uuid)
-        self.assertTrue(not pid, 'vm[%s] vm still running' % vm_uuid)
+        vm_utils.destroy_vm(self.vm_uuid)
+        pid = linux.find_vm_pid_by_uuid(self.vm_uuid)
+        self.assertTrue(not pid, 'vm[%s] vm still running' % self.vm_uuid)
 

--- a/kvmagent/kvmagent/test/localstorage_testsuite/test_resize_volume.py
+++ b/kvmagent/kvmagent/test/localstorage_testsuite/test_resize_volume.py
@@ -12,6 +12,9 @@ __ENV_SETUP__ = {
     'self': {}
 }
 
+TEMPLATE_PATH = "/root/.zguest/min-vm.qcow2"
+LOCAL_PS_PATH = "/local_ps"
+
 
 ## describe: case will manage by ztest
 class TestLocalStoragePlugin(TestCase):
@@ -19,27 +22,34 @@ class TestLocalStoragePlugin(TestCase):
     @classmethod
     def setUpClass(cls):
         return
+
+    def tearDown(self):
+        # Always clean up localstorage path to avoid polluting subsequent runs
+        bash.bash_ro("rm -rf %s" % LOCAL_PS_PATH)
+
     @pytest_utils.ztest_decorater
     def test_resize_volume(self):
-        rsp = localstorage_utils.localstorage_init(
-            "/local_ps"
-        )
+        if not os.path.exists(TEMPLATE_PATH):
+            self.skipTest("Template %s not found on this node, skip" % TEMPLATE_PATH)
+
+        rsp = localstorage_utils.localstorage_init(LOCAL_PS_PATH)
         self.assertGreater(rsp.totalCapacity, 0, rsp.error)
         self.assertGreater(rsp.availableCapacity, 0, rsp.error)
 
+        install_url = os.path.join(LOCAL_PS_PATH, "test/test.qcow2")
+
         rsp = localstorage_utils.create_root_volume_from_template(
-            templatePathInCache = "/root/.zguest/min-vm.qcow2",
-            installUrl = "/local_ps/test/test.qcow2",
-            storagePath = "/local_ps"
+            templatePathInCache=TEMPLATE_PATH,
+            installUrl=install_url,
+            storagePath=LOCAL_PS_PATH
         )
 
-        self.assertEqual(True, os.path.exists("/local_ps/test/test.qcow2"), "[check] cannot find rootvolume in host")
+        self.assertTrue(os.path.exists(install_url), "[check] cannot find rootvolume in host")
 
         rsp = localstorage_utils.resize_volume(
-            installPath="/local_ps/test/test.qcow2",
+            installPath=install_url,
             size=5242880,
             force=True
         )
 
-        self.assertEqual(5242880, rsp.size , "[check] cannot resize_volume in host")
-        bash.bash_ro("rm -rf /local_ps")
+        self.assertEqual(5242880, rsp.size, "[check] cannot resize_volume in host")

--- a/kvmagent/kvmagent/test/test_deip.py
+++ b/kvmagent/kvmagent/test/test_deip.py
@@ -38,28 +38,29 @@ def _make_eip(ipVersion=4):
 def _make_fake_process(executed_cmds):
     """Create a fake shell.get_process that captures resolved commands."""
 
-    def fake_get_process(cmd_path, pipe=True):
+    def fake_get_process(*args, **kwargs):
+        cmd_path = args[0] if args else kwargs.get("cmd_path")
         proc = mock.MagicMock()
 
-        def communicate(cmd_str):
-            executed_cmds.append(cmd_str)
+        def communicate(*args, **kwargs):
+            executed_cmds.append(cmd_path)
             # ip link show -> return a MAC for GATEWAY_MAC resolution
-            if "ip link show" in cmd_str and "awk" in cmd_str:
+            if "ip link show" in cmd_path and "awk" in cmd_path:
                 proc.returncode = 0
                 return ("    link/ether aa:bb:cc:dd:ee:ff brd ff:ff:ff:ff:ff:ff\n", "")
             # ip -o -f inet addr show -> return a CIDR for perf monitor
-            if "ip -o -f inet addr show" in cmd_str:
+            if "ip -o -f inet addr show" in cmd_path:
                 proc.returncode = 0
                 return (
                     "2: eth0    inet 10.0.0.100/24 brd 10.0.0.255 scope global eth0\n",
                     "",
                 )
             # ip -o -f inet6 addr show
-            if "ip -o -f inet6 addr show" in cmd_str:
+            if "ip -o -f inet6 addr show" in cmd_path:
                 proc.returncode = 0
                 return ("2: eth0    inet6 fd00::100/64 scope global\n", "")
             # ebtables -L ... --Lx -> return empty (no existing jump rules to old chains)
-            if "--Lx" in cmd_str:
+            if "--Lx" in cmd_path:
                 proc.returncode = 0
                 return ("", "")
             # default: success with empty output
@@ -423,6 +424,9 @@ class _DeleteEipTestBase(unittest.TestCase):
 
         self.patcher_iproute = mock.patch("kvmagent.plugins.deip.iproute")
         self.mock_iproute = self.patcher_iproute.start()
+        self.mock_iproute.IpNetnsShell.list_netns.return_value = [
+            "br_eth0_192_168_1_100"
+        ]
 
         self.patcher_linux = mock.patch("kvmagent.plugins.deip.linux")
         self.mock_linux = self.patcher_linux.start()
@@ -517,6 +521,63 @@ class TestDeleteIpv6RulesLegacyCleanup(_DeleteEipTestBase):
             len(legacy_cmds) > 0,
             "Expected cleanup for legacy 'vnic1.0-gw' in IPv6 delete path",
         )
+
+
+class TestDeleteEipWithMissingNamespace(unittest.TestCase):
+    def _call_delete_eip_with_ns(self, del_netns_side_effect=None):
+        patchers = [
+            mock.patch("kvmagent.plugins.deip.iproute"),
+            mock.patch("kvmagent.plugins.deip.linux"),
+            mock.patch("zstacklib.utils.shell.get_process"),
+        ]
+        mock_iproute = patchers[0].start()
+        mock_linux = patchers[1].start()
+        mock_get_process = patchers[2].start()
+        try:
+            mock_linux.is_network_device_existing.return_value = False
+            mock_get_process.side_effect = _make_fake_process([])
+            mock_iproute.IpNetnsShell.return_value.del_netns.side_effect = (
+                del_netns_side_effect
+            )
+
+            eip_cmd = Eip()
+            method = type(eip_cmd).delete_eip_with_ns
+            inspect.unwrap(method)(
+                eip_cmd,
+                ns="br_eth0_192_168_1_100",
+                eip_uuid="abcdef123456789",
+                version=4,
+                nic_name="vnic1.0",
+            )
+
+            mock_iproute.IpNetnsShell.return_value.del_netns.assert_called_once()
+        finally:
+            for patcher in patchers:
+                patcher.stop()
+
+    def test_missing_namespace_is_idempotent(self):
+        self._call_delete_eip_with_ns(
+            del_netns_side_effect=Exception(
+                'Cannot remove namespace file "/run/netns/br_eth0_192_168_1_100": '
+                "No such file or directory"
+            )
+        )
+
+    def test_missing_namespace_exception_is_idempotent(self):
+        self._call_delete_eip_with_ns(
+            del_netns_side_effect=Exception(
+                "Network namespace : br_eth0_192_168_1_100 could not be found."
+            )
+        )
+
+    def test_unexpected_namespace_delete_error_is_raised(self):
+        with self.assertRaisesRegex(Exception, "Permission denied"):
+            self._call_delete_eip_with_ns(
+                del_netns_side_effect=Exception(
+                    'Cannot remove namespace file "/run/netns/br_eth0_192_168_1_100": '
+                    "Permission denied"
+                )
+            )
 
 
 if __name__ == "__main__":

--- a/kvmagent/kvmagent/test/test_deip.py
+++ b/kvmagent/kvmagent/test/test_deip.py
@@ -1,0 +1,523 @@
+import inspect
+import unittest
+import mock
+
+from kvmagent.plugins.deip import Eip
+
+
+def _make_eip(ipVersion=4):
+    eip = mock.MagicMock()
+    eip.nicName = "vnic1.0"
+    eip.eipUuid = "abcdef123456789"
+    eip.publicBridgeName = "br_eth0"
+    eip.vmBridgeName = "br_eth1"
+    eip.vip = "192.168.1.100"
+    eip.vipNetmask = "255.255.255.0"
+    eip.vipGateway = "192.168.1.1"
+    eip.vipPrefixLen = 64
+    eip.nicGateway = "10.0.0.1"
+    eip.nicNetmask = "255.255.255.0"
+    eip.nicPrefixLen = 24
+    eip.nicIp = "10.0.0.100"
+    eip.nicMac = "00:0c:29:aa:bb:cc"
+    eip.vmUuid = "vm-uuid-1234"
+    eip.vipUuid = "vip-uuid-5678"
+    eip.ipVersion = ipVersion
+    eip.addfdb = False
+    eip.physicalNic = "eth0"
+    eip.skipArpCheck = True
+    return eip
+
+
+# EIP_UUID[-9:] = '123456789'
+# PUB_ODEV = '123456789_eo', PUB_IDEV = '123456789_ei'
+# PRI_ODEV = '123456789_o',  PRI_IDEV = '123456789_i'
+# NIC_NAME = 'vnic1.0'
+
+
+def _make_fake_process(executed_cmds):
+    """Create a fake shell.get_process that captures resolved commands."""
+
+    def fake_get_process(cmd_path, pipe=True):
+        proc = mock.MagicMock()
+
+        def communicate(cmd_str):
+            executed_cmds.append(cmd_str)
+            # ip link show -> return a MAC for GATEWAY_MAC resolution
+            if "ip link show" in cmd_str and "awk" in cmd_str:
+                proc.returncode = 0
+                return ("    link/ether aa:bb:cc:dd:ee:ff brd ff:ff:ff:ff:ff:ff\n", "")
+            # ip -o -f inet addr show -> return a CIDR for perf monitor
+            if "ip -o -f inet addr show" in cmd_str:
+                proc.returncode = 0
+                return (
+                    "2: eth0    inet 10.0.0.100/24 brd 10.0.0.255 scope global eth0\n",
+                    "",
+                )
+            # ip -o -f inet6 addr show
+            if "ip -o -f inet6 addr show" in cmd_str:
+                proc.returncode = 0
+                return ("2: eth0    inet6 fd00::100/64 scope global\n", "")
+            # ebtables -L ... --Lx -> return empty (no existing jump rules to old chains)
+            if "--Lx" in cmd_str:
+                proc.returncode = 0
+                return ("", "")
+            # default: success with empty output
+            proc.returncode = 0
+            return ("", "")
+
+        proc.communicate = communicate
+        proc.returncode = 0
+        return proc
+
+    return fake_get_process
+
+
+# Patches common to all apply_eip tests
+_APPLY_PATCHES = [
+    mock.patch("kvmagent.plugins.deip.EBTABLES_CMD", "ebtables"),
+    mock.patch("kvmagent.plugins.deip.IPTABLES_CMD", "iptables"),
+    mock.patch("kvmagent.plugins.deip.IP6TABLES_CMD", "ip6tables"),
+    mock.patch(
+        "kvmagent.plugins.deip.ip.removeZeroFromMacAddress",
+        return_value="0:c:29:aa:bb:cc",
+    ),
+]
+
+
+class _ApplyEipTestBase(unittest.TestCase):
+    """Base class that sets up mocks and runs apply_eip, capturing all shell commands."""
+
+    IP_VERSION = 4  # override in subclass for v6
+
+    def setUp(self):
+        self.executed_cmds = []
+
+        # Start common patches
+        self._patchers = [p for p in _APPLY_PATCHES]
+        self._patchers.append(
+            mock.patch(
+                "zstacklib.utils.shell.get_process",
+                side_effect=_make_fake_process(self.executed_cmds),
+            )
+        )
+        for p in self._patchers:
+            p.start()
+
+        # Mock iproute
+        self.patcher_iproute = mock.patch("kvmagent.plugins.deip.iproute")
+        self.mock_iproute = self.patcher_iproute.start()
+        self.mock_iproute.IpNetnsShell.list_netns.return_value = []
+        self.mock_iproute.IpNetnsShell.return_value.get_mac.return_value = (
+            None  # force create
+        )
+
+        # Mock linux
+        self.patcher_linux = mock.patch("kvmagent.plugins.deip.linux")
+        self.mock_linux = self.patcher_linux.start()
+        self.mock_linux.is_network_device_existing.return_value = False
+        self.mock_linux.netmask_to_cidr.return_value = 24
+        self.mock_linux.MAX_MTU_OF_VNIC = 65000
+
+        # Run the undecorated method so tests don't depend on real file/thread locks.
+        eip = _make_eip(ipVersion=self.IP_VERSION)
+        eip_cmd = Eip()
+        self._call_unwrapped_method(eip_cmd, "apply_eip", eip)
+
+    def tearDown(self):
+        for p in self._patchers:
+            p.stop()
+        self.patcher_iproute.stop()
+        self.patcher_linux.stop()
+
+    def _has_cmd(self, pattern):
+        return any(pattern in cmd for cmd in self.executed_cmds)
+
+    def _cmds_matching(self, pattern):
+        return [cmd for cmd in self.executed_cmds if pattern in cmd]
+
+    def _call_unwrapped_method(self, obj, method_name, *args, **kwargs):
+        method = getattr(type(obj), method_name)
+        inspect.unwrap(method)(obj, *args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Test: eip- prefix on chain names
+# ---------------------------------------------------------------------------
+class TestApplyEipChainNames(_ApplyEipTestBase):
+    def test_gateway_arp_chain_uses_eip_prefix(self):
+        """set_gateway_arp_if_needed should create chain 'eip-vnic1.0-gw'."""
+        self.assertTrue(
+            self._has_cmd("eip-vnic1.0-gw"),
+            "Expected 'eip-vnic1.0-gw' in commands:\n"
+            + "\n".join(self._cmds_matching("vnic1.0")),
+        )
+
+    def test_block_arp_chains_use_eip_prefix(self):
+        """Block ARP chains should have eip- prefix."""
+        self.assertTrue(
+            self._has_cmd("eip-123456789_o-arp"),
+            "Expected 'eip-123456789_o-arp' (PRI_ODEV)",
+        )
+        self.assertTrue(
+            self._has_cmd("eip-123456789_eo-arp"),
+            "Expected 'eip-123456789_eo-arp' (PUB_ODEV)",
+        )
+        self.assertTrue(
+            self._has_cmd("eip-vnic1.0-arp"), "Expected 'eip-vnic1.0-arp' (NIC_NAME)"
+        )
+
+    def test_pri_odev_filter_chain_uses_eip_prefix(self):
+        """add_filter_to_prevent_namespace_arp_request should use 'eip-123456789_o-gw'."""
+        self.assertTrue(
+            self._has_cmd("eip-123456789_o-gw"),
+            "Expected 'eip-123456789_o-gw' (PRI_ODEV filter chain)",
+        )
+
+
+class TestApplyEipPostroutingOrder(_ApplyEipTestBase):
+    def test_postrouting_arp_jumps_are_inserted_at_head(self):
+        expected = [
+            "-I POSTROUTING -p ARP -o vnic1.0 -j eip-vnic1.0-arp",
+            "-I POSTROUTING -p ARP -o 123456789_o -j eip-123456789_o-arp",
+            "-I POSTROUTING -p ARP -o 123456789_eo -j eip-123456789_eo-arp",
+        ]
+
+        for rule in expected:
+            self.assertTrue(
+                self._has_cmd(rule),
+                "Expected POSTROUTING ARP jump at head: %s" % rule,
+            )
+
+    def test_postrouting_arp_jumps_try_to_reorder_existing_rules(self):
+        expected = [
+            "-D POSTROUTING -p ARP -o vnic1.0 -j eip-vnic1.0-arp",
+            "-D POSTROUTING -p ARP -o 123456789_o -j eip-123456789_o-arp",
+            "-D POSTROUTING -p ARP -o 123456789_eo -j eip-123456789_eo-arp",
+        ]
+
+        for rule in expected:
+            self.assertTrue(
+                self._has_cmd(rule),
+                "Expected POSTROUTING ARP jump reorder path: %s" % rule,
+            )
+
+    def test_prerouting_ipv4_gateway_jump_try_to_reorder_existing_rule(self):
+        expected = [
+            "-D PREROUTING -p ARP -i vnic1.0 -j eip-vnic1.0-gw",
+            "-I PREROUTING -p ARP -i vnic1.0 -j eip-vnic1.0-gw",
+        ]
+
+        for rule in expected:
+            self.assertTrue(
+                self._has_cmd(rule),
+                "Expected IPv4 PREROUTING gateway jump reorder path: %s" % rule,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test: ARP rules (arpreply source check, Reply DROP, gratuitous ARP)
+# ---------------------------------------------------------------------------
+class TestApplyEipArpRules(_ApplyEipTestBase):
+    def test_arpreply_no_source_mac_check(self):
+        """arpreply rule in set_gateway_arp_if_needed should NOT include --arp-mac-src (VM may have internal bridge)."""
+        arpreply_cmds = [c for c in self.executed_cmds if 'arpreply' in c and 'eip-vnic1.0-gw' in c]
+        mac_src_cmds = [c for c in arpreply_cmds if '--arp-mac-src' in c]
+        self.assertEqual(
+            len(mac_src_cmds), 0,
+            "arpreply rule should NOT have --arp-mac-src, got:\n" + "\n".join(arpreply_cmds),
+        )
+
+    def test_arpreply_no_source_ip_check(self):
+        """arpreply rule in set_gateway_arp_if_needed should NOT include --arp-ip-src (VM may have VIP)."""
+        arpreply_cmds = [c for c in self.executed_cmds if 'arpreply' in c and 'eip-vnic1.0-gw' in c]
+        ip_src_cmds = [c for c in arpreply_cmds if '--arp-ip-src' in c]
+        self.assertEqual(
+            len(ip_src_cmds), 0,
+            "arpreply rule should NOT have --arp-ip-src, got:\n" + "\n".join(arpreply_cmds),
+        )
+
+    def test_arp_reply_drop_rules_for_nic_name_chain(self):
+        """NIC_NAME arp chain should have ARP Reply DROP rules with gateway MAC check."""
+        reply_drop_cmds = [
+            c
+            for c in self.executed_cmds
+            if "--arp-op Reply" in c and "-j DROP" in c and "10.0.0.1" in c
+        ]
+        self.assertTrue(
+            len(reply_drop_cmds) > 0,
+            "Expected ARP Reply DROP rule for NIC_GATEWAY 10.0.0.1",
+        )
+
+    def test_pri_odev_chain_dnat_rule(self):
+        """PRI_ODEV filter chain should dnat namespace gateway ARP to VM MAC (unicast)."""
+        dnat_cmds = [
+            c
+            for c in self.executed_cmds
+            if "dnat" in c and "10.0.0.1" in c and "eip-123456789_o-gw" in c
+        ]
+        self.assertTrue(
+            len(dnat_cmds) > 0,
+            "Expected dnat rule for NIC_GATEWAY in PRI_ODEV chain, got:\n"
+            + "\n".join(self._cmds_matching("eip-123456789_o-gw")),
+        )
+
+    def test_pri_odev_chain_catchall_drop(self):
+        """PRI_ODEV filter chain should have a catchall ARP DROP (after dnat)."""
+        drop_cmds = [
+            c
+            for c in self.executed_cmds
+            if "eip-123456789_o-gw" in c and "-p ARP -j DROP" in c
+        ]
+        self.assertTrue(
+            len(drop_cmds) > 0,
+            "Expected catchall '-p ARP -j DROP' in PRI_ODEV chain",
+        )
+
+    def test_pri_odev_chain_no_blanket_request_drop(self):
+        """PRI_ODEV chain should NOT have blanket '--arp-op Request -j DROP' (blocks gratuitous ARP)."""
+        blanket_req_drop = [
+            c
+            for c in self.executed_cmds
+            if "eip-123456789_o-gw" in c and "--arp-op Request" in c and "-j DROP" in c
+        ]
+        self.assertEqual(
+            len(blanket_req_drop), 0,
+            "PRI_ODEV chain should NOT have blanket Request DROP, got:\n"
+            + "\n".join(blanket_req_drop),
+        )
+
+    def test_gratuitous_arp_sent_after_ebtables(self):
+        """After set_gateway_arp_if_needed, a gratuitous ARP should be sent via PRI_IDEV."""
+        garp_cmds = [
+            c
+            for c in self.executed_cmds
+            if "arping" in c and "-U" in c and "123456789_i" in c and "10.0.0.1" in c
+        ]
+        self.assertTrue(
+            len(garp_cmds) > 0, "Expected 'arping -q -U ... -I 123456789_i 10.0.0.1'"
+        )
+
+    def test_gratuitous_arp_after_gateway_arp_setup(self):
+        """Gratuitous ARP command should appear AFTER the eip-vnic1.0-gw chain setup."""
+        gw_chain_idx = None
+        garp_idx = None
+        for i, cmd in enumerate(self.executed_cmds):
+            if "eip-vnic1.0-gw" in cmd and gw_chain_idx is None:
+                gw_chain_idx = i
+            if "arping" in cmd and "-U" in cmd and "123456789_i" in cmd:
+                garp_idx = i
+        self.assertIsNotNone(gw_chain_idx, "Gateway ARP chain setup not found")
+        self.assertIsNotNone(garp_idx, "Gratuitous ARP command not found")
+        self.assertGreater(
+            garp_idx,
+            gw_chain_idx,
+            "Gratuitous ARP should come after gateway chain setup",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: Legacy chain cleanup during apply
+# ---------------------------------------------------------------------------
+class TestApplyEipLegacyCleanup(_ApplyEipTestBase):
+    def test_legacy_gw_chain_cleanup(self):
+        """After setting eip-vnic1.0-gw, should attempt to check/delete old 'vnic1.0-gw'."""
+        # delete_ebtables_chain_if_exists checks if old chain exists
+        legacy_cmds = [
+            c for c in self.executed_cmds if "vnic1.0-gw" in c and "eip-" not in c
+        ]
+        self.assertTrue(
+            len(legacy_cmds) > 0,
+            "Expected cleanup attempt for legacy chain 'vnic1.0-gw'",
+        )
+
+    def test_legacy_block_arp_chain_cleanup(self):
+        """Should attempt to clean up old {DEV}-arp chains (without eip- prefix)."""
+        # PRI_ODEV-arp = 123456789_o-arp
+        legacy_pri = [
+            c for c in self.executed_cmds if "123456789_o-arp" in c and "eip-" not in c
+        ]
+        self.assertTrue(
+            len(legacy_pri) > 0, "Expected cleanup for legacy '123456789_o-arp'"
+        )
+        # PUB_ODEV-arp = 123456789_eo-arp
+        legacy_pub = [
+            c for c in self.executed_cmds if "123456789_eo-arp" in c and "eip-" not in c
+        ]
+        self.assertTrue(
+            len(legacy_pub) > 0, "Expected cleanup for legacy '123456789_eo-arp'"
+        )
+        # NIC_NAME-arp = vnic1.0-arp
+        legacy_nic = [
+            c for c in self.executed_cmds if "vnic1.0-arp" in c and "eip-" not in c
+        ]
+        self.assertTrue(
+            len(legacy_nic) > 0, "Expected cleanup for legacy 'vnic1.0-arp'"
+        )
+
+    def test_legacy_pri_odev_gw_cleanup(self):
+        """add_filter_to_prevent_namespace_arp_request should clean old '{PRI_ODEV}-gw'."""
+        legacy_cmds = [
+            c for c in self.executed_cmds if "123456789_o-gw" in c and "eip-" not in c
+        ]
+        self.assertTrue(
+            len(legacy_cmds) > 0, "Expected cleanup for legacy '123456789_o-gw'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: IPv6 apply path
+# ---------------------------------------------------------------------------
+class TestApplyEipV6ChainNames(_ApplyEipTestBase):
+    IP_VERSION = 6
+
+    def test_v6_gateway_chain_uses_eip_prefix(self):
+        """set_gateway_arp_if_needed_v6 should create chain 'eip-vnic1.0-gw'."""
+        self.assertTrue(
+            self._has_cmd("eip-vnic1.0-gw"), "Expected 'eip-vnic1.0-gw' in IPv6 path"
+        )
+
+    def test_v6_legacy_gw_chain_cleanup(self):
+        """IPv6 path should clean up old 'vnic1.0-gw' chain."""
+        legacy_cmds = [
+            c for c in self.executed_cmds if "vnic1.0-gw" in c and "eip-" not in c
+        ]
+        self.assertTrue(
+            len(legacy_cmds) > 0,
+            "Expected cleanup for legacy 'vnic1.0-gw' in IPv6 path",
+        )
+
+    def test_v6_prerouting_gateway_jump_try_to_reorder_existing_rule(self):
+        expected = [
+            "-D PREROUTING -i vnic1.0 -j eip-vnic1.0-gw",
+            "-I PREROUTING -i vnic1.0 -j eip-vnic1.0-gw",
+        ]
+
+        for rule in expected:
+            self.assertTrue(
+                self._has_cmd(rule),
+                "Expected IPv6 PREROUTING gateway jump reorder path: %s" % rule,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test: delete path legacy cleanup
+# ---------------------------------------------------------------------------
+class _DeleteEipTestBase(unittest.TestCase):
+    """Base for delete_eip_with_ns tests."""
+
+    IP_VERSION = 4
+
+    def setUp(self):
+        self.executed_cmds = []
+
+        self._patchers = [p for p in _APPLY_PATCHES]
+        self._patchers.append(
+            mock.patch(
+                "zstacklib.utils.shell.get_process",
+                side_effect=_make_fake_process(self.executed_cmds),
+            )
+        )
+        for p in self._patchers:
+            p.start()
+
+        self.patcher_iproute = mock.patch("kvmagent.plugins.deip.iproute")
+        self.mock_iproute = self.patcher_iproute.start()
+
+        self.patcher_linux = mock.patch("kvmagent.plugins.deip.linux")
+        self.mock_linux = self.patcher_linux.start()
+        self.mock_linux.is_network_device_existing.return_value = False
+
+        eip_cmd = Eip()
+        self._call_unwrapped_method(
+            eip_cmd,
+            "delete_eip_with_ns",
+            ns="br_eth0_192_168_1_100",
+            eip_uuid="abcdef123456789",
+            version=self.IP_VERSION,
+            nic_name="vnic1.0",
+        )
+
+    def tearDown(self):
+        for p in self._patchers:
+            p.stop()
+        self.patcher_iproute.stop()
+        self.patcher_linux.stop()
+
+    def _has_cmd(self, pattern):
+        return any(pattern in cmd for cmd in self.executed_cmds)
+
+    def _cmds_matching(self, pattern):
+        return [cmd for cmd in self.executed_cmds if pattern in cmd]
+
+    def _call_unwrapped_method(self, obj, method_name, *args, **kwargs):
+        method = getattr(type(obj), method_name)
+        inspect.unwrap(method)(obj, *args, **kwargs)
+
+
+class TestDeleteArpRulesLegacyCleanup(_DeleteEipTestBase):
+    IP_VERSION = 4
+
+    def test_delete_uses_eip_prefix_chain_names(self):
+        """delete_arp_rules should reference eip- prefixed chain names."""
+        self.assertTrue(
+            self._has_cmd("eip-vnic1.0-gw"), "Expected 'eip-vnic1.0-gw' in delete path"
+        )
+        self.assertTrue(
+            self._has_cmd("eip-123456789_o-gw"),
+            "Expected 'eip-123456789_o-gw' in delete path",
+        )
+
+    def test_delete_cleans_legacy_gw_chain(self):
+        """delete_arp_rules should clean up old 'vnic1.0-gw' chain."""
+        legacy_cmds = [
+            c for c in self.executed_cmds if "vnic1.0-gw" in c and "eip-" not in c
+        ]
+        self.assertTrue(
+            len(legacy_cmds) > 0,
+            "Expected cleanup for legacy 'vnic1.0-gw' in delete path",
+        )
+
+    def test_delete_cleans_legacy_pri_odev_gw(self):
+        """delete_arp_rules should clean up old '{PRI_ODEV}-gw' chain."""
+        legacy_cmds = [
+            c for c in self.executed_cmds if "123456789_o-gw" in c and "eip-" not in c
+        ]
+        self.assertTrue(
+            len(legacy_cmds) > 0,
+            "Expected cleanup for legacy '123456789_o-gw' in delete path",
+        )
+
+    def test_delete_cleans_legacy_block_arp_chains(self):
+        """delete_arp_rules should clean up old {DEV}-arp chains."""
+        for dev in ["123456789_o", "123456789_eo", "vnic1.0"]:
+            pattern = "%s-arp" % dev
+            legacy = [c for c in self.executed_cmds if pattern in c and "eip-" not in c]
+            self.assertTrue(
+                len(legacy) > 0, "Expected cleanup for legacy '%s'" % pattern
+            )
+
+
+class TestDeleteIpv6RulesLegacyCleanup(_DeleteEipTestBase):
+    IP_VERSION = 6
+
+    def test_delete_v6_uses_eip_prefix(self):
+        """delete_ipv6_rules should reference eip- prefixed chain name."""
+        self.assertTrue(
+            self._has_cmd("eip-vnic1.0-gw"),
+            "Expected 'eip-vnic1.0-gw' in IPv6 delete path",
+        )
+
+    def test_delete_v6_cleans_legacy_gw_chain(self):
+        """delete_ipv6_rules should clean up old 'vnic1.0-gw' chain."""
+        legacy_cmds = [
+            c for c in self.executed_cmds if "vnic1.0-gw" in c and "eip-" not in c
+        ]
+        self.assertTrue(
+            len(legacy_cmds) > 0,
+            "Expected cleanup for legacy 'vnic1.0-gw' in IPv6 delete path",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kvmagent/kvmagent/test/test_ha_fencer.py
+++ b/kvmagent/kvmagent/test/test_ha_fencer.py
@@ -1,42 +1,237 @@
+import ast
+import os
+import sys
+import types
 import unittest
-import mock
-from kvmagent.plugins.ha_plugin import AbstractStorageFencer
+from unittest import mock
+from xml.etree import ElementTree as etree
 
 
-class FakeStorageFencer(AbstractStorageFencer):
+# ============================================================
+# VmStruct standalone copy for testing (avoids Py2 import chain)
+# Keep in sync with zstacklib/zstacklib/utils/linux.py VmStruct
+# ============================================================
+class VmStruct(object):
     def __init__(self):
-        super(FakeStorageFencer, self).__init__(5, 5, "test", [])
+        self.pid = ""
+        self.xml = ""
+        self.root_volume = ""
+        self.uuid = ""
+        self.volumes = []
+        self.bridges = []
 
-    def get_ha_fencer_name(self):
-        return "FakeStorageFencer"
+    def load_from_xml(self, xml):
+        def load_interface_source(element):
+            for e in element:
+                if e.tag == "source":
+                    if "bridge" in e.attrib:
+                        self.bridges.append(e.attrib["bridge"])
+
+        def load_disk_source(element):
+            is_root_vol = False
+            path = None
+            for e in element:
+                if e.tag == "boot":
+                    is_root_vol = True
+                elif e.tag == "source":
+                    if "file" in e.attrib:
+                        path = e.attrib["file"]
+                    elif "dev" in e.attrib:
+                        path = e.attrib["dev"]
+                    elif "protocol" in e.attrib and "name" in e.attrib:
+                        path = "%s:%s" % (e.attrib["protocol"], e.attrib["name"])
+                    if path and path.startswith("/dev/"):
+                        self.volumes.append(path)
+            if is_root_vol:
+                self.root_volume = path
+
+        self.xml = xml
+        root = etree.fromstring(xml)
+        for e1 in root:
+            if e1.tag == "domain":
+                for e2 in e1:
+                    if e2.tag == "devices":
+                        for e3 in e2:
+                            if e3.tag == "disk":
+                                load_disk_source(e3)
+                            if e3.tag == "interface":
+                                load_interface_source(e3)
+                        return
 
 
-class TestAbstractStorageFencer(unittest.TestCase):
-    @mock.patch('kvmagent.plugins.ha_plugin.AbstractStorageFencer.read_fencer_hearbeat')
-    def test_check_fencer_heartbeat_raises_exception(self, mock_read_fencer_heartbeat):
-        # Arrange
-        fencer = FakeStorageFencer()
+# ============================================================
+# Test VmStruct.load_from_xml with different disk source types
+# ============================================================
+class TestVmStructLoadFromXml(unittest.TestCase):
+    """Test VmStruct.load_from_xml correctly parses different disk source types"""
 
-        # Mock read_fencer_heartbeat to raise an exception
-        mock_read_fencer_heartbeat.side_effect = Exception("Heartbeat read error")
+    CEPH_RBD_XML = '''<domstatus state='running' reason='booted' pid='73873'>
+  <domain type='kvm' id='4'>
+    <name>abc123</name>
+    <devices>
+      <disk type='network' device='disk'>
+        <driver name='qemu' type='raw' cache='none'/>
+        <auth username='zstack'>
+          <secret type='ceph' uuid='55a6169b-7b60-4c81-bb3e-dd881578acf3'/>
+        </auth>
+        <source protocol='rbd' name='pool-xxx/vol-xxx'/>
+        <target dev='vda' bus='virtio'/>
+        <boot order='1'/>
+      </disk>
+    </devices>
+  </domain>
+</domstatus>'''
 
-        # Act & Assert
-        with self.assertRaises(Exception) as context:
-            fencer.check_fencer_heartbeat("fakeHostUuid", 5, 5, 5, "fakePrimaryStorageUuid")
-        self.assertEqual("Heartbeat read error", str(context.exception))
+    FILE_DISK_XML = '''<domstatus state='running' reason='booted' pid='12345'>
+  <domain type='kvm' id='5'>
+    <name>def456</name>
+    <devices>
+      <disk type='file' device='disk'>
+        <driver name='qemu' type='qcow2'/>
+        <source file='/mnt/ps-uuid/vol-uuid.qcow2'/>
+        <target dev='vda' bus='virtio'/>
+        <boot order='1'/>
+      </disk>
+    </devices>
+  </domain>
+</domstatus>'''
 
-    @mock.patch('kvmagent.plugins.ha_plugin.AbstractStorageFencer.read_fencer_hearbeat')
-    def test_check_fencer_heartbeat_returns_nothing(self, mock_read_fencer_heartbeat):
-        # Arrange
-        fencer = FakeStorageFencer()
+    BLOCK_DISK_XML = '''<domstatus state='running' reason='booted' pid='99999'>
+  <domain type='kvm' id='6'>
+    <name>ghi789</name>
+    <devices>
+      <disk type='block' device='disk'>
+        <driver name='qemu' type='raw'/>
+        <source dev='/dev/zvol/pool/vol-xxx'/>
+        <target dev='vda' bus='virtio'/>
+        <boot order='1'/>
+      </disk>
+    </devices>
+  </domain>
+</domstatus>'''
 
-        # Mock read_fencer_heartbeat to return nothing
-        mock_read_fencer_heartbeat.return_value = (None, None)
+    NO_BOOT_XML = '''<domstatus state='running' reason='booted' pid='11111'>
+  <domain type='kvm' id='7'>
+    <name>noboot</name>
+    <devices>
+      <disk type='network' device='disk'>
+        <source protocol='rbd' name='pool-xxx/vol-xxx'/>
+        <target dev='vda' bus='virtio'/>
+      </disk>
+    </devices>
+  </domain>
+</domstatus>'''
 
-        # Act & Assert
-        with self.assertRaises(Exception) as context:
-            fencer.check_fencer_heartbeat("fakeHostUuid", 5, 5, 5, "fakePrimaryStorageUuid")
-        self.assertIn("cannot read content from hb", str(context.exception))
+    BRIDGE_XML = '''<domstatus state='running' reason='booted' pid='22222'>
+  <domain type='kvm' id='8'>
+    <name>bridgevm</name>
+    <devices>
+      <disk type='network' device='disk'>
+        <source protocol='rbd' name='pool-xxx/vol-xxx'/>
+        <target dev='vda' bus='virtio'/>
+        <boot order='1'/>
+      </disk>
+      <interface type='bridge'>
+        <source bridge='br_eth0'/>
+      </interface>
+    </devices>
+  </domain>
+</domstatus>'''
+
+    def test_load_ceph_rbd_disk_sets_root_volume(self):
+        """Ceph RBD disk (protocol+name) should be parsed as root_volume"""
+        vm = VmStruct()
+        vm.load_from_xml(self.CEPH_RBD_XML)
+        self.assertEqual('rbd:pool-xxx/vol-xxx', vm.root_volume)
+
+    def test_load_file_disk_sets_root_volume(self):
+        """File-based disk should be parsed as root_volume"""
+        vm = VmStruct()
+        vm.load_from_xml(self.FILE_DISK_XML)
+        self.assertEqual('/mnt/ps-uuid/vol-uuid.qcow2', vm.root_volume)
+
+    def test_load_block_disk_sets_root_volume(self):
+        """Block device disk should be parsed as root_volume"""
+        vm = VmStruct()
+        vm.load_from_xml(self.BLOCK_DISK_XML)
+        self.assertEqual('/dev/zvol/pool/vol-xxx', vm.root_volume)
+        self.assertIn('/dev/zvol/pool/vol-xxx', vm.volumes)
+
+    def test_no_boot_element_leaves_root_volume_empty(self):
+        """Disk without <boot> element should not set root_volume"""
+        vm = VmStruct()
+        vm.load_from_xml(self.NO_BOOT_XML)
+        self.assertEqual('', vm.root_volume)
+
+    def test_ceph_root_volume_contains_pool_name(self):
+        """Verify mountPath matching works: pool name is substring of root_volume"""
+        vm = VmStruct()
+        vm.load_from_xml(self.CEPH_RBD_XML)
+        mount_path = 'pool-xxx/'
+        self.assertIn(mount_path, vm.root_volume)
+
+    def test_bridge_interface_parsed(self):
+        """Verify bridge interfaces are parsed from XML"""
+        vm = VmStruct()
+        vm.load_from_xml(self.BRIDGE_XML)
+        self.assertIn('br_eth0', vm.bridges)
+        self.assertEqual('rbd:pool-xxx/vol-xxx', vm.root_volume)
+
+
+# ============================================================
+# Verify fencers call kill_vm_by_xml (not kill_vm) via AST
+# ============================================================
+class TestFencerCallsKillVmByXml(unittest.TestCase):
+    """Verify at source level that fencers call kill_vm_by_xml, not kill_vm"""
+
+    @classmethod
+    def setUpClass(cls):
+        ha_plugin_path = os.path.join(
+            os.path.dirname(__file__), '..', 'plugins', 'ha_plugin.py')
+        with open(ha_plugin_path, 'r') as f:
+            cls.tree = ast.parse(f.read())
+
+    def _get_method_calls(self, class_name, method_name):
+        """Extract all function call names from a method in a class"""
+        calls = []
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.ClassDef) and node.name == class_name:
+                for item in ast.walk(node):
+                    if isinstance(item, ast.FunctionDef) and item.name == method_name:
+                        for call_node in ast.walk(item):
+                            if isinstance(call_node, ast.Call):
+                                if isinstance(call_node.func, ast.Name):
+                                    calls.append(call_node.func.id)
+                                elif isinstance(call_node.func, ast.Attribute):
+                                    calls.append(call_node.func.attr)
+        return calls
+
+    def test_filesystem_fencer_calls_kill_vm_by_xml(self):
+        """FileSystemHeartbeatController.check_storage_heartbeat should call kill_vm_by_xml"""
+        calls = self._get_method_calls('FileSystemHeartbeatController', 'check_storage_heartbeat')
+        self.assertIn('kill_vm_by_xml', calls,
+                      "check_storage_heartbeat must call kill_vm_by_xml")
+        self.assertNotIn('kill_vm', calls,
+                         "check_storage_heartbeat must NOT call kill_vm directly")
+
+    def test_ceph_fencer_calls_kill_vm_by_xml(self):
+        """CephHeartbeatController.handle_heartbeat_failure should call kill_vm_by_xml"""
+        calls = self._get_method_calls('CephHeartbeatController', 'handle_heartbeat_failure')
+        self.assertIn('kill_vm_by_xml', calls,
+                      "handle_heartbeat_failure must call kill_vm_by_xml")
+        self.assertNotIn('kill_vm', calls,
+                         "handle_heartbeat_failure must NOT call kill_vm directly")
+
+    def test_get_runnning_vm_calls_load_from_xml(self):
+        """get_runnning_vm_root_volume_on_ps must call vm.load_from_xml"""
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.FunctionDef) and node.name == 'get_runnning_vm_root_volume_on_ps':
+                source = ast.dump(node)
+                self.assertIn('load_from_xml', source,
+                              "get_runnning_vm_root_volume_on_ps must call load_from_xml")
+                return
+        self.fail("get_runnning_vm_root_volume_on_ps not found in source")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/kvmagent/kvmagent/test/test_ha_fencer.py
+++ b/kvmagent/kvmagent/test/test_ha_fencer.py
@@ -232,6 +232,30 @@ class TestFencerCallsKillVmByXml(unittest.TestCase):
                 return
         self.fail("get_runnning_vm_root_volume_on_ps not found in source")
 
+    def test_get_runnning_vm_uses_not_exec_kill_vm_not_is_allow_fencer(self):
+        """get_runnning_vm_root_volume_on_ps must use not_exec_kill_vm to skip VMs (not is_allow_fencer).
+
+        allowRules lists VMs that SHOULD be killed even in Permissive strategy (e.g. VPC/SLB system VMs).
+        Using is_allow_fencer directly as the skip condition reverses the semantics:
+        VMs in allowRules would be skipped instead of killed.
+        """
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.FunctionDef) and node.name == 'get_runnning_vm_root_volume_on_ps':
+                calls = []
+                for call_node in ast.walk(node):
+                    if isinstance(call_node, ast.Call):
+                        if isinstance(call_node.func, ast.Name):
+                            calls.append(call_node.func.id)
+                        elif isinstance(call_node.func, ast.Attribute):
+                            calls.append(call_node.func.attr)
+                self.assertIn('not_exec_kill_vm', calls,
+                              "get_runnning_vm_root_volume_on_ps must use not_exec_kill_vm to skip VMs")
+                self.assertNotIn('is_allow_fencer', calls,
+                                 "get_runnning_vm_root_volume_on_ps must NOT call is_allow_fencer directly "
+                                 "(allowRules VMs should be killed, not skipped)")
+                return
+        self.fail("get_runnning_vm_root_volume_on_ps not found in source")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/kvmagent/kvmagent/test/test_make_usb_redirect.py
+++ b/kvmagent/kvmagent/test/test_make_usb_redirect.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for ``vm_plugin._make_usb_redirect_xml``.
+
+Regression coverage for ZSTAC-84629: on aarch64 + RPM-based hosts the
+``set_default`` early-return previously dropped the ``set_redirdev``
+call, silently disabling USB redirection. These tests pin down each
+host/arch/flag combination so the early-return cannot regress without
+a failing assertion.
+"""
+import unittest
+from xml.etree import ElementTree as etree
+
+from kvmagent.plugins import vm_plugin
+
+
+class _FakeStartVmCmd(object):
+    """Minimal stand-in for ``StartVmCmd``.
+
+    ``_make_usb_redirect_xml`` only reads four boolean-ish fields, so a
+    plain attribute holder is enough -- avoids spinning up the full
+    HTTP/agent machinery just to exercise XML emission.
+    """
+
+    def __init__(self, usbRedirect=False, coloPrimary=False,
+                 coloSecondary=False, useColoBinary=False):
+        self.usbRedirect = usbRedirect
+        self.coloPrimary = coloPrimary
+        self.coloSecondary = coloSecondary
+        self.useColoBinary = useColoBinary
+
+
+def _new_devices_element():
+    return etree.Element('devices')
+
+
+def _controller_indexes(devices):
+    return [c.get('index') for c in devices.findall('controller')]
+
+
+def _controller_models(devices):
+    return [c.get('model') for c in devices.findall('controller')]
+
+
+def _redirdev_addresses(devices):
+    return [
+        (rd.find('address').get('bus'), rd.find('address').get('port'))
+        for rd in devices.findall('redirdev')
+    ]
+
+
+def _spicevmc_channel_count(devices):
+    return sum(
+        1 for ch in devices.findall('channel')
+        if ch.get('type') == 'spicevmc'
+    )
+
+
+class AArch64RpmBasedRedirectTest(unittest.TestCase):
+    """Drives the legacy aarch64 RPM-based ``set_default`` branch."""
+
+    def test_redirdev_attached_when_usb_redirect_requested(self):
+        # The original ZSTAC-84629 symptom: usbRedirect=true on aarch64
+        # + RPM-based host produced zero <redirdev> nodes. After the
+        # fix, set_default() is followed by two extra default-model
+        # controllers (3, 4) and the four redirdev devices.
+        devices = _new_devices_element()
+
+        vm_plugin._make_usb_redirect_xml(
+            devices,
+            _FakeStartVmCmd(usbRedirect=True),
+            dist_name='centos',
+            host_arch='aarch64',
+        )
+
+        self.assertEqual(['0', '1', '2', '3', '4'],
+                         _controller_indexes(devices))
+        # set_default + the two added controllers must use libvirt's
+        # default qemu-xhci -- never ehci/nec-xhci on this branch.
+        self.assertEqual([None] * 5, _controller_models(devices))
+        self.assertEqual(1, _spicevmc_channel_count(devices))
+        self.assertEqual(
+            [('3', '1'), ('3', '2'), ('4', '1'), ('4', '2')],
+            _redirdev_addresses(devices),
+        )
+
+    def test_no_redirdev_when_usb_redirect_disabled(self):
+        # usbRedirect=false must not perturb the legacy controller
+        # layout: only 0/1/2 controllers, no redirdev, no spice channel.
+        devices = _new_devices_element()
+
+        vm_plugin._make_usb_redirect_xml(
+            devices,
+            _FakeStartVmCmd(usbRedirect=False),
+            dist_name='centos',
+            host_arch='aarch64',
+        )
+
+        self.assertEqual(['0', '1', '2'], _controller_indexes(devices))
+        self.assertEqual([None, None, None], _controller_models(devices))
+        self.assertEqual(0, _spicevmc_channel_count(devices))
+        self.assertEqual([], _redirdev_addresses(devices))
+
+    def test_colo_primary_skips_redirdev(self):
+        # COLO VMs must keep skipping redirdev even though
+        # set_default() succeeds and usbRedirect is true.
+        devices = _new_devices_element()
+
+        vm_plugin._make_usb_redirect_xml(
+            devices,
+            _FakeStartVmCmd(usbRedirect=True, coloPrimary=True),
+            dist_name='centos',
+            host_arch='aarch64',
+        )
+
+        self.assertEqual(['0', '1', '2'], _controller_indexes(devices))
+        self.assertEqual([], _redirdev_addresses(devices))
+        self.assertEqual(0, _spicevmc_channel_count(devices))
+
+
+class NonDefaultBranchRedirectTest(unittest.TestCase):
+    """Drives the ``set_usb2_3`` branch (non-aarch64 or non-RPM)."""
+
+    def test_x86_redirect_uses_ehci_and_nec_xhci_models(self):
+        # x86_64 + RPM-based: with_arch(['aarch64']) skips set_default,
+        # so set_usb2_3() runs and emits ehci + nec-xhci controllers.
+        devices = _new_devices_element()
+
+        vm_plugin._make_usb_redirect_xml(
+            devices,
+            _FakeStartVmCmd(usbRedirect=True),
+            dist_name='centos',
+            host_arch='x86_64',
+        )
+
+        self.assertEqual(['0', '1', '2', '3', '4'],
+                         _controller_indexes(devices))
+        self.assertEqual(
+            [None, 'ehci', 'nec-xhci', 'ehci', 'nec-xhci'],
+            _controller_models(devices),
+        )
+        self.assertEqual(4, len(_redirdev_addresses(devices)))
+
+    def test_aarch64_non_rpm_uses_set_usb2_3(self):
+        # aarch64 + Debian-family: on_redhat_based() rejects 'ubuntu',
+        # so set_default returns None and the function falls through
+        # to set_usb2_3 + set_redirdev.
+        devices = _new_devices_element()
+
+        vm_plugin._make_usb_redirect_xml(
+            devices,
+            _FakeStartVmCmd(usbRedirect=True),
+            dist_name='ubuntu',
+            host_arch='aarch64',
+        )
+
+        self.assertEqual(['0', '1', '2', '3', '4'],
+                         _controller_indexes(devices))
+        self.assertEqual(
+            [None, 'ehci', 'nec-xhci', 'ehci', 'nec-xhci'],
+            _controller_models(devices),
+        )
+        self.assertEqual(4, len(_redirdev_addresses(devices)))
+
+    def test_loongarch64_uses_nec_xhci_throughout(self):
+        # loongarch64 has its own controller-model branch; protect it
+        # from regressions while we are reshaping this code path.
+        devices = _new_devices_element()
+
+        vm_plugin._make_usb_redirect_xml(
+            devices,
+            _FakeStartVmCmd(usbRedirect=True),
+            dist_name='ubuntu',
+            host_arch='loongarch64',
+        )
+
+        self.assertEqual(
+            [None, 'nec-xhci', 'nec-xhci', 'nec-xhci', 'nec-xhci'],
+            _controller_models(devices),
+        )
+        self.assertEqual(4, len(_redirdev_addresses(devices)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kvmagent/kvmagent/test/test_mevoco_userdata_veth.py
+++ b/kvmagent/kvmagent/test/test_mevoco_userdata_veth.py
@@ -1,0 +1,72 @@
+import unittest
+
+import mock
+
+from kvmagent.plugins import mevoco
+
+
+class FakeNetnsShell(object):
+    def __init__(self, mac):
+        self.mac = mac
+        self.deleted_links = []
+
+    def get_mac(self, link_name):
+        return self.mac
+
+    def del_link(self, link_name):
+        self.deleted_links.append(link_name)
+
+
+class TestUserdataVethPair(unittest.TestCase):
+    def _run(self, outer_exist, inner_exist):
+        shell = FakeNetnsShell('fa:16:3e:00:00:01' if inner_exist else None)
+        patches = [
+            mock.patch.object(mevoco.linux, 'is_network_device_existing', return_value=outer_exist),
+            mock.patch.object(mevoco.iproute, 'IpNetnsShell', return_value=shell),
+            mock.patch.object(mevoco.iproute, 'delete_link_no_error'),
+            mock.patch.object(mevoco.iproute, 'add_link'),
+            mock.patch.object(mevoco.iproute, 'set_link_attribute'),
+        ]
+        started = [p.start() for p in patches]
+        try:
+            mevoco.ensure_userdata_veth_pair('ns0', 'ud_outer9', 'ud_inner9', 65500)
+            return shell, started[2], started[3], started[4]
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+    def test_keep_complete_pair(self):
+        shell, delete_link, add_link, set_link_attribute = self._run(True, True)
+
+        self.assertEqual([], shell.deleted_links)
+        self.assertEqual(0, delete_link.call_count)
+        self.assertEqual(0, add_link.call_count)
+        self.assertEqual(0, set_link_attribute.call_count)
+
+    def test_create_missing_pair(self):
+        shell, delete_link, add_link, set_link_attribute = self._run(False, False)
+
+        self.assertEqual([], shell.deleted_links)
+        self.assertEqual(0, delete_link.call_count)
+        add_link.assert_called_once_with('ud_outer9', 'veth', peer='ud_inner9')
+        self.assertEqual(2, set_link_attribute.call_count)
+
+    def test_recreate_when_outer_left_without_inner(self):
+        shell, delete_link, add_link, set_link_attribute = self._run(True, False)
+
+        self.assertEqual([], shell.deleted_links)
+        delete_link.assert_called_once_with('ud_outer9')
+        add_link.assert_called_once_with('ud_outer9', 'veth', peer='ud_inner9')
+        self.assertEqual(2, set_link_attribute.call_count)
+
+    def test_recreate_when_inner_left_without_outer(self):
+        shell, delete_link, add_link, set_link_attribute = self._run(False, True)
+
+        self.assertEqual(['ud_inner9'], shell.deleted_links)
+        self.assertEqual(0, delete_link.call_count)
+        add_link.assert_called_once_with('ud_outer9', 'veth', peer='ud_inner9')
+        self.assertEqual(2, set_link_attribute.call_count)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kvmagent/kvmagent/test/test_migrate_domain_xml.py
+++ b/kvmagent/kvmagent/test/test_migrate_domain_xml.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+from xml.etree import ElementTree as ET
+
+from kvmagent.plugins import vm_plugin
+
+
+class TestMigrateDomainXml(unittest.TestCase):
+    def _build_domain_new_xml(self, domain_xml):
+        vm = vm_plugin.Vm.__new__(vm_plugin.Vm)
+        vm.get_migratable_xml = lambda: domain_xml
+        return vm._build_domain_new_xml({})
+
+    def test_split_legacy_rbd_cdrom_snapshot(self):
+        domain_xml = """
+<domain type='kvm'>
+  <name>vm-uuid</name>
+  <devices>
+    <disk type='network' device='cdrom'>
+      <driver name='qemu' type='raw'/>
+      <source protocol='rbd' name='pool/image@snapshot'>
+        <host name='172.24.1.1' port='6789'/>
+      </source>
+      <target dev='hdc' bus='ide'/>
+      <readonly/>
+    </disk>
+  </devices>
+</domain>
+"""
+        disks, dest_xml = self._build_domain_new_xml(domain_xml)
+
+        self.assertEqual([], disks)
+        root = ET.fromstring(dest_xml)
+        source = root.find("devices/disk/source")
+        self.assertEqual("pool/image", source.attrib["name"])
+        self.assertEqual("snapshot", source.find("snapshot").attrib["name"])
+
+    def test_keep_non_rbd_network_disk_snapshot_unchanged(self):
+        domain_xml = """
+<domain type='kvm'>
+  <name>vm-uuid</name>
+  <devices>
+    <disk type='network' device='disk'>
+      <driver name='qemu' type='raw'/>
+      <source protocol='cbd' name='pool/image@snapshot'>
+        <host name='172.24.1.1' port='7777'/>
+      </source>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+  </devices>
+</domain>
+"""
+        disks, dest_xml = self._build_domain_new_xml(domain_xml)
+
+        self.assertIsNone(disks)
+        self.assertIsNone(dest_xml)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kvmagent/kvmagent/test/test_vm_pmu.py
+++ b/kvmagent/kvmagent/test/test_vm_pmu.py
@@ -1,0 +1,64 @@
+import unittest
+import xml.etree.ElementTree as etree
+
+from kvmagent.plugins.vm_plugin import e
+from kvmagent.plugins.vm_plugin import make_pmu_feature
+
+
+class TestVmPmuConfig(unittest.TestCase):
+    def test_pmu_off_generates_xml(self):
+        root, features = self._new_domain_with_features()
+        cmd = self._cmd(False)
+
+        make_pmu_feature(cmd, features)
+
+        pmu = root.find('./features/pmu')
+        self.assertIsNotNone(pmu)
+        self.assertEqual('off', pmu.get('state'))
+
+    def test_pmu_true_omits_pmu_element(self):
+        root, features = self._new_domain_with_features()
+        cmd = self._cmd(True)
+
+        make_pmu_feature(cmd, features)
+
+        self.assertIsNone(root.find('./features/pmu'))
+
+    def test_missing_pmu_omits_pmu_element(self):
+        root, features = self._new_domain_with_features()
+
+        make_pmu_feature(object(), features)
+
+        self.assertIsNone(root.find('./features/pmu'))
+
+    def test_pmu_element_stays_under_features(self):
+        root, features = self._new_domain_with_features()
+        cmd = self._cmd(False)
+
+        make_pmu_feature(cmd, features)
+
+        children = [child.tag for child in features]
+        self.assertEqual(['apic', 'pae', 'acpi', 'pmu'], children)
+        self.assertIn('<pmu state="off"', etree.tostring(root).decode('utf-8'))
+
+    @staticmethod
+    def _new_domain_with_features():
+        root = etree.Element('domain')
+        features = e(root, 'features')
+        e(features, 'apic')
+        e(features, 'pae')
+        e(features, 'acpi')
+        return root, features
+
+    @staticmethod
+    def _cmd(pmu):
+        class Cmd(object):
+            pass
+
+        cmd = Cmd()
+        cmd.pmu = pmu
+        return cmd
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -3381,14 +3381,18 @@ class InstallDbCmd(Command):
       shell: "yum clean metadata; yum --nogpgcheck install -y mysql mysql-server "
       register: install_result
 
-    - name: install MySQL for RedHat 7/Kylin10/openEuler/UnionTech kongzi/Nfs from local
-      when: (ansible_os_family == 'RedHat' and ansible_distribution_major_version >= 7 and yum_repo != 'false') or ansible_os_family == 'Kylin' \
-            or ansible_os_family == 'Openeuler' or ansible_os_family == 'Nfs' or (ansible_os_family == 'UnionTech' and ansible_distribution_release == 'kongzi')
+    - name: install MySQL for RedHat 7/Kylin10/openEuler/UnionTech/Nfs from local
+      when: (ansible_os_family == 'RedHat' and ansible_distribution_major_version >= 7 and yum_repo != 'false')
+            or ((ansible_os_family == 'Kylin' or ansible_os_family == 'Openeuler' or ansible_os_family == 'Nfs' or ansible_os_family == 'UnionTech') and yum_repo != 'false')
       shell: yum clean metadata; yum --disablerepo=* --enablerepo={{yum_repo}} --nogpgcheck install -y  mariadb mariadb-server iptables-services
       register: install_result
 
-    - name: install MySQL for RedHat 7/Kylin10 or from local
-      when: (ansible_os_family == 'RedHat' and ansible_distribution_major_version >= 7 and yum_repo == 'false') or (ansible_os_family == 'Kylin' and ansible_distribution_major_version == '10' and yum_repo == 'false')
+    - name: install MySQL for RedHat 7/Kylin10/openEuler/UnionTech/Nfs from system repos
+      when: (ansible_os_family == 'RedHat' and ansible_distribution_major_version >= 7 and yum_repo == 'false')
+            or (ansible_os_family == 'Kylin' and ansible_distribution_major_version == '10' and yum_repo == 'false')
+            or (ansible_os_family == 'Openeuler' and yum_repo == 'false')
+            or (ansible_os_family == 'Nfs' and yum_repo == 'false')
+            or (ansible_os_family == 'UnionTech' and yum_repo == 'false')
       shell: yum clean metadata; yum --nogpgcheck install -y  mariadb mariadb-server iptables-services
       register: install_result
 
@@ -3412,9 +3416,9 @@ class InstallDbCmd(Command):
       shell: apt-get -y install --allow-unauthenticated mariadb-server mariadb-client netfilter-persistent
       register: install_result
 
-    - name: open 3306 port on RedHat 7/Alibaba/Kyliin10/openEuler/UnionTech kongzi/Nfs
+    - name: open 3306 port on RedHat 7/Alibaba/Kylin10/openEuler/UnionTech/Nfs
       when: ansible_os_family == 'RedHat' or ansible_os_family == 'Alibaba' or (ansible_os_family == 'Kylin' and ansible_distribution_version == '10')
-            or ansible_os_family == 'Nfs' or (ansible_os_family == 'UnionTech' and ansible_distribution_release == 'kongzi')
+            or ansible_os_family == 'Openeuler' or ansible_os_family == 'Nfs' or ansible_os_family == 'UnionTech'
       shell: iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport 3306 -j ACCEPT" > /dev/null || (iptables -I INPUT -p tcp -m tcp --dport 3306 -j ACCEPT && service iptables save)
 
     - name: open 3306 port
@@ -3428,9 +3432,9 @@ class InstallDbCmd(Command):
       when: ansible_os_family == 'RedHat' and ansible_distribution_major_version < 7
       service: name=mysqld state=restarted enabled=yes
 
-    - name: enable MySQL daemon on RedHat 7/Kyliin10/openEuler/UnionTech kongzi/Nfs
+    - name: enable MySQL daemon on RedHat 7/Kylin10/openEuler/UnionTech/Nfs
       when: (ansible_os_family == 'RedHat' and ansible_distribution_major_version >= 7) or ansible_os_family == 'Kylin' or ansible_os_family == 'Openeuler'
-            or ansible_os_family == 'Nfs' or (ansible_os_family == 'UnionTech' and ansible_distribution_release == 'kongzi')
+            or ansible_os_family == 'Nfs' or ansible_os_family == 'UnionTech'
       service: name=mariadb state=restarted enabled=yes
 
     - name: enable MySQL daemon on AliOS 7
@@ -3468,6 +3472,11 @@ class InstallDbCmd(Command):
 
     - name: rollback MySQL installation on AliOS 7
       when: ansible_os_family == 'Alibaba' and ansible_distribution_major_version >= 7 and change_root_result.rc != 0 and install_result.changed == True
+      shell: rpm -ev mariadb mariadb-server
+
+    - name: rollback MySQL installation on UnionTech/openEuler/Nfs
+      when: (ansible_os_family == 'UnionTech' or ansible_os_family == 'Openeuler' or ansible_os_family == 'Nfs')
+            and change_root_result.rc != 0 and install_result.changed == True
       shell: rpm -ev mariadb mariadb-server
 
     - name: rollback MySql installation on Ubuntu

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -11456,10 +11456,30 @@ class IamService(ExtraService):
     default_nginx_port = 18182
     base_init_path = "/var/lib/zstack/keycloak/init.sh"
 
+    SUPPORTED_OS = ['h84r', 'ky10sp3']
+    SUPPORTED_ARCH = ['x86_64', 'aarch64']
+
     def service_name(self):
         return "keycloak"
 
+    def init_validation(self):
+        """
+        Validate that the current OS and architecture are supported for IAM service.
+        Raises CtlError if validation fails.
+        """
+        current_arch = Ctl.BASEARCH
+        current_os = Ctl.ZS_RELEASE
+
+        if current_arch not in self.SUPPORTED_ARCH:
+            raise CtlError("IAM service does not support architecture '%s'. Supported architectures: %s"
+                           % (current_arch, ', '.join(self.SUPPORTED_ARCH)))
+
+        if current_os not in self.SUPPORTED_OS:
+            raise CtlError("IAM service does not support OS '%s'. Supported OS: %s"
+                           % (current_os, ', '.join(self.SUPPORTED_OS)))
+
     def init(self):
+        self.init_validation()
         if not self.zsha2_utils:
             return
         template_path = "/var/lib/zstack/keycloak/conf/keycloak.upstream.nginx.conf"

--- a/zstacklib/zstacklib/utils/ip.py
+++ b/zstacklib/zstacklib/utils/ip.py
@@ -314,7 +314,7 @@ def find_host_physicl_nics():
         return []
 
     nic_without_sriov = [nic for nic in nic_all_physical if not is_sriovVf_nic(nic)]
-    nic_without_virtual = [nic for nic in nic_without_sriov if not any(keyword in nic for keyword in ['vnic', 'outer', 'br_'])]
+    nic_without_virtual = [nic for nic in nic_without_sriov if not any(keyword in nic for keyword in ['vnic', 'outer', 'br_', 'br-', 'ovs-', 'patch-', 'vxlan_sys_'])]
 
     smart_nic_representors = get_smart_nic_representors()
     nic_without_smart_nic_representors = [nic for nic in nic_without_virtual if nic not in smart_nic_representors]

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -140,6 +140,8 @@ class VmStruct(object):
                         path = e.attrib["file"]
                     elif "dev" in e.attrib:
                         path = e.attrib["dev"]
+                    elif "protocol" in e.attrib and "name" in e.attrib:
+                        path = "%s:%s" % (e.attrib["protocol"], e.attrib["name"])
                     if path and path.startswith("/dev/"):
                         self.volumes.append(path)
 

--- a/zstacklib/zstacklib/utils/pci.py
+++ b/zstacklib/zstacklib/utils/pci.py
@@ -118,7 +118,7 @@ def get_bars_max_addressable_memory():
         logger.warn("max_addressable_memory is None, please reconnect host and try again")
 
     if platform.machine() == 'aarch64':
-        return "%sG" % sizeunit.Byte.toGigaByte(max_addressable_memory_64bit)
+        return "%sG" % sizeunit.Byte.toGigaByte(calc_next_power_of_2(max_addressable_memory_64bit))
 
     if max_addressable_memory_64bit < DEFAULT_PCDPCIMMIO64SIZE_MIN_SIZE:
         return DEFAULT_PCDPCIMMIO64SIZE_MIN_SIZE / 1024 / 1024


### PR DESCRIPTION
"## Root Cause\n\nBackport for ZSTAC-86307 from an already resolved issue. Migration can fail when legacy RBD source names include an inline snapshot after qemu/libvirt upgrades.\n\n## Resolve\n\n- Cherry-picked and resolved the legacy RBD snapshot XML conversion fix from f6bd0db974bb.\n- Preserved existing 5.4.10 migration task handling while adding snapshot splitting before destination XML generation.\n\n## Updated Behavior\n\n5.4.10 normalizes legacy RBD source names like pool/image@snapshot into image plus snapshot XML before live migration.\n\n## Verification\n\n```bash\npython2 -m py_compile kvmagent/kvmagent/plugins/vm_plugin.py kvmagent/kvmagent/test/test_migrate_domain_xml.py\ngit cherry-pick -x f6bd0db974bb\ngit status --short\n```\n\nNo full runtime migration test was run locally.\n\n## Residual Risk\n\nNeeds QA validation on a 5.4.10 xsky/RBD migration environment.\n\n## Jira\n\nResolves: ZSTAC-86307"

sync from gitlab !7442