### PR TITLE
<fix>[ceph]: ZSTAC-86340 backport image cache trash cleanup

### DIFF
--- a/cephprimarystorage/cephprimarystorage/cephagent.py
+++ b/cephprimarystorage/cephprimarystorage/cephagent.py
@@ -11,7 +11,6 @@ import rados
 import rbd
 import Queue
 import threading
-import simplejson
 
 import zstacklib.utils.daemon as daemon
 import zstacklib.utils.jsonobject as jsonobject
@@ -596,6 +595,37 @@ class CephAgent(plugin.TaskManager):
         with open(path) as f:
             return f.read()
 
+    def _purge_trash_child(self, snapshot_path, child):
+        pool_name, child_name = self._parse_install_path(child)
+        ret, trash_list, error = ceph.rbd_trash_list(pool_name)
+        if ret != 0:
+            logger.warn("unable to list rbd trash while deleting image cache snapshot[%s], "
+                        "pool[%s], child[%s], ret[%s], stderr[%s]" %
+                        (snapshot_path, pool_name, child, ret, error))
+            return False
+
+        trash = ceph.find_rbd_trash(trash_list, child_name)
+        if trash is None or not trash.get("id"):
+            logger.warn("unable to find rbd child[%s] in trash while deleting image cache snapshot[%s], "
+                        "pool[%s]" % (child, snapshot_path, pool_name))
+            return False
+
+        trash_id = trash.get("id")
+        ret, _, error = ceph.rbd_trash_rm(pool_name, trash_id, True)
+        if ret != 0:
+            logger.warn("unable to purge rbd trash child while deleting image cache snapshot[%s], "
+                        "pool[%s], child[%s], trash id[%s], ret[%s], stderr[%s]" %
+                        (snapshot_path, pool_name, child, trash_id, ret, error))
+            return False
+        return True
+
+    def _purge_trash_children(self, snapshot_path, children):
+        remaining_children = []
+        for child in children:
+            if not self._purge_trash_child(snapshot_path, child):
+                remaining_children.append(child)
+        return remaining_children
+
     @replyerror
     @in_bash
     def resize_volume(self, req):
@@ -623,10 +653,10 @@ class CephAgent(plugin.TaskManager):
         if bash_r('rbd info {{IMAGE_PATH}}') != 0:
             return jsonobject.dumps(rsp)
 
-        o = bash_o('rbd children {{SP_PATH}}')
-        o = o.strip(' \t\r\n')
-        if o:
-            raise Exception('the image cache[%s] is still in used' % cmd.imagePath)
+        snapshot_children = ceph.rbd_children(SP_PATH)
+        remaining_children = self._purge_trash_children(SP_PATH, snapshot_children)
+        if remaining_children:
+            raise Exception('the image cache[%s] is still in used, children: %s' % (cmd.imagePath, remaining_children))
 
         bash_errorout('rbd snap unprotect {{SP_PATH}}')
         bash_errorout('rbd snap rm {{SP_PATH}}')
@@ -643,22 +673,21 @@ class CephAgent(plugin.TaskManager):
         if not cmd.pools or not ceph.support_defer_deleting():
             return jsonobject.dumps(rsp)
 
-        force = "--force" if cmd.force else ""
         for pool_name in set(cmd.pools):
-            r, o, e = bash_roe("rbd trash list -p %s --format json" % pool_name)
-            if r != 0 or o.strip() == '':
+            ret, trash_list, _ = ceph.rbd_trash_list(pool_name)
+            if ret != 0 or not trash_list:
                 continue
 
-            rsp.pool2TrashResult.update({pool_name: []})
-            trash_list = jsonobject.loads(o)
-            if len(trash_list) != 0 and isinstance(trash_list[0], str):
-                trash_list = [{"id": trash_list[idx], "name": trash_list[idx+1]} for idx in range(0, len(trash_list), 2)]
-                trash_list = jsonobject.loads(simplejson.dumps(trash_list))
-
+            pool_trashes = []
             for trash in trash_list:
-                r, o, e = bash_roe("rbd trash rm %s/%s %s" % (pool_name, trash.id, force))
-                if r == 0:
-                    rsp.pool2TrashResult.get(pool_name).append(trash.name)
+                trash_id = trash.get("id")
+                if not trash_id:
+                    continue
+
+                ret, _, _ = ceph.rbd_trash_rm(pool_name, trash_id, cmd.force)
+                if ret == 0:
+                    pool_trashes.append(trash.get("name"))
+            rsp.pool2TrashResult[pool_name] = pool_trashes
         self._set_capacity_to_response(rsp)
         return jsonobject.dumps(rsp)
 

--- a/zstacklib/zstacklib/utils/ceph.py
+++ b/zstacklib/zstacklib/utils/ceph.py
@@ -54,6 +54,37 @@ def get_defer_deleting_options(cmd):
 
     return opts
 
+def find_rbd_trash(trash_list, image_name):
+    return next((t for t in trash_list if image_name in (t.get("id"), t.get("name"))), None)
+
+def rbd_children(path):
+    children = bash.bash_o('rbd children %s' % path)
+    if not children:
+        return []
+    return [c.strip() for c in children.splitlines() if c.strip()]
+
+def rbd_trash_list(pool_name):
+    ret, stdout, stderr = bash.bash_roe("rbd trash list -p %s --format json" % pool_name)
+    if ret != 0 or not stdout or not stdout.strip():
+        return ret, [], stderr
+
+    entries = jsonobject.loads(stdout)
+    if not entries:
+        return ret, [], stderr
+
+    if isinstance(entries[0], str):
+        trash_list = [{"id": entries[i], "name": entries[i + 1] if i + 1 < len(entries) else entries[i]}
+                      for i in range(0, len(entries), 2)]
+    else:
+        trash_list = [{"id": e.id, "name": e.name} for e in entries]
+    return ret, trash_list, stderr
+
+def rbd_trash_rm(pool_name, trash_id, force=False):
+    cmd = "rbd trash rm %s/%s" % (pool_name, trash_id)
+    if force:
+        cmd += " --force"
+    return bash.bash_roe(cmd)
+
 def is_zstone():
     return os.path.exists("/opt/zstone/bin/zstnlet")
 


### PR DESCRIPTION
## Summary

Backport the merged Ceph image-cache trash-child cleanup from `zstack-utility!7029` / `41a7ce2d1818c07ad365ffc949288a096ca0db2f` to `5.4.12`.

When `ceph.image.expiration.time > 0`, an expunged VM root volume remains in RBD trash and is still returned by `rbd children`. The old `delete_image_cache` path treats it as an active child and refuses to delete the image-cache snapshot.

## Changes

- Purge only children that match `rbd trash list` entries before deleting the image cache.
- Keep unmatched active children in `remaining_children`, so they still block destructive snapshot deletion.
- Reuse shared RBD trash parsing/removal helpers in the existing `clean_trash` path.
- Backport production code only. The source pytest harness does not exist on `5.4.12`; `tests/conftest.py`, `tests/plugins`, `tests/fixtures`, and `tests/unit/ceph/test_ceph_primary_handlers.py` are intentionally not backported.

## Testing

- [x] Source MR `!7029`: auditable targeted RED -> GREEN.
- [x] Source Jira/MR records: `tests/unit/ceph/test_ceph_primary_handlers.py` 57/58 passed.
- [x] Source live agent replacement: trash child and image cache removed; active-child safety retained.
- [x] Backport production diff verified semantically equivalent to source commit `41a7ce2d1`.
- [x] `python3 -m py_compile` passed for both modified production files.
- [x] `git diff --check upstream/5.4.12..HEAD` passed.
- [ ] Target `5.4.12` pytest not run: the source pytest harness is absent and intentionally not backported.
- [ ] No live Ceph run was performed on the `5.4.12` backport.

Resolves: ZSTAC-86340

sync from gitlab !7492