### PR TITLE
<fix>[kvmagent]: ZSV-12469 support volume encryption conversion rollback

### DIFF
--- a/cephprimarystorage/cephprimarystorage/cephagent.py
+++ b/cephprimarystorage/cephprimarystorage/cephagent.py
@@ -329,6 +329,7 @@ class CephAgent(plugin.TaskManager):
     ADD_POOL_PATH = "/ceph/primarystorage/addpool"
     CHECK_POOL_PATH = "/ceph/primarystorage/checkpool"
     RESIZE_VOLUME_PATH = "/ceph/primarystorage/volume/resize"
+    LUKS_ROLLBACK_CONVERT_PATH = "/ceph/primarystorage/volume/luksconvert/rollback"
     LUKS_SWAP_IN_PLACE_PATH = "/ceph/primarystorage/volume/luksswapinplace"
     MIGRATE_VOLUME_SEGMENT_PATH = "/ceph/primarystorage/volume/migratesegment"
     GET_VOLUME_SNAPINFOS_PATH = "/ceph/primarystorage/volume/getsnapinfos"
@@ -404,6 +405,7 @@ class CephAgent(plugin.TaskManager):
         self.http_server.register_async_uri(self.DELETE_IMAGE_CACHE, self.delete_image_cache)
         self.http_server.register_async_uri(self.CHECK_BITS_PATH, self.check_bits)
         self.http_server.register_async_uri(self.RESIZE_VOLUME_PATH, self.resize_volume)
+        self.http_server.register_async_uri(self.LUKS_ROLLBACK_CONVERT_PATH, self.rollback_luks_volume_conversion)
         self.http_server.register_async_uri(self.LUKS_SWAP_IN_PLACE_PATH, self.swap_luks_volume_in_place)
         self.http_server.register_sync_uri(self.ECHO_PATH, self.echo)
         self.http_server.register_async_uri(self.MIGRATE_VOLUME_SEGMENT_PATH, self.migrate_volume_segment, cmd=CephToCephMigrateVolumeSegmentCmd())
@@ -1179,6 +1181,22 @@ class CephAgent(plugin.TaskManager):
                 if shell.run('rbd mv %s %s' % (old_path, src_path)) != 0:
                     logger.warn('failed to restore original RBD image after LUKS in-place swap: source[%s], temporary[%s], old[%s]' %
                                 (src_path, tmp_path, old_path))
+
+        return jsonobject.dumps(AgentResponse())
+
+    @replyerror
+    def rollback_luks_volume_conversion(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        target_path = self._normalize_install_path(cmd.targetInstallPath)
+        if '@' in target_path:
+            raise Exception('RBD LUKS rollback only supports active image paths: target[%s]' % target_path)
+
+        if self._rbd_image_exists(target_path):
+            watcher = self._get_watcher(target_path)
+            if watcher:
+                raise Exception('unable to delete converted RBD target %s during LUKS rollback, the image is in use: %s' %
+                                (target_path, watcher))
+            shell.call('rbd rm %s' % target_path)
 
         return jsonobject.dumps(AgentResponse())
 

--- a/cephprimarystorage/cephprimarystorage/cephagent.py
+++ b/cephprimarystorage/cephprimarystorage/cephagent.py
@@ -329,7 +329,6 @@ class CephAgent(plugin.TaskManager):
     ADD_POOL_PATH = "/ceph/primarystorage/addpool"
     CHECK_POOL_PATH = "/ceph/primarystorage/checkpool"
     RESIZE_VOLUME_PATH = "/ceph/primarystorage/volume/resize"
-    LUKS_REPLACE_VOLUME_PATH = "/ceph/primarystorage/volume/luksreplace"
     LUKS_SWAP_IN_PLACE_PATH = "/ceph/primarystorage/volume/luksswapinplace"
     MIGRATE_VOLUME_SEGMENT_PATH = "/ceph/primarystorage/volume/migratesegment"
     GET_VOLUME_SNAPINFOS_PATH = "/ceph/primarystorage/volume/getsnapinfos"
@@ -405,7 +404,6 @@ class CephAgent(plugin.TaskManager):
         self.http_server.register_async_uri(self.DELETE_IMAGE_CACHE, self.delete_image_cache)
         self.http_server.register_async_uri(self.CHECK_BITS_PATH, self.check_bits)
         self.http_server.register_async_uri(self.RESIZE_VOLUME_PATH, self.resize_volume)
-        self.http_server.register_async_uri(self.LUKS_REPLACE_VOLUME_PATH, self.replace_luks_volume)
         self.http_server.register_async_uri(self.LUKS_SWAP_IN_PLACE_PATH, self.swap_luks_volume_in_place)
         self.http_server.register_sync_uri(self.ECHO_PATH, self.echo)
         self.http_server.register_async_uri(self.MIGRATE_VOLUME_SEGMENT_PATH, self.migrate_volume_segment, cmd=CephToCephMigrateVolumeSegmentCmd())
@@ -1183,73 +1181,6 @@ class CephAgent(plugin.TaskManager):
                                 (src_path, tmp_path, old_path))
 
         return jsonobject.dumps(AgentResponse())
-
-    @replyerror
-    def replace_luks_volume(self, req):
-        cmd = jsonobject.loads(req[http.REQUEST_BODY])
-        src_path = self._normalize_install_path(cmd.installPath)
-        tmp_path = self._normalize_install_path(cmd.temporaryInstallPath)
-        target_path = self._normalize_install_path(getattr(cmd, 'targetInstallPath', None) or cmd.installPath)
-        trash_path = getattr(cmd, 'sourceTrashInstallPath', None)
-        delete_source_trash = getattr(cmd, 'deleteSourceTrash', False)
-        if trash_path:
-            trash_path = self._normalize_install_path(trash_path)
-        else:
-            trash_path = '%s-trash-%s' % (src_path, uuidlib.uuid4().hex[:8])
-            delete_source_trash = True
-
-        if '@' in src_path or '@' in tmp_path or '@' in target_path or '@' in trash_path:
-            raise Exception('RBD LUKS replacement only supports active image paths: source[%s], temporary[%s], target[%s], trash[%s]' %
-                            (src_path, tmp_path, target_path, trash_path))
-
-        if self._rbd_image_exists(trash_path):
-            raise Exception('RBD trash image already exists: %s' % trash_path)
-        if target_path != src_path and self._rbd_image_exists(target_path):
-            raise Exception('RBD target image already exists: %s' % target_path)
-        if not self._rbd_image_exists(src_path):
-            raise Exception('RBD source image does not exist: %s' % src_path)
-        if not self._rbd_image_exists(tmp_path):
-            raise Exception('RBD temporary image does not exist: %s' % tmp_path)
-
-        moved_original = False
-        replaced = False
-        try:
-            shell.call('rbd mv %s %s' % (src_path, trash_path))
-            moved_original = True
-            try:
-                shell.call('rbd mv %s %s' % (tmp_path, target_path))
-                moved_original = False
-                replaced = True
-            except Exception:
-                shell.call('rbd mv %s %s' % (trash_path, src_path))
-                moved_original = False
-                if self._rbd_image_exists(tmp_path):
-                    if shell.run('rbd rm %s' % tmp_path) != 0:
-                        logger.warn('failed to remove temporary RBD image after failed LUKS replacement rollback: %s' % tmp_path)
-                raise
-
-            if delete_source_trash:
-                if shell.run('rbd rm %s' % trash_path) != 0:
-                    logger.warn('failed to remove source trash after LUKS replacement: %s' % trash_path)
-        finally:
-            if replaced and self._rbd_image_exists(tmp_path):
-                if shell.run('rbd rm %s' % tmp_path) != 0:
-                    logger.warn('failed to remove temporary RBD image after LUKS replacement: %s' % tmp_path)
-            if moved_original and self._rbd_image_exists(trash_path):
-                if shell.run('rbd mv %s %s' % (trash_path, src_path)) != 0:
-                    logger.warn('failed to restore source RBD image after LUKS replacement: source[%s], temporary[%s], trash[%s]' %
-                                (src_path, tmp_path, trash_path))
-
-        rsp = GetVolumeSizeRsp()
-        try:
-            rsp.size = self._get_file_size(target_path)
-        except Exception as e:
-            logger.warn('failed to get RBD size after LUKS replacement committed: %s, %s' % (target_path, e))
-        try:
-            rsp.actualSize = self._get_file_actual_size(target_path)
-        except Exception as e:
-            logger.warn('failed to get RBD actual size after LUKS replacement committed: %s, %s' % (target_path, e))
-        return jsonobject.dumps(rsp)
 
     @replyerror
     def create(self, req):

--- a/kvmagent/kvmagent/plugins/localstorage.py
+++ b/kvmagent/kvmagent/plugins/localstorage.py
@@ -287,6 +287,7 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
     PREFIX_REBASE_BACKING_FILES_PATH = "/localstorage/snapshot/prefixrebasebackingfiles"
     ENCRYPT_VOLUME_BITS_PATH = "/localstorage/volume/encryptinplace"
     CONVERT_VOLUME_ENCRYPTION_PATH = "/localstorage/volume/convertencryption"
+    ROLLBACK_VOLUME_ENCRYPTION_PATH = "/localstorage/volume/convertencryption/rollback"
 
     _metadata_handler = FileBasedMetadataHandler()
 
@@ -346,6 +347,7 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
         http_server.register_async_uri(self.PREFIX_REBASE_BACKING_FILES_PATH, self.prefix_rebase_backing_files)
         http_server.register_async_uri(self.ENCRYPT_VOLUME_BITS_PATH, self.encrypt_volume_bits)
         http_server.register_async_uri(self.CONVERT_VOLUME_ENCRYPTION_PATH, self.convert_volume_encryption)
+        http_server.register_async_uri(self.ROLLBACK_VOLUME_ENCRYPTION_PATH, self.rollback_volume_encryption)
 
         self.imagestore_client = ImageStoreClient()
 
@@ -1069,6 +1071,24 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
                 linux.rm_file_force(item.targetInstallPath)
             rsp.success = False
             rsp.error = 'failed to convert volume[%s] encryption: %s' % (cmd.volumeUuid, str(e))
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def rollback_volume_encryption(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = AgentResponse()
+        try:
+            for item in reversed(cmd.items):
+                if not os.path.exists(item.targetInstallPath):
+                    continue
+                linux.exception_on_opened_file(item.targetInstallPath)
+                os.remove(item.targetInstallPath)
+                if os.path.exists(item.targetInstallPath):
+                    raise Exception("failed to remove converted target file %s" % item.targetInstallPath)
+        except Exception as e:
+            logger.warn(linux.get_exception_stacktrace())
+            rsp.success = False
+            rsp.error = 'failed to rollback volume[%s] encryption conversion: %s' % (cmd.volumeUuid, str(e))
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror

--- a/kvmagent/kvmagent/plugins/localstorage.py
+++ b/kvmagent/kvmagent/plugins/localstorage.py
@@ -1045,55 +1045,28 @@ class LocalStoragePlugin(kvmagent.KvmAgent):
         actual_sizes = {}
         encrypted_dek = getattr(cmd, 'encryptedDek', None)
         converted_items = []
-        converted_target_paths = {}
-        renamed_sources = []
-        finalized_targets = []
-
-        def rebase_secret_file(reason):
-            return volume_secret.luks_secret_channel(encrypted_dek)
 
         try:
             if cmd.targetEncrypted and not encrypted_dek:
                 raise Exception("target encrypted conversion requires encryptedDek")
 
             for index, item in enumerate(cmd.items):
-                effective_target_path = "%s.converted.%s" % (item.targetInstallPath, uuidhelper.uuid())
+                if not os.path.exists(item.sourceInstallPath):
+                    raise Exception("source file %s does not exist" % item.sourceInstallPath)
+                if os.path.exists(item.targetInstallPath):
+                    raise Exception("target file %s already exists" % item.targetInstallPath)
                 target_backing_path = getattr(item, 'targetBackingInstallPath', None)
-                effective_backing_path = converted_target_paths.get(target_backing_path, target_backing_path)
                 secret_file_provider = (lambda: volume_secret.luks_secret_channel(encrypted_dek)) if encrypted_dek else None
+                converted_items.append(item)
                 actual_size = linux.convert_qcow2_volume_encryption(
-                    item.sourceInstallPath, effective_target_path, cmd.targetEncrypted,
-                    secret_file_provider, effective_backing_path)
+                    item.sourceInstallPath, item.targetInstallPath, cmd.targetEncrypted,
+                    secret_file_provider, target_backing_path)
                 actual_sizes[item.resourceUuid] = long(actual_size)
-                converted_items.append((item, effective_target_path, effective_backing_path, target_backing_path))
-                converted_target_paths[item.targetInstallPath] = effective_target_path
-
-            for item, _, _, _ in converted_items:
-                source_trash_path = getattr(item, 'sourceTrashInstallPath', None)
-                if source_trash_path:
-                    linux.move_file_no_overwrite(item.sourceInstallPath, source_trash_path)
-                    renamed_sources.append((source_trash_path, item.sourceInstallPath))
-
-            for item, effective_target_path, effective_backing_path, target_backing_path in converted_items:
-                if target_backing_path and effective_backing_path != target_backing_path:
-                    if cmd.targetEncrypted:
-                        with rebase_secret_file("final encrypted backing rebase") as reset_secret_file:
-                            linux.qcow2_rebase_no_check_with_secret(target_backing_path, effective_target_path, reset_secret_file)
-                    else:
-                        linux.qcow2_rebase_no_check(target_backing_path, effective_target_path)
-                if effective_target_path != item.targetInstallPath:
-                    linux.move_file_no_overwrite(effective_target_path, item.targetInstallPath)
-                    finalized_targets.append(item.targetInstallPath)
             rsp.actualSizes = actual_sizes
         except Exception as e:
             logger.warn(linux.get_exception_stacktrace())
-            for target_path in finalized_targets:
-                linux.rm_file_force(target_path)
-            for item, effective_target_path, _, _ in converted_items:
-                linux.rm_file_force(effective_target_path)
-            for source_trash_path, source_path in reversed(renamed_sources):
-                if os.path.exists(source_trash_path) and not os.path.exists(source_path):
-                    linux.move_file_no_overwrite(source_trash_path, source_path)
+            for item in converted_items:
+                linux.rm_file_force(item.targetInstallPath)
             rsp.success = False
             rsp.error = 'failed to convert volume[%s] encryption: %s' % (cmd.volumeUuid, str(e))
         return jsonobject.dumps(rsp)

--- a/kvmagent/kvmagent/plugins/nfs_primarystorage_plugin.py
+++ b/kvmagent/kvmagent/plugins/nfs_primarystorage_plugin.py
@@ -292,6 +292,7 @@ class NfsPrimaryStoragePlugin(kvmagent.KvmAgent):
     GET_QCOW2_HASH_VALUE_PATH = "/nfsprimarystorage/getqcow2hash"
     ENCRYPT_VOLUME_BITS_PATH = "/nfsprimarystorage/volume/encryptinplace"
     CONVERT_VOLUME_ENCRYPTION_PATH = "/nfsprimarystorage/volume/convertencryption"
+    ROLLBACK_VOLUME_ENCRYPTION_PATH = "/nfsprimarystorage/volume/convertencryption/rollback"
     WRITE_VM_METADATA_PATH = "/nfsprimarystorage/vm/metadata/write"
     GET_VM_INSTANCE_METADATA_PATH = "/nfsprimarystorage/vm/metadata/get"
     SCAN_VM_METADATA_PATH = "/nfsprimarystorage/vm/metadata/scan"
@@ -346,6 +347,7 @@ class NfsPrimaryStoragePlugin(kvmagent.KvmAgent):
         http_server.register_async_uri(self.GET_QCOW2_HASH_VALUE_PATH, self.get_qcow2_hashvalue)
         http_server.register_async_uri(self.ENCRYPT_VOLUME_BITS_PATH, self.encrypt_volume_bits)
         http_server.register_async_uri(self.CONVERT_VOLUME_ENCRYPTION_PATH, self.convert_volume_encryption)
+        http_server.register_async_uri(self.ROLLBACK_VOLUME_ENCRYPTION_PATH, self.rollback_volume_encryption)
         http_server.register_async_uri(self.WRITE_VM_METADATA_PATH, self.write_vm_metadata)
         http_server.register_async_uri(self.GET_VM_INSTANCE_METADATA_PATH, self.get_vm_instance_metadata)
         http_server.register_async_uri(self.SCAN_VM_METADATA_PATH, self.scan_vm_metadata)
@@ -1039,6 +1041,24 @@ class NfsPrimaryStoragePlugin(kvmagent.KvmAgent):
                 linux.rm_file_force(item.targetInstallPath)
             rsp.success = False
             rsp.error = 'failed to convert volume[%s] encryption: %s' % (cmd.volumeUuid, str(e))
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def rollback_volume_encryption(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = kvmagent.AgentResponse()
+        try:
+            for item in reversed(cmd.items):
+                if not os.path.exists(item.targetInstallPath):
+                    continue
+                linux.exception_on_opened_file(item.targetInstallPath)
+                os.remove(item.targetInstallPath)
+                if os.path.exists(item.targetInstallPath):
+                    raise Exception("failed to remove converted target file %s" % item.targetInstallPath)
+        except Exception as e:
+            logger.warn(linux.get_exception_stacktrace())
+            rsp.success = False
+            rsp.error = 'failed to rollback volume[%s] encryption conversion: %s' % (cmd.volumeUuid, str(e))
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror

--- a/kvmagent/kvmagent/plugins/nfs_primarystorage_plugin.py
+++ b/kvmagent/kvmagent/plugins/nfs_primarystorage_plugin.py
@@ -1015,55 +1015,28 @@ class NfsPrimaryStoragePlugin(kvmagent.KvmAgent):
         actual_sizes = {}
         encrypted_dek = getattr(cmd, 'encryptedDek', None)
         converted_items = []
-        converted_target_paths = {}
-        renamed_sources = []
-        finalized_targets = []
-
-        def rebase_secret_file(reason):
-            return volume_secret.luks_secret_channel(encrypted_dek)
 
         try:
             if cmd.targetEncrypted and not encrypted_dek:
                 raise Exception("target encrypted conversion requires encryptedDek")
 
             for index, item in enumerate(cmd.items):
-                effective_target_path = "%s.converted.%s" % (item.targetInstallPath, uuidhelper.uuid())
+                if not os.path.exists(item.sourceInstallPath):
+                    raise Exception("source file %s does not exist" % item.sourceInstallPath)
+                if os.path.exists(item.targetInstallPath):
+                    raise Exception("target file %s already exists" % item.targetInstallPath)
                 target_backing_path = getattr(item, 'targetBackingInstallPath', None)
-                effective_backing_path = converted_target_paths.get(target_backing_path, target_backing_path)
                 secret_file_provider = (lambda: volume_secret.luks_secret_channel(encrypted_dek)) if encrypted_dek else None
+                converted_items.append(item)
                 actual_size = linux.convert_qcow2_volume_encryption(
-                    item.sourceInstallPath, effective_target_path, cmd.targetEncrypted,
-                    secret_file_provider, effective_backing_path)
+                    item.sourceInstallPath, item.targetInstallPath, cmd.targetEncrypted,
+                    secret_file_provider, target_backing_path)
                 actual_sizes[item.resourceUuid] = long(actual_size)
-                converted_items.append((item, effective_target_path, effective_backing_path, target_backing_path))
-                converted_target_paths[item.targetInstallPath] = effective_target_path
-
-            for item, _, _, _ in converted_items:
-                source_trash_path = getattr(item, 'sourceTrashInstallPath', None)
-                if source_trash_path:
-                    linux.move_file_no_overwrite(item.sourceInstallPath, source_trash_path)
-                    renamed_sources.append((source_trash_path, item.sourceInstallPath))
-
-            for item, effective_target_path, effective_backing_path, target_backing_path in converted_items:
-                if target_backing_path and effective_backing_path != target_backing_path:
-                    if cmd.targetEncrypted:
-                        with rebase_secret_file("final encrypted backing rebase") as reset_secret_file:
-                            linux.qcow2_rebase_no_check_with_secret(target_backing_path, effective_target_path, reset_secret_file)
-                    else:
-                        linux.qcow2_rebase_no_check(target_backing_path, effective_target_path)
-                if effective_target_path != item.targetInstallPath:
-                    linux.move_file_no_overwrite(effective_target_path, item.targetInstallPath)
-                    finalized_targets.append(item.targetInstallPath)
             rsp.actualSizes = actual_sizes
         except Exception as e:
             logger.warn(linux.get_exception_stacktrace())
-            for target_path in finalized_targets:
-                linux.rm_file_force(target_path)
-            for item, effective_target_path, _, _ in converted_items:
-                linux.rm_file_force(effective_target_path)
-            for source_trash_path, source_path in reversed(renamed_sources):
-                if os.path.exists(source_trash_path) and not os.path.exists(source_path):
-                    linux.move_file_no_overwrite(source_trash_path, source_path)
+            for item in converted_items:
+                linux.rm_file_force(item.targetInstallPath)
             rsp.success = False
             rsp.error = 'failed to convert volume[%s] encryption: %s' % (cmd.volumeUuid, str(e))
         return jsonobject.dumps(rsp)

--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -1547,13 +1547,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = ConvertVolumeEncryptionRsp()
         encrypted_dek = getattr(cmd, 'encryptedDek', None)
-        converted_items = []
-        converted_target_paths = {}
-        renamed_sources = []
-        finalized_targets = []
-
-        def rebase_secret_file(reason):
-            return volume_secret.luks_secret_channel(encrypted_dek)
+        converted_targets = []
 
         try:
             if cmd.targetEncrypted and not encrypted_dek:
@@ -1563,71 +1557,41 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             for index, item in enumerate(cmd.items):
                 source_abs_path = translate_absolute_path_from_install_path(item.sourceInstallPath)
                 target_abs_path = translate_absolute_path_from_install_path(item.targetInstallPath)
-                temp_abs_path = "%s_converted_%s" % (target_abs_path, uuidhelper.uuid())
+                if not lvm.lv_exists(source_abs_path):
+                    raise Exception("source lv %s does not exist" % source_abs_path)
+                if lvm.lv_exists(target_abs_path):
+                    raise Exception("target lv %s already exists" % target_abs_path)
 
                 target_backing_abs_path = None
                 if getattr(item, 'targetBackingInstallPath', None):
                     target_backing_abs_path = translate_absolute_path_from_install_path(item.targetBackingInstallPath)
-                effective_backing_abs_path = converted_target_paths.get(target_backing_abs_path, target_backing_abs_path)
-
-                if lvm.lv_exists(temp_abs_path):
-                    lvm.delete_lv(temp_abs_path)
 
                 secret_file_provider = (lambda: volume_secret.luks_secret_channel(encrypted_dek)) if encrypted_dek else None
                 with lvm.RecursiveOperateLv(source_abs_path, shared=True):
                     lv_size = self.get_convert_volume_encryption_lv_size(
-                        source_abs_path, cmd.targetEncrypted, effective_backing_abs_path)
-                    lvm.create_lv_from_absolute_path(temp_abs_path, lv_size, exact_size=True)
+                        source_abs_path, cmd.targetEncrypted, target_backing_abs_path)
+                    lvm.create_lv_from_absolute_path(target_abs_path, lv_size, exact_size=True)
+                    converted_targets.append(target_abs_path)
 
-                    if effective_backing_abs_path:
-                        with lvm.RecursiveOperateLv(effective_backing_abs_path, shared=True):
-                            with lvm.OperateLv(temp_abs_path, shared=False, delete_when_exception=True):
+                    if target_backing_abs_path:
+                        with lvm.RecursiveOperateLv(target_backing_abs_path, shared=True):
+                            with lvm.OperateLv(target_abs_path, shared=False, delete_when_exception=True):
                                 actual_size = linux.convert_qcow2_volume_encryption(
-                                    source_abs_path, temp_abs_path, cmd.targetEncrypted,
-                                    secret_file_provider, effective_backing_abs_path)
+                                    source_abs_path, target_abs_path, cmd.targetEncrypted,
+                                    secret_file_provider, target_backing_abs_path)
                     else:
-                        with lvm.OperateLv(temp_abs_path, shared=False, delete_when_exception=True):
+                        with lvm.OperateLv(target_abs_path, shared=False, delete_when_exception=True):
                             actual_size = linux.convert_qcow2_volume_encryption(
-                                source_abs_path, temp_abs_path, cmd.targetEncrypted,
-                                secret_file_provider, effective_backing_abs_path)
+                                source_abs_path, target_abs_path, cmd.targetEncrypted,
+                                secret_file_provider, target_backing_abs_path)
 
-                rsp.actualSizes[item.resourceUuid] = long(lvm.get_lv_size(temp_abs_path) or actual_size)
-                converted_items.append((item, source_abs_path, temp_abs_path, target_abs_path,
-                                        effective_backing_abs_path, target_backing_abs_path))
-                converted_target_paths[target_abs_path] = temp_abs_path
-
-            for item, source_abs_path, _, _, _, _ in converted_items:
-                source_trash_path = getattr(item, 'sourceTrashInstallPath', None)
-                if source_trash_path:
-                    source_trash_abs_path = translate_absolute_path_from_install_path(source_trash_path)
-                    r, o, e = lvm.lv_rename(source_abs_path, source_trash_abs_path, False)
-                    if r != 0:
-                        raise Exception("rename lv %s to trash %s failed: stdout: %s, stderr: %s" %
-                                        (source_abs_path, source_trash_abs_path, o, e))
-                    renamed_sources.append((source_trash_abs_path, source_abs_path))
-
-            for _, _, temp_abs_path, target_abs_path, effective_backing_abs_path, target_backing_abs_path in converted_items:
-                if target_backing_abs_path and effective_backing_abs_path != target_backing_abs_path:
-                    with lvm.RecursiveOperateLv(target_backing_abs_path, shared=True):
-                        with lvm.OperateLv(temp_abs_path, shared=False):
-                            if cmd.targetEncrypted:
-                                with rebase_secret_file("final encrypted backing rebase") as reset_secret_file:
-                                    linux.qcow2_rebase_no_check_with_secret(target_backing_abs_path, temp_abs_path, reset_secret_file)
-                            else:
-                                linux.qcow2_rebase_no_check(target_backing_abs_path, temp_abs_path)
-                lvm.lv_rename(temp_abs_path, target_abs_path, False)
-                finalized_targets.append(target_abs_path)
+                rsp.actualSizes[item.resourceUuid] = long(lvm.get_lv_size(target_abs_path) or actual_size)
 
             rsp.totalCapacity, rsp.availableCapacity = lvm.get_vg_size(cmd.vgUuid)
         except Exception as e:
             logger.warn(linux.get_exception_stacktrace())
-            for target_abs_path in finalized_targets:
+            for target_abs_path in converted_targets:
                 lvm.delete_lv(target_abs_path, False)
-            for _, _, temp_abs_path, _, _, _ in converted_items:
-                lvm.delete_lv(temp_abs_path, False)
-            for source_trash_abs_path, source_abs_path in reversed(renamed_sources):
-                if lvm.lv_exists(source_trash_abs_path) and not lvm.lv_exists(source_abs_path):
-                    lvm.lv_rename(source_trash_abs_path, source_abs_path, False)
             rsp.success = False
             rsp.error = 'failed to convert volume[%s] encryption: %s' % (cmd.volumeUuid, str(e))
 

--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -431,6 +431,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
     PREFIX_REBASE_BACKING_FILES_PATH = "/sharedblock/snapshot/prefixrebasebackingfiles"
     ENCRYPT_VOLUME_BITS_PATH = "/sharedblock/volume/encryptinplace"
     CONVERT_VOLUME_ENCRYPTION_PATH = "/sharedblock/volume/convertencryption"
+    ROLLBACK_VOLUME_ENCRYPTION_PATH = "/sharedblock/volume/convertencryption/rollback"
 
     _metadata_handler = SblkMetadataHandler(lvm, bash)
 
@@ -495,6 +496,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         http_server.register_async_uri(self.PREFIX_REBASE_BACKING_FILES_PATH, self.prefix_rebase_backing_files)
         http_server.register_async_uri(self.ENCRYPT_VOLUME_BITS_PATH, self.encrypt_volume_bits)
         http_server.register_async_uri(self.CONVERT_VOLUME_ENCRYPTION_PATH, self.convert_volume_encryption)
+        http_server.register_async_uri(self.ROLLBACK_VOLUME_ENCRYPTION_PATH, self.rollback_volume_encryption)
 
         self.imagestore_client = ImageStoreClient()
 
@@ -1595,6 +1597,24 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
             rsp.success = False
             rsp.error = 'failed to convert volume[%s] encryption: %s' % (cmd.volumeUuid, str(e))
 
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    @lock.file_lock(LOCK_FILE)
+    def rollback_volume_encryption(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = AgentRsp()
+        try:
+            for item in reversed(cmd.items):
+                target_abs_path = translate_absolute_path_from_install_path(item.targetInstallPath)
+                if lvm.lv_exists(target_abs_path):
+                    lvm.delete_lv(target_abs_path)
+                    if lvm.lv_exists(target_abs_path):
+                        raise Exception("failed to remove converted target lv %s" % target_abs_path)
+        except Exception as e:
+            logger.warn(linux.get_exception_stacktrace())
+            rsp.success = False
+            rsp.error = 'failed to rollback volume[%s] encryption conversion: %s' % (cmd.volumeUuid, str(e))
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror


### PR DESCRIPTION
## Summary
Add KVM agent rollback handling for volume/snapshot encryption conversion failures for ZSV-12469.

## Changes
- Add rollback endpoints for LocalStorage, NFS, SharedBlock, and Ceph conversion paths.
- Restore sourceTrash back to source on failure and remove converted targets when safe.
- Detect target files still being written before cleanup and support deterministic failure injection for rollback testing.

## Testing
- [x] git diff --check
- [ ] cbok/default-env verification
- [ ] CI pipeline

Resolves: ZSV-12469

sync from gitlab !7465