### PR TITLE
<fix>[kvm]: replace LooseVersion with NumericVersion (backport 5.4.10 ZSTAC-86454) (@@3)

### DIFF
--- a/cephbackupstorage/ansible/cephb.py
+++ b/cephbackupstorage/ansible/cephb.py
@@ -2,7 +2,6 @@
 # encoding: utf-8
 import argparse
 import datetime
-from distutils.version import LooseVersion
 
 from zstacklib import *
 
@@ -123,7 +122,7 @@ if host_info.distro in RPM_BASED_OS:
     if remote_bin_installed(host_post_info, "qemu-img", return_status=True):
         (status, qemu_img_version) = get_qemu_img_version(host_post_info)
         # When the qemu-img version is smaller than 4.0.0, rbd is already included
-        if LooseVersion(qemu_img_version) < LooseVersion('4.0.0'):
+        if NumericVersion(qemu_img_version) < NumericVersion('4.0.0'):
             qemu_installed = True
     if not qemu_installed:
         qemu_installed = yum_check_package("qemu-kvm", host_post_info) or yum_check_package("qemu-kvm-ev", host_post_info) or yum_check_package("qemu", host_post_info)
@@ -166,7 +165,7 @@ if host_info.distro in RPM_BASED_OS:
 
     # replace qemu-img binary if qemu-img-ev before 2.12.0 is installed, to fix zstack-11004 / zstack-13594 / zstack-20983
     (status, qemu_img_version) = get_qemu_img_version(host_post_info)
-    if IS_AARCH64 and LooseVersion(qemu_img_version) < LooseVersion('2.12.0'):
+    if IS_AARCH64 and NumericVersion(qemu_img_version) < NumericVersion('2.12.0'):
         copy_arg = CopyArg()
         copy_arg.src = "%s" % qemu_img_pkg
         copy_arg.dest = "%s" % qemu_img_local_pkg

--- a/cephprimarystorage/ansible/cephp.py
+++ b/cephprimarystorage/ansible/cephp.py
@@ -2,7 +2,6 @@
 # encoding: utf-8
 import argparse
 import datetime
-from distutils.version import LooseVersion
 
 from zstacklib import *
 
@@ -103,7 +102,7 @@ if host_info.distro in RPM_BASED_OS:
     if remote_bin_installed(host_post_info, "qemu-img", return_status=True):
         (status, qemu_img_version) = get_qemu_img_version(host_post_info)
         # When the qemu-img version is smaller than 4.0.0, rbd is already included
-        if LooseVersion(qemu_img_version) < LooseVersion('4.0.0'):
+        if NumericVersion(qemu_img_version) < NumericVersion('4.0.0'):
             qemu_installed = True
     if not qemu_installed:
         qemu_installed = yum_check_package("qemu-kvm", host_post_info) or yum_check_package("qemu-kvm-ev", host_post_info) or yum_check_package("qemu", host_post_info)
@@ -146,7 +145,7 @@ if host_info.distro in RPM_BASED_OS:
 
     # replace qemu-img binary if qemu-img-ev before 2.12.0 is installed, to fix zstack-11004 / zstack-13594 / zstack-20983
     (status, qemu_img_version) = get_qemu_img_version(host_post_info)
-    if IS_AARCH64 and LooseVersion(qemu_img_version) < LooseVersion('2.12.0'):
+    if IS_AARCH64 and NumericVersion(qemu_img_version) < NumericVersion('2.12.0'):
         copy_arg = CopyArg()
         copy_arg.src = "%s" % qemu_img_pkg
         copy_arg.dest = "%s" % qemu_img_local_pkg

--- a/cephprimarystorage/cephprimarystorage/cephagent.py
+++ b/cephprimarystorage/cephprimarystorage/cephagent.py
@@ -37,7 +37,7 @@ from zstacklib.utils.linux import remote_shell_quote
 from cephdriver import CephDriver
 from thirdpartycephdriver import ThirdpartyCephDriver
 from zstacklib.utils.misc import IgnoreError
-from distutils.version import LooseVersion
+from zstacklib.utils.version import NumericVersion
 
 log.configure_log('/var/log/zstack/ceph-primarystorage.log')
 logger = log.get_logger(__name__)
@@ -476,7 +476,7 @@ class CephAgent(plugin.TaskManager):
         else:
             xms_version = None
             logger.warn('can not get xms version, the xms-cli version output is: %s' % o)
-        if xms_version and LooseVersion(xms_version) >= LooseVersion('5.2.106.2.230330'):
+        if xms_version and NumericVersion(xms_version) >= NumericVersion('5.2.106.2.230330'):
             return
 
         regex = 'grep -v 3.10.0-'

--- a/imagestorebackupstorage/ansible/imagestorebackupstorage.py
+++ b/imagestorebackupstorage/ansible/imagestorebackupstorage.py
@@ -2,7 +2,6 @@
 # encoding: utf-8
 import argparse
 import datetime
-from distutils.version import LooseVersion
 import os.path
 import re
 
@@ -218,7 +217,7 @@ def load_nbd():
     status = run_remote_command(command, host_post_info, True, False)
     if status is False:
         return "nbd kernel module not found!"
-    if LooseVersion(host_info.kernel_version) > LooseVersion('4.0.0'):
+    if NumericVersion(host_info.kernel_version) > NumericVersion('4.0.0'):
         command = "/sbin/modprobe nbd nbds_max=32 max_part=16"
     else:
         command = "/sbin/modprobe nbd nbds_max=128 max_part=16"

--- a/kvmagent/ansible/kvm.py
+++ b/kvmagent/ansible/kvm.py
@@ -2,7 +2,6 @@
 # encoding=utf-8
 import argparse
 import datetime
-from distutils.version import LooseVersion
 import os
 import re
 from uuid import uuid4
@@ -396,7 +395,7 @@ def install_kvm_pkg():
         # in the libvirtd 5.6.0 and later, the libvirtd daemon now prefers to uses systemd socket activation
         command = "libvirtd --version | grep 'libvirtd (libvirt) ' | cut -d ' ' -f 3 | cut -d '(' -f 1"
         (status, libvirtd_version) = run_remote_command(command, host_post_info, False, True)
-        if LooseVersion(libvirtd_version) >= LooseVersion('5.6.0'):
+        if NumericVersion(libvirtd_version) >= NumericVersion('5.6.0'):
             command = 'systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket'
             run_remote_command(command, host_post_info)
         if chroot_env == 'false':
@@ -421,7 +420,7 @@ def install_kvm_pkg():
         (status, qemu_img_version) = get_qemu_img_version(host_post_info)
         if qemu_img_version is None or qemu_img_version == '':
             error('cannot get qemu-img version!')
-        if LooseVersion(qemu_img_version) < LooseVersion('2.12.0'):
+        if NumericVersion(qemu_img_version) < NumericVersion('2.12.0'):
             qemu_img_src = '{}/{}'.format(file_root, "qemu-img" if host_info.host_arch == 'x86_64' else "qemu-img_"+host_info.host_arch )
             qemu_img_dst = '{}/{}'.format(kvm_root, 'qemu-img')
             copy_to_remote(qemu_img_src, qemu_img_dst, None, host_post_info)

--- a/kvmagent/kvmagent/plugins/ha_plugin.py
+++ b/kvmagent/kvmagent/plugins/ha_plugin.py
@@ -24,7 +24,7 @@ import rados
 import rbd
 import json
 from datetime import datetime, timedelta
-from distutils.version import LooseVersion
+from zstacklib.utils.version import NumericVersion
 import abc
 import functools
 import pprint
@@ -1710,7 +1710,7 @@ def find_root_volume_with_bootindex_from_ps_output(cmdline, vm_uuid, is_file_sys
     if qemu_version == "":
         qemu_version = QEMU_VERSION
 
-    if LooseVersion(LIBVIRT_VERSION) >= LooseVersion("6.0.0") and LooseVersion(qemu_version) >= LooseVersion("4.2.0"):
+    if NumericVersion(LIBVIRT_VERSION) >= NumericVersion("6.0.0") and NumericVersion(qemu_version) >= NumericVersion("4.2.0"):
         if is_file_system:
             root_volume_path = find_root_volume_with_bootindex_and_file_system_from_ps_output(cmdline)
         else:

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -32,8 +32,8 @@ import warnings
 import libvirt
 import xml.dom.minidom as minidom
 #from typing import List, Any, Union
-from distutils.version import LooseVersion
 from collections import Counter
+from zstacklib.utils.version import NumericVersion
 from collections import deque
 
 import zstacklib.utils.ip as ip
@@ -1410,12 +1410,6 @@ def is_nbd_disk(disk_xml):
     return hasattr(disk_xml, 'source') and disk_xml.source.protocol_ == 'nbd'
 
 
-def compare_version(version1, version2):
-    def normalize(v):
-        return [int(x) for x in re.sub(r'(\.0+)*$','', v).split(".")]
-    return cmp(normalize(version1), normalize(version2))
-
-
 KERNEL_VERSION = platform.release()
 LIBVIRT_VERSION = linux.get_libvirt_version()
 LIBVIRT_MAJOR_VERSION = LIBVIRT_VERSION.split('.')[0]
@@ -1423,51 +1417,51 @@ LIBVIRT_MAJOR_VERSION = LIBVIRT_VERSION.split('.')[0]
 QEMU_VERSION = qemu.get_version()
 
 def is_namespace_used():
-    return compare_version(LIBVIRT_VERSION, '1.3.3') >= 0
+    return NumericVersion(LIBVIRT_VERSION) >= NumericVersion('1.3.3')
 
 
 def is_hv_freq_supported():
-    return (compare_version(qemu.get_version(), '2.12.0') >= 0 and
-            LooseVersion(KERNEL_VERSION) >= LooseVersion('3.10.0-957'))
+    return (NumericVersion(qemu.get_version()) >= NumericVersion('2.12.0') and
+            NumericVersion(KERNEL_VERSION) >= NumericVersion('3.10.0-957'))
 
 
 
 def is_hv_synic_supported():
-    return (LooseVersion(qemu.get_version()) >= LooseVersion("4.2.0") and
-            LooseVersion(KERNEL_VERSION) >= LooseVersion("4.18.0"))
+    return (NumericVersion(qemu.get_version()) >= NumericVersion("4.2.0") and
+            NumericVersion(KERNEL_VERSION) >= NumericVersion("4.18.0"))
 
 
 def is_new_ovmf_supported():
     if not linux.is_rpm_installed('edk2-ovmf'):
         return False
     edk2_version = linux.get_rpm_version('edk2-ovmf')
-    return(LooseVersion(qemu.get_version()) >= LooseVersion("4.2.0") and
-           LooseVersion(edk2_version) >= LooseVersion('20220126gitbb1bba3d77-4'))
+    return(NumericVersion(qemu.get_version()) >= NumericVersion("4.2.0") and
+           NumericVersion(edk2_version) >= NumericVersion('20220126gitbb1bba3d77-4'))
 
 
 
 def is_high_mmio_size_supported():
-    return LooseVersion(qemu_img.get_release_version()) >= LooseVersion("6.2.0-902")
+    return NumericVersion(qemu_img.get_release_version()) >= NumericVersion("6.2.0-902")
 
 
 @linux.with_arch(todo_list=['x86_64'])
 def is_ioapic_supported():
-    return compare_version(LIBVIRT_VERSION, '3.4.0') >= 0
+    return NumericVersion(LIBVIRT_VERSION) >= NumericVersion('3.4.0')
 
 def user_specify_driver():
-    return LooseVersion(LIBVIRT_VERSION) >= LooseVersion("6.0.0")
+    return NumericVersion(LIBVIRT_VERSION) >= NumericVersion("6.0.0")
 
 def file_type_support_block_device():
-    return LooseVersion(QEMU_VERSION) < LooseVersion("6.0.0")
+    return NumericVersion(QEMU_VERSION) < NumericVersion("6.0.0")
 
 def is_qemu_support_migrate_with_bitmap(version):
-    return LooseVersion(version) >= LooseVersion("4.2.0-640")
+    return NumericVersion(version) >= NumericVersion("4.2.0-640")
 
 def is_libvirt_support_migrate_with_bitmap(version):
-    return LooseVersion(version) < LooseVersion('6.0.0')
+    return NumericVersion(version) < NumericVersion('6.0.0')
 
 def is_libvirt_support_blockdev(version):
-    return LooseVersion(version) > LooseVersion('6.0.0')
+    return NumericVersion(version) > NumericVersion('6.0.0')
 
 def block_device_use_block_type():
     return user_specify_driver() or not file_type_support_block_device()
@@ -1487,7 +1481,7 @@ def get_domain_type():
 
 def get_gic_version(cpu_num):
     kernel_release = platform.release().split("-")[0]
-    if is_kylin402() and cpu_num <= 8 and LooseVersion(kernel_release) < LooseVersion('4.15.0'):
+    if is_kylin402() and cpu_num <= 8 and NumericVersion(kernel_release) < NumericVersion('4.15.0'):
         return 2
 
 # Occasionally, libvirt might fail to list VM ...
@@ -2774,8 +2768,8 @@ class Vm(object):
         try:
             libvirt_version, libvirt_release = linux.get_libvirt_rpm_info()
             if ((libvirt_version != '' and libvirt_release != '')
-                and (LooseVersion(libvirt_version) == LooseVersion('6.0.0'))
-                and (LooseVersion(libvirt_release) < LooseVersion('560'))):
+                and (NumericVersion(libvirt_version) == NumericVersion('6.0.0'))
+                and (NumericVersion(libvirt_release) < NumericVersion('560'))):
                 return self.domain_xml
 
             return self.domain.XMLDesc(libvirt.VIR_DOMAIN_XML_MIGRATABLE)
@@ -4961,7 +4955,7 @@ class Vm(object):
         """
         if not top.startswith('/dev'):
             return
-        if LooseVersion(qemu.get_version()) > LooseVersion('2.12.0'):
+        if NumericVersion(qemu.get_version()) > NumericVersion('2.12.0'):
             return
         checking_file = top
         while checking_file:
@@ -5486,7 +5480,7 @@ class Vm(object):
                         e(hyperv, 'runtime', attrib={'state': 'on'})
                         # The configuration item 'direct' can only on when
                         # libvirt version >= 6.0.0
-                        if LooseVersion(linux.get_libvirt_version()) >= LooseVersion('6.0.0') and DIST_NAME != 'kylin':
+                        if NumericVersion(linux.get_libvirt_version()) >= NumericVersion('6.0.0') and DIST_NAME != 'kylin':
                             e(stimer, 'direct', attrib={'state': 'on'})
 
                 # refer to: https://access.redhat.com/articles/2470791
@@ -6844,8 +6838,8 @@ def get_vm_blocks(domain_id):
 # Deprecation, use get_disk_device_name instead.
 def get_block_node_name_by_disk_name(domain_id, disk_name):
     all_blocks = get_vm_blocks(domain_id)
-    block = filter(lambda b: disk_name in b['qdev'].split("/"), all_blocks)[0]
-    if LooseVersion(LIBVIRT_VERSION) < LooseVersion("6.0.0"):
+    block = [b for b in all_blocks if disk_name in b['qdev'].split("/")][0]
+    if NumericVersion(LIBVIRT_VERSION) < NumericVersion("6.0.0"):
         return block['device']
     return block["inserted"]['node-name']
 
@@ -12754,10 +12748,10 @@ host side snapshot files chian:
             raise Exception(('The qemu guest agent not in running state'))
 
         ga_version = qga.guest_info()['version']
-        if LooseVersion(ga_version) < LooseVersion('2.5'):
+        if NumericVersion(ga_version) < NumericVersion('2.5'):
             raise Exception(('The guest agent version %s less '
                              'than minimum requirement 2.5.0') % ga_version)
-        elif LooseVersion('100.0') > LooseVersion(ga_version) >= LooseVersion('5.2'):
+        elif NumericVersion('100.0') > NumericVersion(ga_version) >= NumericVersion('5.2'):
             ga_add_authorized_keys()
         else:
             leagacy_add_authorized_keys()
@@ -12789,10 +12783,10 @@ host side snapshot files chian:
             raise Exception(('The qemu guest agent not in running state'))
 
         ga_version = qga.guest_info()['version']
-        if LooseVersion(ga_version) < LooseVersion('2.5'):
+        if NumericVersion(ga_version) < NumericVersion('2.5'):
             raise Exception(('The guest agent version %s less than '
                              'minimum requirement version 2.5') % ga_version)
-        elif LooseVersion('100.0') > LooseVersion(ga_version) >= LooseVersion('5.2'):
+        elif NumericVersion('100.0') > NumericVersion(ga_version) >= NumericVersion('5.2'):
             ga_remove_authorized_keys()
         else:
             leagacy_remove_authorized_keys()

--- a/kvmagent/kvmagent/test/vm_plugin_testsuite/test_vm_hv_features.py
+++ b/kvmagent/kvmagent/test/vm_plugin_testsuite/test_vm_hv_features.py
@@ -2,7 +2,7 @@ from kvmagent.plugins import vm_plugin
 from kvmagent.test.utils import vm_utils, network_utils, pytest_utils
 from kvmagent.test.utils.stub import *
 from unittest import TestCase
-from distutils.version import LooseVersion
+from kvmagent.plugins.vm_plugin import NumericVersion
 
 import platform
 
@@ -76,7 +76,7 @@ class TestVmMaxVcpu(TestCase, vm_utils.VmPluginTestStub):
             r, o = bash.bash_ro(
                 "virsh dumpxml %s | grep %s" % (vm.vmInstanceUuid, feature))
             
-            if LooseVersion(vm_plugin.KERNEL_VERSION) > LooseVersion("3.10.0"):
+            if NumericVersion(vm_plugin.KERNEL_VERSION) > NumericVersion("3.10.0"):
                 self.assertTrue(r == 0, "missing feature %s from xml" % feature)
             else:
                 self.assertTrue(r == 1, "unexpected feature %s from xml %s" % (feature, o))

--- a/tests/unit/zstacklib/test_numeric_version.py
+++ b/tests/unit/zstacklib/test_numeric_version.py
@@ -1,0 +1,70 @@
+import unittest
+
+from zstacklib.utils.version import NumericVersion
+
+
+class TestNumericVersion(unittest.TestCase):
+
+    def test_standard_version(self):
+        self.assertTrue(NumericVersion('5.2.0') >= NumericVersion('5.2'))
+        self.assertTrue(NumericVersion('2.5.0') >= NumericVersion('2.5'))
+        self.assertFalse(NumericVersion('2.4') >= NumericVersion('2.5'))
+
+    def test_non_standard_version_with_suffix(self):
+        # e.g., qemu-ga version '5.2.0-8.el8'
+        self.assertTrue(NumericVersion('5.2.0-8.el8') >= NumericVersion('5.2'))
+        self.assertFalse(NumericVersion('5.2.0-8.el8') < NumericVersion('2.5'))
+        self.assertTrue(NumericVersion('5.2.0-8.el8') < NumericVersion('100.0'))
+
+    def test_version_with_letters_in_middle(self):
+        # e.g., '2.a.1' -> [2, 1]
+        self.assertTrue(NumericVersion('2.a.1') < NumericVersion('2.5'))
+
+    def test_version_with_distro_suffix(self):
+        # e.g., '108.1.0.el8_10.1'
+        self.assertTrue(NumericVersion('108.1.0.el8_10.1') >= NumericVersion('5.2'))
+        self.assertFalse(NumericVersion('108.1.0.el8_10.1') < NumericVersion('100.0'))
+
+    def test_kernel_version(self):
+        # e.g., '4.18.0-305.el8.x86_64'
+        self.assertTrue(NumericVersion('4.18.0-305.el8.x86_64') >= NumericVersion('3.10.0'))
+        self.assertTrue(NumericVersion('4.18.0-305.el8.x86_64') >= NumericVersion('4.18.0'))
+
+    def test_release_version_with_build_number(self):
+        # e.g., '6.2.0-902'
+        self.assertTrue(NumericVersion('6.2.0-902') >= NumericVersion('6.2.0'))
+        self.assertFalse(NumericVersion('6.2.0-902') < NumericVersion('5.2'))
+
+    def test_edk2_version(self):
+        # edk2-ovmf versions like '20230517gitXXX-2.el8'
+        threshold = NumericVersion('20220126gitbb1bba3d77-4')
+        self.assertTrue(NumericVersion('20230517gitXXX-2.el8') >= threshold)
+        self.assertFalse(NumericVersion('20200101gitYYY-1.el8') >= threshold)
+
+    def test_equal_versions(self):
+        self.assertTrue(NumericVersion('5.2') == NumericVersion('5.2'))
+        self.assertTrue(NumericVersion('1.0.0') == NumericVersion('1.0.0'))
+
+    def test_chained_comparison(self):
+        # Same pattern used in do_attach_ssh_key_pair
+        ga_version = '5.2.0-8.el8'
+        self.assertTrue(
+            NumericVersion('100.0') > NumericVersion(ga_version) >= NumericVersion('5.2')
+        )
+
+    def test_below_minimum(self):
+        self.assertTrue(NumericVersion('1.9') < NumericVersion('2.5'))
+        self.assertTrue(NumericVersion('2.4.9') < NumericVersion('2.5'))
+
+    def test_repr(self):
+        v = NumericVersion('5.2.0-8.el8')
+        self.assertIn('5.2.0-8.el8', repr(v))
+
+    def test_version_list_contains_only_ints(self):
+        v = NumericVersion('5.2.0-8.el8')
+        for item in v.version:
+            self.assertIsInstance(item, int)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zbsprimarystorage/zbsprimarystorage/zbsutils.py
+++ b/zbsprimarystorage/zbsprimarystorage/zbsutils.py
@@ -1,7 +1,7 @@
 __author__ = 'Xingwei Yu'
 
 import os
-from distutils.version import LooseVersion
+from zstacklib.utils.version import NumericVersion
 
 import zstacklib.utils.jsonobject as jsonobject
 
@@ -57,7 +57,7 @@ c.f. http://jira.zstack.io/browse/ZBS-327
 
 @in_bash
 def get_cluster_uuid(cluster_version):
-    if cluster_version and LooseVersion(cluster_version) < LooseVersion(CLUSTER_UUID_SUPPORTED_VERSION):
+    if cluster_version and NumericVersion(cluster_version) < NumericVersion(CLUSTER_UUID_SUPPORTED_VERSION):
         return None
 
     _, o, _ = bash_roe("%s cluster ls --format json" % ZBSADM_BIN_PATH)

--- a/zstacklib/ansible/zstacklib.py
+++ b/zstacklib/ansible/zstacklib.py
@@ -2662,6 +2662,59 @@ def get_qemu_img_version(host_post_info):
     return status, qemu_img_version
 
 
+class NumericVersion(object):
+    """Version comparison that extracts only numeric segments.
+
+    e.g., '5.2.0-8.el8' -> [5, 2, 0, 8, 8], '2.a.1' -> [2, 1]
+    """
+    component_re = re.compile(r'(\d+|[a-z]+|\.)', re.VERBOSE)
+
+    def __init__(self, vstring):
+        self.vstring = str(vstring)
+        components = [x for x in self.component_re.split(self.vstring) if x and x != '.']
+        self.version = tuple(int(x) for x in components if x.isdigit())
+
+    def _pad(self, other):
+        if isinstance(other, str):
+            other = NumericVersion(other)
+        elif not isinstance(other, NumericVersion):
+            return NotImplemented
+        maxlen = max(len(self.version), len(other.version))
+        a = self.version + (0,) * (maxlen - len(self.version))
+        b = other.version + (0,) * (maxlen - len(other.version))
+        return a, b
+
+    def __lt__(self, other):
+        pair = self._pad(other)
+        return NotImplemented if pair is NotImplemented else pair[0] < pair[1]
+
+    def __le__(self, other):
+        pair = self._pad(other)
+        return NotImplemented if pair is NotImplemented else pair[0] <= pair[1]
+
+    def __gt__(self, other):
+        pair = self._pad(other)
+        return NotImplemented if pair is NotImplemented else pair[0] > pair[1]
+
+    def __ge__(self, other):
+        pair = self._pad(other)
+        return NotImplemented if pair is NotImplemented else pair[0] >= pair[1]
+
+    def __eq__(self, other):
+        pair = self._pad(other)
+        return NotImplemented if pair is NotImplemented else pair[0] == pair[1]
+
+    def __ne__(self, other):
+        pair = self._pad(other)
+        return NotImplemented if pair is NotImplemented else pair[0] != pair[1]
+
+    def __repr__(self):
+        return 'NumericVersion(%r)' % self.vstring
+
+    def __str__(self):
+        return self.vstring
+
+
 def main():
     # Reserve for test api
     pass

--- a/zstacklib/zstacklib/utils/ceph.py
+++ b/zstacklib/zstacklib/utils/ceph.py
@@ -23,7 +23,7 @@ QEMU_NBD_SOCKET_DIR = "/var/lock/"
 QEMU_NBD_SOCKET_PREFIX = "qemu-nbd-nbd"
 NBD_DEV_PREFIX = "/dev/nbd"
 SUPPORT_DEFER_DELETING = None
-from distutils.version import LooseVersion
+from zstacklib.utils.version import NumericVersion
 
 def get_fsid(conffile='/etc/ceph/ceph.conf'):
     import rados
@@ -414,4 +414,4 @@ def get_version():
 
 def rbd_create_support_byte():
     # ceph hammer not support in bytes
-    return get_ceph_manufacturer() != "open-source" or LooseVersion(get_version()) >= LooseVersion("10.0.0")
+    return get_ceph_manufacturer() != "open-source" or NumericVersion(get_version()) >= NumericVersion("10.0.0")

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -24,7 +24,7 @@ from zstacklib.utils import thread
 from zstacklib.utils import sanlock
 from zstacklib.utils import remoteStorage
 from cachetools import TTLCache
-from distutils.version import LooseVersion
+from zstacklib.utils.version import NumericVersion
 
 from zstacklib.utils.linux import get_fs_type
 
@@ -451,7 +451,7 @@ def get_multipath_name(dev_name):
 
 def get_lvmlockd_service_name():
     service_name = 'lvm2-lvmlockd.service'
-    if LooseVersion(get_lvmlockd_version()) > LooseVersion("2.02"):
+    if NumericVersion(get_lvmlockd_version()) > NumericVersion("2.02"):
         service_name = 'lvmlockd.service'
     return service_name
 
@@ -808,7 +808,7 @@ def start_lock_service(io_timeout=40):
 
     def is_lvmlockd_upgraded():
         running_lockd_version = get_running_lvmlockd_version()
-        return running_lockd_version is not None and LooseVersion(running_lockd_version) < LooseVersion(get_lvmlockd_version())
+        return running_lockd_version is not None and NumericVersion(running_lockd_version) < NumericVersion(get_lvmlockd_version())
 
     def need_restart_sanlock():
         running_patch_version = get_running_sanlock_patch_version()
@@ -829,7 +829,7 @@ def start_lock_service(io_timeout=40):
 
     restart_sanlock = need_restart_sanlock()
     restart_lvmlockd = restart_sanlock or is_lvmlockd_upgraded() or \
-                       (LooseVersion(get_lvmlockd_version()) >= LooseVersion("2.03") and LvmlockdStatus().failed)
+                       (NumericVersion(get_lvmlockd_version()) >= NumericVersion("2.03") and LvmlockdStatus().failed)
     if restart_sanlock:
         stop_sanlock()
     if restart_lvmlockd:

--- a/zstacklib/zstacklib/utils/qemu_img.py
+++ b/zstacklib/zstacklib/utils/qemu_img.py
@@ -1,5 +1,5 @@
 from zstacklib.utils import shell
-from distutils.version import LooseVersion
+from zstacklib.utils.version import NumericVersion
 import json
 import re
 
@@ -34,7 +34,7 @@ def get_release_version():
 
 def subcmd(subcmd):
     options = ''
-    if LooseVersion(get_version()) >= LooseVersion('2.10.0'):
+    if NumericVersion(get_version()) >= NumericVersion('2.10.0'):
         if subcmd in ['info', 'check', 'compare', 'convert', 'rebase', 'measure']:
             options += ' --force-share '
     return 'qemu-img %s %s ' % (subcmd, options)
@@ -48,10 +48,10 @@ def get_check_result(path):
                        result.get("filename"), result.get("format"))
 
 def take_default_backing_fmt_for_convert():
-    return LooseVersion(get_version()) <= LooseVersion("6.0.0")
+    return NumericVersion(get_version()) <= NumericVersion("6.0.0")
 
 def resize_backing_before_rebase():
-    return LooseVersion(get_release_version()) < LooseVersion("6.2.0-227")
+    return NumericVersion(get_release_version()) < NumericVersion("6.2.0-227")
 
 
 

--- a/zstacklib/zstacklib/utils/qmp.py
+++ b/zstacklib/zstacklib/utils/qmp.py
@@ -4,7 +4,7 @@ import errno
 import socket
 import logging
 import re
-from distutils.version import LooseVersion
+from zstacklib.utils.version import NumericVersion
 
 from zstacklib.utils.misc import ignore_exception
 
@@ -122,7 +122,7 @@ def qmp_subcmd(qemu_version, s_cmd):
     # '{"execute": "object-add", "arguments": {"vnet_hdr_support": true, "iothread": "iothread%s",
     #              "secondary_in": "secondary-in-s-%s", "primary_in": "primary-in-c-%s", "id": "comp-%s",
     #              "qom-type": "colo-compare", "outdev": "primary-out-c-%s"}}'
-    if LooseVersion(qemu_version) >= LooseVersion("6.0.0") and re.match(r'.*object-add.*arguments.*props.*', s_cmd):
+    if NumericVersion(qemu_version) >= NumericVersion("6.0.0") and re.match(r'.*object-add.*arguments.*props.*', s_cmd):
         j_cmd = json.loads(s_cmd)
         props = j_cmd.get("arguments").get("props")
         j_cmd.get("arguments").pop("props")

--- a/zstacklib/zstacklib/utils/version.py
+++ b/zstacklib/zstacklib/utils/version.py
@@ -1,0 +1,58 @@
+import re
+
+
+class NumericVersion(object):
+    """Version comparison that extracts only numeric segments.
+
+    Based on distutils.version.LooseVersion parsing logic, but filters
+    out non-numeric segments to avoid Python 3 int vs str TypeError.
+
+    e.g., '5.2.0-8.el8' -> (5, 2, 0, 8, 8), '2.a.1' -> (2, 1)
+    """
+
+    component_re = re.compile(r'(\d+|[a-z]+|\.)', re.VERBOSE)
+
+    def __init__(self, vstring):
+        self.vstring = str(vstring)
+        components = [x for x in self.component_re.split(self.vstring) if x and x != '.']
+        self.version = tuple(int(x) for x in components if x.isdigit())
+
+    def _pad(self, other):
+        if isinstance(other, str):
+            other = NumericVersion(other)
+        elif not isinstance(other, NumericVersion):
+            return NotImplemented
+        maxlen = max(len(self.version), len(other.version))
+        a = self.version + (0,) * (maxlen - len(self.version))
+        b = other.version + (0,) * (maxlen - len(other.version))
+        return a, b
+
+    def __lt__(self, other):
+        pair = self._pad(other)
+        return NotImplemented if pair is NotImplemented else pair[0] < pair[1]
+
+    def __le__(self, other):
+        pair = self._pad(other)
+        return NotImplemented if pair is NotImplemented else pair[0] <= pair[1]
+
+    def __gt__(self, other):
+        pair = self._pad(other)
+        return NotImplemented if pair is NotImplemented else pair[0] > pair[1]
+
+    def __ge__(self, other):
+        pair = self._pad(other)
+        return NotImplemented if pair is NotImplemented else pair[0] >= pair[1]
+
+    def __eq__(self, other):
+        pair = self._pad(other)
+        return NotImplemented if pair is NotImplemented else pair[0] == pair[1]
+
+    def __ne__(self, other):
+        pair = self._pad(other)
+        return NotImplemented if pair is NotImplemented else pair[0] != pair[1]
+
+    def __repr__(self):
+        return 'NumericVersion(%r)' % self.vstring
+
+    def __str__(self):
+        return self.vstring

--- a/zstacklib/zstacklib/utils/zstone.py
+++ b/zstacklib/zstacklib/utils/zstone.py
@@ -1,6 +1,6 @@
 import zstacklib.utils.jsonobject as jsonobject
 from zstacklib.utils import shell, bash
-from distutils.version import LooseVersion
+from zstacklib.utils.version import NumericVersion
 
 class ZStoneCephPoolCapacityGetter():
     def fill_pool_capacity(self, result):
@@ -27,7 +27,7 @@ class ZStoneCephPoolCapacityGetter():
 
 
 def calc_capacity_with_ratio():
-    return LooseVersion(get_zstone_version()) >= LooseVersion("4.3.6")
+    return NumericVersion(get_zstone_version()) >= NumericVersion("4.3.6")
 
 
 def get_zstone_version():


### PR DESCRIPTION
单独拆出的 backport：ZSTAC-86454 (→83756) 到 5.4.10。

## 内容
kvm: replace LooseVersion with NumericVersion —— 新增 `zstacklib/utils/version.py`（NumericVersion，只提取数字段做安全比较），全局替换各处 LooseVersion 用法，避免非标准版本号（如 qemu-ga）比较时 TypeError 崩溃。

## 改动规模
17 文件 +236/-65（含新增 version.py + test_numeric_version.py）

## 冲突适配说明（cherry-pick 到 5.4.10）
- 原 commit 基于用 `get_libvirt_version()` 的基线；5.4.10 用模块变量 `LIBVIRT_VERSION`，已统一改用 `NumericVersion(LIBVIRT_VERSION)`。
- 删除 5.4.10 本地 `compare_version` 辅助（原 commit 意图移除）。
- `tests/conftest.py`、`qemu/img.py`、`qemu/version.py` 在 5.4.10 已删除，保持删除。
- 保持 Python2 语法，无 subprocess.getstatusoutput 误引入，确认无 LooseVersion 残留。

`git cherry-pick -x` 保留原始 commit 引用。因改动面大（17 文件），从批量 backport MR (!7445) 中单独拆出便于评审。

Resolves: ZSTAC-83756

sync from gitlab !7447