### PR TITLE
<fix>[zstacklib]: wait qemu-nbd before LV deactivate

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -9474,10 +9474,15 @@ host side snapshot files chian:
     def unexport_nbd_volumes(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = kvmagent.AgentResponse()
+
+        @linux.retry(times=3, sleep_time=2)
+        def deactive_volume(path):
+            self.deactive_volume_if_need(path, False)
+
         for volume in cmd.volumes:
             real_path = self.get_cbt_volume_actual_install_path(volume.installPath)
             qemu_nbd.kill_nbd_process_by_flag(real_path)
-            self.deactive_volume_if_need(real_path, False)
+            deactive_volume(real_path)
 
         rsp.success = True
         return jsonobject.dumps(rsp)
@@ -9496,7 +9501,10 @@ host side snapshot files chian:
         volume_export_info = {}
         for volume in cmd.volumes:
             volume_export_info[volume.volumeUuid] = False
+            real_path = self.get_cbt_volume_actual_install_path(volume.installPath)
             if qemu_nbd.find_qemu_nbd_process(volume.installPath) == 0:
+                volume_export_info[volume.volumeUuid] = True
+            elif real_path != volume.installPath and qemu_nbd.find_qemu_nbd_process(real_path) == 0:
                 volume_export_info[volume.volumeUuid] = True
 
         rsp.volumeExportInfos = volume_export_info

--- a/zstacklib/zstacklib/test/test_qemu_nbd.py
+++ b/zstacklib/zstacklib/test/test_qemu_nbd.py
@@ -1,0 +1,83 @@
+import unittest
+
+from zstacklib.utils import qemu_nbd
+
+
+class TestQemuNbd(unittest.TestCase):
+    def test_kill_nbd_waits_until_process_gone(self):
+        calls = []
+        original_kill = qemu_nbd.kill_qemu_nbd_process
+        original_wait = qemu_nbd.wait_qemu_nbd_process_gone
+
+        def kill(pattern):
+            calls.append(('kill', pattern))
+            return 0
+
+        def wait(pattern, timeout, interval):
+            calls.append(('wait', pattern, timeout, interval))
+            return True
+
+        qemu_nbd.kill_qemu_nbd_process = kill
+        qemu_nbd.wait_qemu_nbd_process_gone = wait
+        try:
+            ret = qemu_nbd.kill_nbd_process_by_flag('/dev/vg/volume', timeout=7, interval=2)
+        finally:
+            qemu_nbd.kill_qemu_nbd_process = original_kill
+            qemu_nbd.wait_qemu_nbd_process_gone = original_wait
+
+        self.assertEqual(0, ret)
+        self.assertEqual(('kill', '/dev/vg/volume'), calls[0])
+        self.assertEqual(('wait', '/dev/vg/volume', 7, 2), calls[1])
+
+    def test_kill_nbd_fails_when_process_still_exists(self):
+        original_kill = qemu_nbd.kill_qemu_nbd_process
+        original_wait = qemu_nbd.wait_qemu_nbd_process_gone
+
+        qemu_nbd.kill_qemu_nbd_process = lambda pattern: 0
+        qemu_nbd.wait_qemu_nbd_process_gone = lambda pattern, timeout, interval: False
+        try:
+            self.assertRaises(Exception, qemu_nbd.kill_nbd_process_by_flag, '/dev/vg/volume')
+        finally:
+            qemu_nbd.kill_qemu_nbd_process = original_kill
+            qemu_nbd.wait_qemu_nbd_process_gone = original_wait
+
+    def test_find_qemu_nbd_process_uses_fixed_string_match(self):
+        original_run = qemu_nbd.shell.run
+        commands = []
+
+        def run(command):
+            commands.append(command)
+            return 1
+
+        qemu_nbd.shell.run = run
+        try:
+            qemu_nbd.find_qemu_nbd_process("/dev/vg/volume'with-quote")
+        finally:
+            qemu_nbd.shell.run = original_run
+
+        self.assertEqual(1, len(commands))
+        self.assertTrue("grep -F --" in commands[0])
+        self.assertTrue("/dev/vg/volume" in commands[0])
+
+    def test_kill_qemu_nbd_process_uses_fixed_string_match(self):
+        original_run = qemu_nbd.shell.run
+        commands = []
+
+        def run(command):
+            commands.append(command)
+            return 0
+
+        qemu_nbd.shell.run = run
+        try:
+            qemu_nbd.kill_qemu_nbd_process("/dev/vg/volume'with-quote")
+        finally:
+            qemu_nbd.shell.run = original_run
+
+        self.assertEqual(1, len(commands))
+        self.assertTrue("grep -F --" in commands[0])
+        self.assertTrue("xargs -r kill -15" in commands[0])
+        self.assertTrue("'\\''" in commands[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zstacklib/zstacklib/utils/qemu_nbd.py
+++ b/zstacklib/zstacklib/utils/qemu_nbd.py
@@ -2,6 +2,9 @@ from zstacklib.utils import linux
 from zstacklib.utils import shell
 import subprocess
 
+DEFAULT_KILL_TIMEOUT = 60
+DEFAULT_KILL_INTERVAL = 1
+
 
 def export(port, *args):
     command = 'qemu-nbd -p %s' % port
@@ -11,11 +14,26 @@ def export(port, *args):
     return process
 
 
-def kill_nbd_process_by_flag(flag):
-    regex = 'qemu-nbd.*%s' % flag
-    return linux.pkill_by_pattern(regex)
-
-
 def find_qemu_nbd_process(pattern):
-    command = "pgrep -a qemu-nbd | grep %s" % pattern
+    command = "pgrep -a qemu-nbd | grep -F -- %s" % linux.shellquote(pattern)
     return shell.run(command)
+
+
+def kill_qemu_nbd_process(pattern):
+    command = ("pgrep -a qemu-nbd | grep -F -- %s | "
+               "awk '{print $1}' | xargs -r kill -15") % linux.shellquote(pattern)
+    return shell.run(command)
+
+
+def wait_qemu_nbd_process_gone(pattern, timeout=DEFAULT_KILL_TIMEOUT, interval=DEFAULT_KILL_INTERVAL):
+    def gone(_):
+        return find_qemu_nbd_process(pattern) != 0
+
+    return linux.wait_callback_success(gone, timeout=timeout, interval=interval)
+
+
+def kill_nbd_process_by_flag(flag, timeout=DEFAULT_KILL_TIMEOUT, interval=DEFAULT_KILL_INTERVAL):
+    ret = kill_qemu_nbd_process(flag)
+    if not wait_qemu_nbd_process_gone(flag, timeout, interval):
+        raise Exception('timeout waiting qemu-nbd process[%s] gone after SIGTERM' % flag)
+    return ret


### PR DESCRIPTION
CBT force unexport previously sent SIGTERM to qemu-nbd and immediately
deactivated SharedBlock LVs. When qemu-nbd still held the LV after a
large restore, lvchange -an could fail and stale activation could
block VM start on another host.

Wait for the matching qemu-nbd process to disappear before LV
deactivation, retry the deactivate step, and check both the original
CBT install path and converted real path when detecting exported NBD
volumes. SharedBlock LV buffer flushing is not included in this patch.

Cleanup still fails explicitly if qemu-nbd does not exit or the LV cannot
be deactivated after retries. Added focused qemu_nbd unit coverage; local
unittest execution is blocked in this workspace because zstacklib
imports fcntl, which is unavailable in the local Windows Python runtime.

Resolves: ZSV-12604
Resolves: ZSV-12606

Change-Id: I72676763627771726173656475696c6474637867

sync from gitlab !7461