### PR TITLE
<fix>[kvmagent]: ZSTAC-86650 clear empty multipath blacklist

### DIFF
--- a/kvmagent/kvmagent/plugins/storage_device.py
+++ b/kvmagent/kvmagent/plugins/storage_device.py
@@ -1306,7 +1306,7 @@ class StorageDevicePlugin(kvmagent.KvmAgent):
         default_config_changed = False
         with multipath.MultipathConfigUpdater("/etc/multipath.conf") as updater:
             default_config_changed =  updater.set_default_config()
-            if cmd_dict.get("blacklist", None):
+            if cmd_dict.get("blacklist", None) is not None:
                 updater.config_section("blacklist", cmd_dict["blacklist"])
 
         if updater.modified:

--- a/kvmagent/kvmagent/test/storage_device_testsuite/test_iscsi_login.py
+++ b/kvmagent/kvmagent/test/storage_device_testsuite/test_iscsi_login.py
@@ -52,8 +52,16 @@ class TestSharedBlockPlugin(TestCase, StorageDevicePluginTestStub):
         rsp = storage_device_utils.enable_multipath(blacklist=[{"wwid":blockUuid}])
         self.assertEqual(rsp.success, True, rsp.error)
 
+        r = bash.bash_r("grep -F 'wwid \"%s\"' /etc/multipath.conf" % blockUuid)
+        self.assertEqual(r, 0, "[check] multipath blacklist should contain wwid %s" % blockUuid)
+
+        rsp = storage_device_utils.enable_multipath(blacklist=[])
+        self.assertEqual(rsp.success, True, rsp.error)
+
+        r = bash.bash_r("grep -F 'wwid \"%s\"' /etc/multipath.conf" % blockUuid)
+        self.assertNotEqual(r, 0, "[check] multipath blacklist should remove wwid %s" % blockUuid)
+
         r, o = bash.bash_ro("ls /dev/disk/by-id | grep scsi")
         self.assertEqual(r, 0, "[check] login to iscsi failed")
 
         self.logout(interf_ip,"3260")
-


### PR DESCRIPTION
Allow an explicit empty blacklist to remove stale WWIDs while preserving null as no-op. Adds iSCSI regression coverage. Local syntax and updater behavior verified; system iSCSI test requires CI environment. Resolves: ZSTAC-86650

sync from gitlab !7486