### PR TITLE
<fix>[zbs]: ZSTAC-85515 prepare vhost hugepage mount

### DIFF
--- a/kvmagent/kvmagent/plugins/zbs_storage_plugin.py
+++ b/kvmagent/kvmagent/plugins/zbs_storage_plugin.py
@@ -177,6 +177,7 @@ class ZbsStoragePlugin(kvmagent.KvmAgent):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = kvmagent.AgentResponse()
         zbs_vhost_target.ensure_docker()
+        zbs_vhost_target.ensure_2m_hugetlbfs_mount()
         zbs_vhost_target.ensure_free_hugepages(
             cmd.hugepageNr if cmd.hugepageNr else zbs_vhost_target.DEFAULT_VHOST_TARGET_HUGEPAGE_NR)
         return jsonobject.dumps(rsp)

--- a/kvmagent/kvmagent/plugins/zbs_vhost_target.py
+++ b/kvmagent/kvmagent/plugins/zbs_vhost_target.py
@@ -24,6 +24,7 @@ def _locked(fn):
 HUGEPAGE_DIR = "/sys/kernel/mm/hugepages/hugepages-2048kB"
 HUGEPAGE_NR_PATH = HUGEPAGE_DIR + "/nr_hugepages"
 HUGEPAGE_FREE_PATH = HUGEPAGE_DIR + "/free_hugepages"
+DEFAULT_VHOST_TARGET_HUGEPAGE_DIR = "/dev/hugepages2m"
 DEFAULT_SOCKET_DIR = "/var/tmp/vhost-sockets"
 DEFAULT_CONTROL_SOCK = "/var/tmp/vhost-sockets/vhost.sock"
 DEFAULT_CLIENT_CONF = "/etc/zbs/client.conf"
@@ -159,6 +160,29 @@ def ensure_free_hugepages(need_pages):
     if got < need_pages:
         raise Exception("failed to free %d hugepages, only %d free after growing to %d; "
                         "free up memory on the host" % (need_pages, got, target))
+
+
+def find_2m_hugetlbfs_mount():
+    out = bash.bash_o("findmnt -rn -t hugetlbfs -o TARGET,OPTIONS")
+    for line in out.splitlines():
+        parts = line.split(None, 1)
+        if len(parts) == 2 and "pagesize=2M" in parts[1].split(","):
+            return parts[0]
+    return None
+
+
+def ensure_2m_hugetlbfs_mount(mount_dir=DEFAULT_VHOST_TARGET_HUGEPAGE_DIR):
+    existing = find_2m_hugetlbfs_mount()
+    if existing:
+        return existing
+
+    if not os.path.exists(mount_dir):
+        os.makedirs(mount_dir)
+    if bash.bash_r("findmnt -n -T %s -t hugetlbfs -o OPTIONS | grep -qw pagesize=2M" %
+                   shlex.quote(mount_dir)) == 0:
+        return mount_dir
+    bash.bash_errorout("mount -t hugetlbfs -o pagesize=2M none %s" % shlex.quote(mount_dir))
+    return mount_dir
 
 
 def ensure_hugepages_for_domain(domain_xml):

--- a/tests/unit/kvmagent/test_zbs_vhost_hugepage.py
+++ b/tests/unit/kvmagent/test_zbs_vhost_hugepage.py
@@ -9,7 +9,10 @@ mocked).
 import pytest
 from unittest.mock import patch
 
+from zstacklib.utils import http
+from zstacklib.utils import jsonobject
 from kvmagent.plugins import zbs_vhost_target as t
+from kvmagent.plugins import zbs_storage_plugin
 
 
 HP = t.HUGEPAGE_SIZE_BYTES
@@ -106,6 +109,46 @@ class TestEnsureFreeHugepages:
              patch.object(t.bash, 'bash_o'):
             with pytest.raises(Exception):
                 t.ensure_free_hugepages(150)
+
+
+class TestEnsure2mHugetlbfsMount:
+    def test_reuses_existing_default_hugepages_when_it_is_2mb(self):
+        with patch.object(t.bash, 'bash_o', return_value="/dev/hugepages rw,pagesize=2M\n"), \
+             patch.object(t.bash, 'bash_errorout') as errorout:
+            assert t.ensure_2m_hugetlbfs_mount() == "/dev/hugepages"
+            errorout.assert_not_called()
+
+    def test_mounts_2mb_hugetlbfs_when_absent(self):
+        with patch.object(t.bash, 'bash_o', return_value=""), \
+             patch('os.path.exists', return_value=False), \
+             patch('os.makedirs') as makedirs, \
+             patch.object(t.bash, 'bash_r', return_value=1), \
+             patch.object(t.bash, 'bash_errorout') as errorout:
+            assert t.ensure_2m_hugetlbfs_mount() == t.DEFAULT_VHOST_TARGET_HUGEPAGE_DIR
+            makedirs.assert_called_once_with(t.DEFAULT_VHOST_TARGET_HUGEPAGE_DIR)
+            assert "pagesize=2M" in errorout.call_args[0][0]
+
+    def test_reuses_existing_2mb_hugetlbfs_mount(self):
+        with patch.object(t.bash, 'bash_o', return_value=""), \
+             patch('os.path.exists', return_value=True), \
+             patch.object(t.bash, 'bash_r', return_value=0), \
+             patch.object(t.bash, 'bash_errorout') as errorout:
+            assert t.ensure_2m_hugetlbfs_mount("/dev/hugepages2m") == "/dev/hugepages2m"
+            errorout.assert_not_called()
+
+
+class TestPrepareVhostTargetEnv:
+    def test_ensures_2m_mount_and_free_hugepages(self):
+        body = '{"hugepageNr":1024}'
+        req = {http.REQUEST_BODY: body}
+        with patch.object(t, 'ensure_docker'), \
+             patch.object(t, 'ensure_2m_hugetlbfs_mount') as ensure_mount, \
+             patch.object(t, 'ensure_free_hugepages') as ensure_free:
+            out = zbs_storage_plugin.ZbsStoragePlugin().prepare_vhost_target_env(req)
+            rsp = jsonobject.loads(out)
+            assert rsp.success is True
+            ensure_mount.assert_called_once_with()
+            ensure_free.assert_called_once_with(1024)
 
 
 class TestEnsureHugepagesForDomain:

--- a/tests/unit/zbsprimarystorage/test_vhost.py
+++ b/tests/unit/zbsprimarystorage/test_vhost.py
@@ -74,8 +74,9 @@ class TestDeployVhost:
              patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
              patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, "8\n", "")) as ssh:
             zbsutils.deploy_vhost("10.0.0.9", 2222, "root", "pwd")
-            ssh.assert_called_once_with("10.0.0.9", "pwd", "grep -c processor /proc/cpuinfo",
-                                        user="root", port=2222)
+            assert ssh.call_args_list[0] == (
+                ("10.0.0.9", "pwd", "grep -c processor /proc/cpuinfo"),
+                {"user": "root", "port": 2222})
 
     def test_single_cpu_host_falls_back_to_core0(self):
         with patch.object(zbsutils.shell, 'call'), \
@@ -84,14 +85,32 @@ class TestDeployVhost:
             zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd")
             assert "--cpuset '[0]'" in _last_cmd()
 
-    def test_omits_hugepage_args_so_zbsadm_defaults_apply(self):
+    def test_uses_existing_2mb_hugetlbfs_mount_when_hugepage_dir_not_set(self):
         with patch.object(zbsutils.shell, 'call'), \
              patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
-             patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, "8\n", "")):
+             patch.object(zbsutils.linux, 'sshpass_run', side_effect=[
+                 (0, "8\n", ""),
+                 (0, "/dev/hugepages\n", ""),
+             ]) as ssh:
             zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd")
             cmd = _last_cmd()
-            assert "--hugepage-size" not in cmd
-            assert "--hugepage-dir" not in cmd
+            assert "--hugepage-dir /dev/hugepages" in cmd
+            assert ssh.call_args_list[1][0][2].startswith("findmnt")
+            assert "\\$2" in ssh.call_args_list[1][0][2]
+            assert "\\$1" in ssh.call_args_list[1][0][2]
+
+    def test_mounts_2mb_hugetlbfs_when_target_has_none(self):
+        with patch.object(zbsutils.shell, 'call'), \
+             patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
+             patch.object(zbsutils.linux, 'sshpass_run', side_effect=[
+                 (0, "8\n", ""),
+                 (0, "", ""),
+                 (0, "", ""),
+             ]) as ssh:
+            zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd")
+            cmd = _last_cmd()
+            assert "--hugepage-dir /dev/hugepages2m" in cmd
+            assert "mount -t hugetlbfs -o pagesize=2M none '/dev/hugepages2m'" in ssh.call_args_list[2][0][2]
 
     def test_explicit_cpuset_overrides_auto(self):
         with patch.object(zbsutils.shell, 'call'), \
@@ -111,6 +130,50 @@ class TestDeployVhost:
             cmd = _last_cmd()
             assert "--hugepage-size 2048" in cmd
             assert "--hugepage-dir /dev/hugepages2m" in cmd
+
+    def test_handler_forwards_hugepage_args_to_zbsadm(self):
+        body = '{"hostIp":"10.0.0.9","sshPort":22,"sshUsername":"root","sshPassword":"pwd",' \
+               '"hugepageSize":1024,"hugepageDir":"/dev/hugepages2m"}'
+        with patch.object(zbsutils, 'deploy_vhost', return_value=_OK) as deploy, \
+             patch.object(zbsutils, 'wait_vhost_target_ready', return_value=True):
+            zbsagent.ZbsAgent().deploy_vhost(_req(body))
+            deploy.assert_called_once_with("10.0.0.9", 22, "root", "pwd",
+                                           hugepage_size=1024, hugepage_dir="/dev/hugepages2m")
+
+    def test_waits_for_target_ready_after_deploy(self):
+        body = '{"hostIp":"10.0.0.9","sshPort":22,"sshUsername":"root","sshPassword":"pwd"}'
+        with patch.object(zbsutils, 'deploy_vhost', return_value=_OK), \
+             patch.object(zbsutils, 'wait_vhost_target_ready', return_value=True) as wait_ready:
+            out = zbsagent.ZbsAgent().deploy_vhost(_req(body))
+            wait_ready.assert_called_once_with("10.0.0.9", 22, "root", "pwd")
+            assert zbsagent.jsonobject.loads(out).success is True
+
+    def test_ready_timeout_fails_deploy(self):
+        body = '{"hostIp":"10.0.0.9","sshPort":22,"sshUsername":"root","sshPassword":"pwd"}'
+        with patch.object(zbsutils, 'deploy_vhost', return_value=_OK), \
+             patch.object(zbsutils, 'wait_vhost_target_ready', return_value=False):
+            out = zbsagent.ZbsAgent().deploy_vhost(_req(body))
+            r = zbsagent.jsonobject.loads(out)
+            assert r.success is False
+            assert "not ready" in r.error
+
+    def test_ready_wait_checks_container_and_admin_sock(self):
+        calls = {'n': 0}
+
+        def ssh(*args, **kwargs):
+            calls['n'] += 1
+            return (0 if calls['n'] == 3 else 1, "", "")
+
+        with patch.object(zbsutils.linux, 'sshpass_run', side_effect=ssh) as sshpass, \
+             patch.object(zbsutils.time, 'sleep') as sleep:
+            assert zbsutils.wait_vhost_target_ready("10.0.0.9", 2222, "root", "pwd",
+                                                    retries=3, interval=0.1) is True
+
+            cmd = sshpass.call_args[0][2]
+            assert "docker ps" in cmd
+            assert "name=^/zbsvhost-10.0.0.9$" in cmd
+            assert "/var/zbsvhost/sockets/admin.sock" in cmd
+            assert sleep.call_count == 2
 
 
 class TestDestroyVhost:

--- a/zbsprimarystorage/zbsprimarystorage/zbsagent.py
+++ b/zbsprimarystorage/zbsprimarystorage/zbsagent.py
@@ -722,11 +722,16 @@ class ZbsAgent(plugin.TaskManager):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = AgentResponse()
 
-        o = zbsutils.deploy_vhost(cmd.hostIp, cmd.sshPort, cmd.sshUsername, cmd.sshPassword)
+        hugepage_size = cmd.hugepageSize if cmd.hasattr('hugepageSize') else None
+        hugepage_dir = cmd.hugepageDir if cmd.hasattr('hugepageDir') else None
+        o = zbsutils.deploy_vhost(cmd.hostIp, cmd.sshPort, cmd.sshUsername, cmd.sshPassword,
+                                  hugepage_size=hugepage_size, hugepage_dir=hugepage_dir)
         r = jsonobject.loads(o)
         if not r.success:
             raise Exception('failed to deploy vhost target on host[%s], error[%s]' % (
                 cmd.hostIp, r.error.message))
+        if not zbsutils.wait_vhost_target_ready(cmd.hostIp, cmd.sshPort, cmd.sshUsername, cmd.sshPassword):
+            raise Exception('deployed vhost target on host[%s] but target is not ready' % cmd.hostIp)
 
         return jsonobject.dumps(rsp)
 

--- a/zbsprimarystorage/zbsprimarystorage/zbsutils.py
+++ b/zbsprimarystorage/zbsprimarystorage/zbsutils.py
@@ -1,6 +1,7 @@
 __author__ = 'Xingwei Yu'
 
 import os
+import time
 from zstacklib.utils.version import NumericVersion
 
 import zstacklib.utils.jsonobject as jsonobject
@@ -22,6 +23,11 @@ CBD_SNAPSHOT_PATH = CBD_VOLUME_PATH + "@{}"
 CLUSTER_UUID_SUPPORTED_VERSION = "1.5.1"
 VHOST_SOCKET_DIR = "/var/zbsvhost/sockets"
 VHOST_VOLUME_SUFFIX = "_zbs_"
+VHOST_TARGET_CONTAINER_PREFIX = "zbsvhost-"
+VHOST_ADMIN_SOCK_NAME = "admin.sock"
+VHOST_DEPLOY_READY_RETRIES = 40
+VHOST_DEPLOY_READY_INTERVAL_SECONDS = 0.5
+DEFAULT_VHOST_TARGET_HUGEPAGE_DIR = "/dev/hugepages2m"
 
 
 class ClientInfo(object):
@@ -86,9 +92,33 @@ def vhost_auto_cpuset(ip, port, username, password):
     return "[%d]" % core
 
 
+def find_2m_hugetlbfs_mount(ip, port, username, password):
+    cmd = "findmnt -rn -t hugetlbfs -o TARGET,OPTIONS | awk '\\$2 ~ /(^|,)pagesize=2M(,|$)/ {print \\$1; exit}'"
+    ret, out, err = linux.sshpass_run(ip, password, cmd, user=username, port=int(port))
+    if ret != 0:
+        raise Exception("failed to find 2M hugetlbfs mount on host[%s]: %s" % (ip, err))
+    return out.strip() if out else None
+
+
+def ensure_2m_hugetlbfs_mount(ip, port, username, password, mount_dir=DEFAULT_VHOST_TARGET_HUGEPAGE_DIR):
+    existing = find_2m_hugetlbfs_mount(ip, port, username, password)
+    if existing:
+        return existing
+
+    quoted_mount_dir = linux.shellquote(mount_dir)
+    cmd = "mkdir -p %s && mount -t hugetlbfs -o pagesize=2M none %s" % (
+        quoted_mount_dir, quoted_mount_dir)
+    ret, _, err = linux.sshpass_run(ip, password, cmd, user=username, port=int(port))
+    if ret != 0:
+        raise Exception("failed to mount 2M hugetlbfs on host[%s], dir[%s]: %s" % (ip, mount_dir, err))
+    return mount_dir
+
+
 def deploy_vhost(ip, port, username, password, cpuset=None, hugepage_size=None, hugepage_dir=None):
     if not cpuset:
         cpuset = vhost_auto_cpuset(ip, port, username, password)
+    if not hugepage_dir:
+        hugepage_dir = ensure_2m_hugetlbfs_mount(ip, port, username, password)
     cmd = "%s vhost deploy --host %s --port %s -u %s -p %s --cpuset %s --silent" % (
         ZBSADM_BIN_PATH, ip, port, username, linux.shellquote(password),
         linux.shellquote(cpuset))
@@ -97,6 +127,23 @@ def deploy_vhost(ip, port, username, password, cpuset=None, hugepage_size=None, 
     if hugepage_dir:
         cmd += " --hugepage-dir %s" % hugepage_dir
     return shell.call(cmd)
+
+
+def wait_vhost_target_ready(ip, port, username, password, retries=VHOST_DEPLOY_READY_RETRIES,
+                            interval=VHOST_DEPLOY_READY_INTERVAL_SECONDS):
+    container_name = VHOST_TARGET_CONTAINER_PREFIX + ip
+    control_sock = "%s/%s" % (VHOST_SOCKET_DIR, VHOST_ADMIN_SOCK_NAME)
+    cmd = "docker ps --filter %s --filter status=running -q | grep -q . && test -S %s" % (
+        linux.shellquote("name=^/%s$" % container_name),
+        linux.shellquote(control_sock))
+
+    for _ in range(retries):
+        ret, _, _ = linux.sshpass_run(ip, password, cmd, user=username, port=int(port))
+        if ret == 0:
+            return True
+        time.sleep(interval)
+
+    return False
 
 
 def destroy_vhost(ip, port, username, password):


### PR DESCRIPTION
## Summary
Prepare the host-side pieces required by ZBS vhost deploy: choose an existing 2M hugetlbfs mount when available, mount one only when absent, and wait until the vhost target is ready before deploy returns success.

## Changes
- Reuse an existing 2M hugetlbfs mount such as `/dev/hugepages` when present.
- Mount `/dev/hugepages2m` only when no 2M mount exists.
- Forward optional hugepage parameters and wait for container/admin socket readiness.
- Add unit coverage for mount selection, escaped remote awk, prepare env, and ready wait.

## Testing
- [x] `pytest -q tests/unit/zbsprimarystorage/test_vhost.py tests/unit/kvmagent/test_zbs_vhost_hugepage.py` (44 passed)
- [x] Manual verification on 172.26.105.253/hosts 172.26.101.188 and 172.26.107.184.
- [ ] CI pipeline

Resolves: ZSTAC-85515

sync from gitlab !7479