### PR TITLE
<backport>[5.4.10]: batch backport jin.ma CLONE issues (@@3)

### DIFF
--- a/kvmagent/kvmagent/plugins/ha_plugin.py
+++ b/kvmagent/kvmagent/plugins/ha_plugin.py
@@ -863,7 +863,7 @@ class FileSystemHeartbeatController(AbstractStorageFencer):
 
             r = bash.bash_r("timeout 5 virsh list")
             if r == 0:
-                vm_uuids = find_ps_running_vm(self.ps_uuid)
+                vm_uuids = find_ps_running_vm(self.mount_path)
             else:
                 _, vm_uuids = get_runnning_vm_root_volume_on_ps(self.max_attempts, self.strategy, self.mount_path, isFlushbufs=False, vm_uuid_only=True)
 

--- a/kvmagent/kvmagent/plugins/ha_plugin.py
+++ b/kvmagent/kvmagent/plugins/ha_plugin.py
@@ -883,7 +883,7 @@ class FileSystemHeartbeatController(AbstractStorageFencer):
             return success_heartbeat
 
         self.failure += 1
-        if self.failure == self.max_attempts:
+        if self.failure >= self.max_attempts:
             logger.warn('failed to touch the heartbeat file[%s] %s times, we lost the connection to the storage,'
                         'shutdown ourselves' % (self.get_heartbeat_file_path, self.max_attempts))
 
@@ -920,6 +920,7 @@ class FileSystemHeartbeatController(AbstractStorageFencer):
                 clean_network_config(killed_vms.keys())
 
             self.after_kill_vm(killed_vms.keys(), on_storage_vm_uuids)
+            self.reset_failure_count()
 
             if self.mounted_by_zstack and not linux.is_mounted(self.mount_path):
                 self.try_remount_fs_callback(self.mount_path, self.ps_uuid, self.created_time, self, self.url, self.options)
@@ -1164,7 +1165,7 @@ class IscsiHeartbeatController(AbstractStorageFencer):
             return True
 
         self.failure += 1
-        if self.failure == self.max_attempts:
+        if self.failure >= self.max_attempts:
             logger.warn('failed to touch the heartbeat file[%s] %s times, we lost the connection to the storage,'
                         'shutdown ourselves' % (self.heartbeat_path, self.max_attempts))
 
@@ -1191,6 +1192,8 @@ class IscsiHeartbeatController(AbstractStorageFencer):
             if len(killed_vms) != 0:
                 self.fencer_triggered_callback([self.ps_uuid], ','.join(killed_vms.keys()))
                 clean_network_config(killed_vms.keys())
+
+            self.reset_failure_count()
 
     def is_fencer_private_args_change(self, cmd):
         pass
@@ -1275,7 +1278,7 @@ class CbdHeartbeatController(AbstractStorageFencer):
             return True
 
         self.failure += 1
-        if self.failure == self.max_attempts:
+        if self.failure >= self.max_attempts:
             logger.warn('failed to touch the heartbeat file[%s] %s times, we lost the connection to the storage,'
                         'shutdown ourselves' % (self.heartbeat_path, self.max_attempts))
 
@@ -1302,6 +1305,8 @@ class CbdHeartbeatController(AbstractStorageFencer):
             if len(killed_vms) != 0:
                 self.fencer_triggered_callback([self.ps_uuid], ','.join(killed_vms.keys()))
                 clean_network_config(killed_vms.keys())
+
+            self.reset_failure_count()
 
     def is_fencer_private_args_change(self, cmd):
         pass

--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -78,6 +78,8 @@ DISTRO_USING_DNF = ['rl84', 'h84r', 'ky10sp1', 'ky10sp2', 'ky10sp3',
 class ConnectResponse(kvmagent.AgentResponse):
     def __init__(self):
         super(ConnectResponse, self).__init__()
+        self.firstConnect = False
+        self.agentStartTimeMillis = 0
 
 class HostCapacityResponse(kvmagent.AgentResponse):
     def __init__(self):
@@ -982,6 +984,8 @@ class HostPlugin(kvmagent.KvmAgent):
         self.IS_YUM = False
         self.IS_APT = False
         self.NVIDIA_SMI_INSTALLED = False
+        self._first_connect_after_boot = True
+        self._agent_start_time_millis = int(time.time() * 1000)
 
         if shell.run("which yum") == 0:
             self.IS_YUM = True
@@ -1025,6 +1029,8 @@ class HostPlugin(kvmagent.KvmAgent):
     def connect(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = ConnectResponse()
+        rsp.agentStartTimeMillis = self._agent_start_time_millis
+        rsp.firstConnect = self._first_connect_after_boot
 
         # page table extension
         if shell.run('lscpu | grep -q -w GenuineIntel') == 0:
@@ -1082,6 +1088,7 @@ class HostPlugin(kvmagent.KvmAgent):
         bash_r(EBTABLES_CMD + ' -D FORWARD -j ZSTACK-VF-NICS')
         bash_r(EBTABLES_CMD + ' -X ZSTACK-VF-NICS')
 
+        self._first_connect_after_boot = False
         return jsonobject.dumps(rsp)
 
     @thread.AsyncThread

--- a/kvmagent/kvmagent/plugins/storage_device.py
+++ b/kvmagent/kvmagent/plugins/storage_device.py
@@ -1174,8 +1174,7 @@ class StorageDevicePlugin(kvmagent.KvmAgent):
         return sum(filter(None, luns), [])
 
     def multipath_conf_cannot_change(self):
-        r, o, e = bash.bash_roe('''grep -rF "<disk type='block' device='lun'" /var/run/libvirt/qemu/* ''')
-        return r == 0
+        return lvm.is_running_vm_using_lun_passthrough()
 
     @kvmagent.replyerror
     @bash.in_bash

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -2839,12 +2839,71 @@ class Vm(object):
         self.start(cmd.timeout)
 
     def restore(self, path):
+        self._patch_cpu_xml_from_saved_image(path)
+
+        # ensure domain_xml is str for restoreFlags regardless of patch branch
+        if isinstance(self.domain_xml, bytes):
+            self.domain_xml = self.domain_xml.decode('utf-8')
+
         @LibvirtAutoReconnect
         def restore_from_file(conn):
             return conn.restoreFlags(path, self.domain_xml)
 
         logger.debug('restoring vm:\n%s' % self.domain_xml)
         restore_from_file()
+
+    def _patch_cpu_xml_from_saved_image(self, path):
+        """Patch CPU XML for host-model VMs restoring from memory snapshot.
+
+        When a VM uses host-model CPU mode, libvirt internally expands it to
+        mode='custom' with a concrete CPU model and check='full' in the saved
+        image. If we pass a freshly built XML with mode='host-model', libvirt's
+        restoreFlags rejects it because the CPU mode/check don't match.
+
+        Fix: extract the CPU element from the saved image XML and replace the
+        agent-built one so that source and target are identical.
+
+        See: http://jira.zstack.io/browse/ZSTAC-61717
+        """
+        try:
+            current_tree = etree.fromstring(self.domain_xml)
+            current_cpu = current_tree.find('cpu')
+            if current_cpu is None or current_cpu.get('mode') != 'host-model':
+                return
+
+            @LibvirtAutoReconnect
+            def get_saved_xml(conn):
+                return conn.saveImageGetXMLDesc(path, 0)
+
+            saved_xml = get_saved_xml()
+            saved_tree = etree.fromstring(saved_xml)
+            saved_cpu = saved_tree.find('cpu')
+
+            if saved_cpu is None:
+                return
+
+            logger.debug('patching CPU xml for host-model memory snapshot restore, '
+                         'saved cpu mode=%s, agent cpu mode=%s'
+                         % (saved_cpu.get('mode'), current_cpu.get('mode')))
+
+            # preserve topology and numa from agent-built xml if not in saved xml
+            for tag in ('topology', 'numa'):
+                agent_elem = current_cpu.find(tag)
+                saved_elem = saved_cpu.find(tag)
+                if agent_elem is not None and saved_elem is None:
+                    saved_cpu.append(agent_elem)
+
+            # cpu is a direct child of the root <domain> element
+            root = current_tree
+            cpu_index = list(root).index(current_cpu)
+            root.remove(current_cpu)
+            root.insert(cpu_index, saved_cpu)
+            self.domain_xml = etree.tostring(root)
+
+            logger.debug('patched CPU xml from saved image for host-model restore')
+        except Exception as ex:
+            logger.warn('failed to patch CPU xml from saved image, '
+                        'falling back to original xml: %s' % str(ex))
 
     def start(self, timeout=60, create_paused=False, wait_console=True):
         # TODO: 1. enable hair_pin mode

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -10027,11 +10027,13 @@ class InstallLicenseCmd(Command):
             install_xsky_license(args)
 
 # tag::deploymentProfiles[]
+# Format: (heap_gb, maxPoolSize, maxThreads.ratio, scrapeInterval, maxThreadNum, enableElaboration, ping.interval, ping.parallelismDegree)
 deploymentProfiles = {
-        'small':  ( 4,  64, 0.6, 15),
-        'medium': ( 8, 128, 0.5, 30),
-        'large':  (16, 128, 0.4, 60),
-        'default':( 12, 100, 0.6, 15),
+        'small':  ( 4,  64, 0.6, 15, 150, 'true', 60, 100),
+        'medium': ( 8, 128, 0.5, 30, 150, 'true', 60, 100),
+        'large':  (16, 128, 0.4, 60, 300, 'true', 60, 200),
+        'xlarge': (32, 256, 0.3, 120, 1000, 'false', 120, 300),
+        'default':( 12, 100, 0.6, 15, 150, 'true', 60, 100),
 }
 # end::deploymentProfiles[]
 
@@ -10044,6 +10046,7 @@ class SetDeploymentCmd(Command):
 
     def install_argparse_arguments(self, parser):
         parser.add_argument('--size', '-s', help="instance size, one of %s" % deploymentProfiles.keys(), required=True)
+
 
     def find_opt(self, opts, prefix):
         for opt in opts:
@@ -10064,17 +10067,38 @@ class SetDeploymentCmd(Command):
         opts.remove(cur)
         return '-Xmx%sG %s' % (heap, ' '.join(opts))
 
+    def update_global_config(self, category, name, value):
+        sval = str(value).strip()
+
+        db_hostname, db_port, db_user, db_password = ctl.get_live_mysql_portal()
+
+        if db_password:
+            cmd = ShellCmd('''mysql -u %s -p%s --host %s --port %s zstack -e "update GlobalConfigVO set value='%s' where name='%s' and category='%s'"'''
+                           % (db_user, shell_quote(db_password), db_hostname, db_port, sval, name, category))
+        else:
+            cmd = ShellCmd('''mysql -u %s --host %s --port %s zstack -e "update GlobalConfigVO set value='%s' where name='%s' and category='%s'"'''
+                           % (db_user, db_hostname, db_port, sval, name, category))
+        cmd(False)
+        if cmd.return_code != 0:
+            raise CtlError('failed to update GlobalConfig %s.%s: %s' % (category, name, cmd.stderr))
+
+        info('updated GlobalConfig %s.%s to %s via DB (will take effect after MN restart)' % (category, name, sval))
+
     def run(self, args):
         s = args.size.lower()
         if not s in deploymentProfiles.keys():
             raise CtlError('unexpected size: %s' % args.size)
 
-        heap, psize, ratio, sint = deploymentProfiles[s]
+        heap, psize, ratio, sint, max_thread, enable_elab, ping_interval, ping_parallel = deploymentProfiles[s]
         # tag::setdeploymentconfig[]
         commands.getstatusoutput("zstack-ctl setenv CATALINA_OPTS='%s'" % self.build_catalina_opts(heap))
         commands.getstatusoutput("zstack-ctl configure DbFacadeDataSource.maxPoolSize=%s" % psize)
         commands.getstatusoutput("zstack-ctl configure KvmHost.maxThreads.ratio=%s" % ratio)
         commands.getstatusoutput("zstack-ctl configure Prometheus.scrapeInterval=%s" % sint)
+        commands.getstatusoutput("zstack-ctl configure ThreadFacade.maxThreadNum=%s" % max_thread)
+        commands.getstatusoutput("zstack-ctl configure enableElaboration=%s" % enable_elab)
+        self.update_global_config('host', 'ping.interval', ping_interval)
+        self.update_global_config('host', 'ping.parallelismDegree', ping_parallel)
         # end::setdeploymentconfig[]
 
 class ClearLicenseCmd(Command):

--- a/zstacklib/ansible/zstacklib.py
+++ b/zstacklib/ansible/zstacklib.py
@@ -829,7 +829,10 @@ def yum_install_package(name, host_post_info, ignore_error=False,
     runner_args = ZstackRunnerArg()
     runner_args.host_post_info = host_post_info
     runner_args.module_name = 'shell'
-    runner_args.module_args = "rpm -q %s" % name
+    # --whatprovides so a capability already satisfied by an installed
+    # package (e.g. libselinux-python provided by python2-libselinux) is
+    # skipped without needing a repo
+    runner_args.module_args = "rpm -q --whatprovides %s" % name
     runner_args.name = name
     zstack_runner = ZstackRunner(runner_args)
     result = zstack_runner.run()

--- a/zstacklib/zstacklib/test/lvm/test_flush_mpath.py
+++ b/zstacklib/zstacklib/test/lvm/test_flush_mpath.py
@@ -1,0 +1,64 @@
+import unittest
+import mock
+
+from zstacklib.utils import bash
+from zstacklib.utils import lvm
+
+
+# ZSTAC-86075 / TIC-5912: adding a SharedBlock LUN must not run a host-wide
+# `systemctl reload multipathd` while a running VM passes a multipath LUN
+# through (device='lun'), because the global reload's device-mapper
+# suspend/resume window aborts in-flight IO on the in-use map -> guest
+# BLOCK_IO_ERROR. flush_mpath() re-creates only the wiped disk's own map in
+# that case, and keeps the original global reload otherwise.
+class TestFlushMpath(unittest.TestCase):
+
+    def _capture(self):
+        issued = []
+        bash.bash_roe = mock.Mock(side_effect=lambda cmd, *a, **k: issued.append(cmd))
+        return issued
+
+    def test_lun_passthrough_vm_running_uses_targeted_recreate(self):
+        issued = self._capture()
+        lvm.get_dm_wwid = mock.Mock(return_value="361449201002ef3fe11f8a16a00000011")
+        lvm.is_running_vm_using_lun_passthrough = mock.Mock(return_value=True)
+
+        lvm.flush_mpath("/dev/dm-38")
+
+        self.assertIn("multipath -f /dev/dm-38", issued)
+        self.assertIn("multipath 361449201002ef3fe11f8a16a00000011 && sleep 1", issued)
+        self.assertFalse(any("systemctl reload multipathd" in c for c in issued),
+                         "must not run host-wide multipathd reload when a LUN-passthrough VM is running")
+
+    def test_no_lun_passthrough_vm_keeps_global_reload(self):
+        issued = self._capture()
+        lvm.get_dm_wwid = mock.Mock(return_value="361449201002ef3fe11f8a16a00000011")
+        lvm.is_running_vm_using_lun_passthrough = mock.Mock(return_value=False)
+
+        lvm.flush_mpath("/dev/dm-38")
+
+        self.assertIn("multipath -f /dev/dm-38", issued)
+        self.assertTrue(any("systemctl reload multipathd.service && sleep 1" in c for c in issued))
+
+    def test_lun_passthrough_vm_but_unknown_wwid_falls_back_to_global_reload(self):
+        issued = self._capture()
+        lvm.get_dm_wwid = mock.Mock(return_value=None)
+        lvm.is_running_vm_using_lun_passthrough = mock.Mock(return_value=True)
+
+        lvm.flush_mpath("/dev/dm-38")
+
+        self.assertTrue(any("systemctl reload multipathd.service && sleep 1" in c for c in issued))
+
+    def test_is_running_vm_using_lun_passthrough_greps_live_xml(self):
+        bash.bash_r = mock.Mock(return_value=0)
+        self.assertTrue(lvm.is_running_vm_using_lun_passthrough())
+        called = bash.bash_r.call_args[0][0]
+        self.assertIn("device='lun'", called)
+        self.assertIn(lvm.LIVE_LIBVIRT_XML_DIR, called)
+
+        bash.bash_r = mock.Mock(return_value=1)
+        self.assertFalse(lvm.is_running_vm_using_lun_passthrough())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -1101,6 +1101,23 @@ def backup_super_block(disk_path):
 
 
 @bash.in_bash
+def is_running_vm_using_lun_passthrough():
+    return bash.bash_r('''grep -rlF "<disk type='block' device='lun'" %s/*''' % LIVE_LIBVIRT_XML_DIR) == 0
+
+
+@bash.in_bash
+def flush_mpath(disk):
+    wwid = get_dm_wwid(disk)
+    bash.bash_roe("multipath -f %s" % disk)
+    if is_running_vm_using_lun_passthrough() and wwid:
+        # re-create only this disk's map; a host-wide multipathd reload would
+        # suspend in-use maps and abort in-flight IO on LUN-passthrough guests
+        bash.bash_roe("multipath %s && sleep 1" % wwid)
+    else:
+        bash.bash_roe("systemctl reload multipathd.service && sleep 1")
+
+
+@bash.in_bash
 def wipe_fs(disks, expected_vg=None, with_lock=True):
     @bash.in_bash
     def clear_lvmlock(vg_name):
@@ -1139,7 +1156,7 @@ def wipe_fs(disks, expected_vg=None, with_lock=True):
             bash.bash_roe("dmsetup remove /dev/%s" % holder)
 
         if need_flush_mpath:
-            bash.bash_roe("multipath -f %s && systemctl reload multipathd.service && sleep 1" % disk)
+            flush_mpath(disk)
 
         if exists_vg is not None:
             bash.bash_r("grep -l %s /etc/drbd.d/* | xargs rm" % exists_vg)


### PR DESCRIPTION
批量 backport 指派给 jin.ma、fixVersion=5.4.10 的 CLONE issue 到 5.4.10。跨仓库同名分支 @@3。

## 本仓（zstack-utility）包含的修复（7 commit）
- ZSTAC-86305 (→73478) ha: use mount_path instead of ps_uuid for SMP fencer VM matching
- ZSTAC-86490 (→80782) ha: use >= and reset failure count in fencer heartbeat check
- ZSTAC-86472 (→61717) vm_plugin: fix memory snapshot restore for host-model CPU VMs
- ZSTAC-86292 (→58310) kvm: report firstConnect and agent start time
- ZSTAC-86447 (→86075) lvm: avoid global multipathd reload on wipe
- ZSTAC-86454 (→83756) kvm: replace LooseVersion with NumericVersion
- ZSTAC-86352 (→86199) zstacklib: make yum precheck provides-aware

均 `git cherry-pick -x` 保留原始 commit 引用；冲突已按 5.4.10 上下文适配（NumericVersion 新增工具类 + 全局替换 LooseVersion；yum precheck 改 whatprovides）。

配套 zstack/premium/store 同名分支 MR 一同合入。

sync from gitlab !7445