### PR TITLE
<fix>[zbs]: ZSTAC-86711 harden vhost target deployment

### DIFF
--- a/kvmagent/kvmagent/plugins/zbs_vhost_target.py
+++ b/kvmagent/kvmagent/plugins/zbs_vhost_target.py
@@ -6,6 +6,7 @@ import socket
 import threading
 import xml.etree.ElementTree as ET
 
+from zstacklib.system.filesystem import read_file, safe_write
 from zstacklib.utils import bash
 from zstacklib.utils import log
 
@@ -35,6 +36,7 @@ HUGEPAGE_SIZE_BYTES = 2 * 1024 * 1024
 DEFAULT_CORE_COUNT = 2
 DOCKER_CE_INSTALL_CMD = "yum --disablerepo=zstack-local --enablerepo=zstack-mn install -y docker-ce docker-ce-cli containerd.io"
 DOCKER_ENGINE_INSTALL_CMD = "yum --disablerepo=zstack-local --enablerepo=zstack-mn install -y docker-engine"
+DOCKER_DAEMON_CONFIG_PATH = "/etc/docker/daemon.json"
 
 
 def host_cpu_num():
@@ -206,14 +208,49 @@ def image_present(image):
     return bash.bash_r("docker image inspect %s >/dev/null 2>&1" % shlex.quote(image)) == 0
 
 
+def docker_active():
+    return bash.bash_r("systemctl is-active --quiet docker") == 0
+
+
 def docker_ready():
-    return bash.bash_r("command -v docker >/dev/null 2>&1") == 0 and \
-           bash.bash_r("systemctl is-active --quiet docker") == 0
+    return bash.bash_r("command -v docker >/dev/null 2>&1") == 0 and docker_active()
 
 
+def _read_docker_daemon_config():
+    try:
+        config = json.loads(read_file(DOCKER_DAEMON_CONFIG_PATH))
+    except FileNotFoundError:
+        return {}
+    except ValueError as e:
+        raise Exception("invalid docker daemon config[%s]: %s" % (DOCKER_DAEMON_CONFIG_PATH, e))
+    if not isinstance(config, dict):
+        raise Exception("invalid docker daemon config[%s]: expected a JSON object" % DOCKER_DAEMON_CONFIG_PATH)
+    return config
+
+
+def _ensure_docker_iptables_disabled():
+    config = _read_docker_daemon_config()
+    if config.get("iptables") is False:
+        return
+    if "iptables" in config:
+        raise Exception("docker daemon config[%s] has conflicting iptables value[%s]" %
+                        (DOCKER_DAEMON_CONFIG_PATH, config["iptables"]))
+
+    config["iptables"] = False
+    safe_write(DOCKER_DAEMON_CONFIG_PATH,
+               json.dumps(config, indent=2, sort_keys=True) + "\n")
+
+
+@_locked
 def ensure_docker():
     if docker_ready():
+        if _read_docker_daemon_config().get("iptables") is not False:
+            raise Exception("docker is active but daemon config[%s] does not set iptables to false" %
+                            DOCKER_DAEMON_CONFIG_PATH)
         return
+    if docker_active():
+        raise Exception("docker service is active but docker command is unavailable")
+    _ensure_docker_iptables_disabled()
     ce_r, ce_o, ce_e = bash.bash_roe(DOCKER_CE_INSTALL_CMD)
     if ce_r != 0:
         logger.warn("docker-ce install failed, falling back to docker-engine, stdout: %s, stderr: %s" % (ce_o, ce_e))

--- a/tests/unit/kvmagent/test_zbs_vhost_deploy.py
+++ b/tests/unit/kvmagent/test_zbs_vhost_deploy.py
@@ -3,6 +3,8 @@ Unit tests for the lazy-deploy path in kvmagent.plugins.zbs_vhost_target:
 image source fallback ordering, conditional insecure-registry downgrade,
 target health semantics, and shell quoting of request-supplied values.
 """
+import json
+
 import pytest
 from unittest.mock import patch
 
@@ -123,21 +125,110 @@ class TestShellQuoting:
 
 
 class TestEnsureDocker:
+    @pytest.fixture(autouse=True)
+    def daemon_config(self, tmp_path):
+        self.daemon_config = tmp_path / "daemon.json"
+        self.daemon_config_path = str(self.daemon_config)
+        with patch.object(t, 'DOCKER_DAEMON_CONFIG_PATH', self.daemon_config_path), \
+             patch.object(t, 'docker_active', return_value=False) as active:
+            self.docker_active = active
+            yield
+
+    def _write_daemon_config(self, config):
+        self.daemon_config.write_text(json.dumps(config) if isinstance(config, dict) else config)
+
+    def _read_daemon_config(self):
+        return json.loads(self.daemon_config.read_text()) if self.daemon_config.exists() else None
+
+    def _read_daemon_config_bytes(self):
+        return self.daemon_config.read_bytes() if self.daemon_config.exists() else None
+
     def test_skips_install_when_docker_ready(self):
+        self._write_daemon_config({'iptables': False})
         with patch.object(t, 'docker_ready', return_value=True), \
+             patch.object(t.bash, 'bash_roe') as br, \
              patch.object(t.bash, 'bash_errorout') as be:
             t.ensure_docker()
+            br.assert_not_called()
             be.assert_not_called()
 
     def test_installs_and_starts_when_missing(self):
         states = iter([False, True])
+
+        def start(cmd):
+            assert self._read_daemon_config()['iptables'] is False
+
         with patch.object(t, 'docker_ready', side_effect=lambda: next(states)), \
              patch.object(t.bash, 'bash_roe', return_value=(0, "", None)) as br, \
-             patch.object(t.bash, 'bash_errorout') as be:
+             patch.object(t.bash, 'bash_errorout', side_effect=start) as be:
             t.ensure_docker()
             cmds = " ".join(str(c) for c in br.call_args_list)
             assert t.DOCKER_CE_INSTALL_CMD in cmds
             assert any('systemctl enable --now docker' in str(c) for c in be.call_args_list)
+            assert self._read_daemon_config() == {'iptables': False}
+
+    def test_preserves_existing_daemon_config_when_disabling_iptables(self):
+        self._write_daemon_config({'registry-mirrors': ['https://mirror.example.com']})
+        states = iter([False, True])
+        with patch.object(t, 'docker_ready', side_effect=lambda: next(states)), \
+             patch.object(t.bash, 'bash_roe', return_value=(0, "", None)), \
+             patch.object(t.bash, 'bash_errorout'):
+            t.ensure_docker()
+
+        assert self._read_daemon_config() == {
+            'iptables': False,
+            'registry-mirrors': ['https://mirror.example.com'],
+        }
+
+    @pytest.mark.parametrize('config', [
+        {'iptables': True},
+        '{invalid-json',
+        '[]',
+        'null',
+    ])
+    def test_rejects_conflicting_daemon_config_before_start(self, config):
+        self._write_daemon_config(config)
+        with patch.object(t, 'docker_ready', return_value=False), \
+             patch.object(t.bash, 'bash_roe') as br, \
+             patch.object(t.bash, 'bash_errorout') as be, \
+             pytest.raises(Exception):
+            t.ensure_docker()
+
+        br.assert_not_called()
+        be.assert_not_called()
+
+    @pytest.mark.parametrize('config', [
+        None,
+        {'iptables': True},
+        '{invalid-json',
+        '[]',
+        'null',
+    ])
+    def test_rejects_active_docker_without_safe_firewall_config(self, config):
+        if config is not None:
+            self._write_daemon_config(config)
+        original = self._read_daemon_config_bytes()
+        with patch.object(t, 'docker_ready', return_value=True), \
+             patch.object(t.bash, 'bash_roe') as br, \
+             patch.object(t.bash, 'bash_errorout') as be, \
+             pytest.raises(Exception):
+            t.ensure_docker()
+
+        br.assert_not_called()
+        be.assert_not_called()
+        assert self._read_daemon_config_bytes() == original
+
+    def test_rejects_active_docker_when_cli_is_unavailable(self):
+        self._write_daemon_config({'iptables': False})
+        self.docker_active.return_value = True
+        with patch.object(t, 'docker_ready', return_value=False), \
+             patch.object(t.bash, 'bash_roe', return_value=(0, "", None)) as br, \
+             patch.object(t.bash, 'bash_errorout') as be, \
+             pytest.raises(Exception, match='active.*command'):
+            t.ensure_docker()
+
+        br.assert_not_called()
+        be.assert_not_called()
 
     def test_installs_docker_ce_from_management_node_repo_first(self):
         states = iter([False, True])
@@ -156,6 +247,7 @@ class TestEnsureDocker:
         installs = []
 
         def run(cmd):
+            assert self._read_daemon_config()['iptables'] is False
             installs.append(cmd)
             if cmd == t.DOCKER_CE_INSTALL_CMD:
                 return 1, "", "No match for argument: docker-ce"

--- a/tests/unit/zbsprimarystorage/test_vhost.py
+++ b/tests/unit/zbsprimarystorage/test_vhost.py
@@ -7,6 +7,8 @@ while the real ZBS file name has none.
 """
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 from zbsprimarystorage import zbsutils
 from zbsprimarystorage import zbsagent
 
@@ -17,6 +19,10 @@ def _real_quote(s):
 
 def _last_cmd():
     return zbsutils.shell.call.call_args[0][0]
+
+
+def _lscpu(*rows):
+    return "CPU NODE SOCKET CORE\n%s\n" % "\n".join(rows)
 
 
 class TestCreateVhostBdev:
@@ -58,73 +64,190 @@ class TestDeleteVhostBdev:
             assert "--name vhost-blk-1" in cmd
 
 
+class TestVhostAutoCpuset:
+    def test_selects_four_cpus_from_largest_numa_node(self):
+        output = _lscpu(
+            "0 0 0 0",
+            "1 1 0 0",
+            "2 0 0 1",
+            "3 1 0 1",
+            "4 0 0 2",
+            "5 1 0 2",
+            "7 1 0 3",
+        )
+        with patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, output, "")):
+            assert zbsutils.vhost_auto_cpuset("10.0.0.9", 22, "root", "pwd") == \
+                "[1,3,5,7]"
+
+    def test_tied_node_sizes_choose_node_with_highest_cpu_id(self):
+        output = _lscpu(
+            "0 0 0 0",
+            "1 0 0 1",
+            "2 0 0 2",
+            "3 0 0 3",
+            "4 1 0 0",
+            "5 1 0 1",
+            "6 1 0 2",
+            "7 1 0 3",
+        )
+        with patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, output, "")):
+            assert zbsutils.vhost_auto_cpuset("10.0.0.9", 22, "root", "pwd") == \
+                "[4,5,6,7]"
+
+    def test_never_crosses_numa_nodes_with_interleaved_cpu_ids(self):
+        output = _lscpu(
+            "0 0 0 0",
+            "1 1 0 0",
+            "2 0 0 1",
+            "3 1 0 1",
+            "4 0 0 2",
+            "5 1 0 2",
+            "6 0 0 3",
+            "7 1 0 3",
+            "8 0 0 4",
+        )
+        with patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, output, "")):
+            assert zbsutils.vhost_auto_cpuset("10.0.0.9", 22, "root", "pwd") == \
+                "[2,4,6,8]"
+
+    def test_prefers_distinct_physical_cores_before_smt_siblings(self):
+        output = _lscpu(
+            "0 0 0 0",
+            "1 0 0 1",
+            "2 0 0 3",
+            "3 0 0 3",
+            "4 0 0 2",
+            "5 0 0 2",
+            "6 0 0 1",
+            "7 0 0 0",
+        )
+        with patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, output, "")):
+            assert zbsutils.vhost_auto_cpuset("10.0.0.9", 22, "root", "pwd") == \
+                "[3,5,6,7]"
+
+    def test_same_core_id_on_different_sockets_is_a_distinct_physical_core(self):
+        output = _lscpu(
+            "0 0 0 0",
+            "1 0 0 1",
+            "2 0 1 1",
+            "3 0 1 1",
+            "4 0 1 0",
+            "5 0 1 0",
+            "6 0 0 1",
+            "7 0 0 0",
+        )
+        with patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, output, "")):
+            assert zbsutils.vhost_auto_cpuset("10.0.0.9", 22, "root", "pwd") == \
+                "[3,5,6,7]"
+
+    def test_fills_remaining_slots_with_highest_smt_siblings(self):
+        output = _lscpu(
+            "0 0 0 0",
+            "1 0 0 1",
+            "2 0 0 0",
+            "3 0 0 1",
+            "4 0 0 0",
+            "5 0 0 1",
+        )
+        with patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, output, "")):
+            assert zbsutils.vhost_auto_cpuset("10.0.0.9", 22, "root", "pwd") == \
+                "[2,3,4,5]"
+
+    def test_uses_all_cpus_when_largest_node_has_fewer_than_four(self):
+        output = _lscpu(
+            "0 0 0 0",
+            "1 1 0 0",
+            "2 0 0 1",
+            "3 1 0 1",
+            "5 1 0 2",
+        )
+        with patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, output, "")):
+            assert zbsutils.vhost_auto_cpuset("10.0.0.9", 22, "root", "pwd") == \
+                "[1,3,5]"
+
+    def test_queries_only_online_cpu_topology_from_target(self):
+        output = "CPU NODE SOCKET CORE\n9 0 1 2\n"
+        with patch.object(zbsutils.linux, 'sshpass_run',
+                          return_value=(0, output, "")) as ssh:
+            assert zbsutils.vhost_auto_cpuset("10.0.0.9", "2222", "admin", "secret") == \
+                "[9]"
+            ssh.assert_called_once_with(
+                "10.0.0.9", "secret", "LC_ALL=C lscpu --online -e=CPU,NODE,SOCKET,CORE",
+                user="admin", port=2222)
+
+    def test_ssh_failure_includes_target_and_original_error(self):
+        with patch.object(zbsutils.linux, 'sshpass_run',
+                          return_value=(255, "", "permission denied")):
+            with pytest.raises(Exception) as exc_info:
+                zbsutils.vhost_auto_cpuset("10.0.0.9", 22, "root", "pwd")
+        assert "10.0.0.9" in str(exc_info.value)
+        assert "permission denied" in str(exc_info.value)
+
+    def test_empty_topology_includes_target(self):
+        output = _lscpu()
+        with patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, output, "")):
+            with pytest.raises(Exception) as exc_info:
+                zbsutils.vhost_auto_cpuset("10.0.0.9", 22, "root", "pwd")
+        assert "10.0.0.9" in str(exc_info.value)
+
+
 class TestDeployVhost:
-    def test_auto_cpuset_pins_last_core_from_target_host_cpu_count(self):
+    def test_default_deploy_uses_auto_cpuset_for_target(self):
         with patch.object(zbsutils.shell, 'call'), \
              patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
-             patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, "8\n", "")):
+             patch.object(zbsutils, 'vhost_auto_cpuset',
+                          return_value="[4,5,6,7]") as auto_cpuset, \
+             patch.object(zbsutils, 'ensure_2m_hugetlbfs_mount',
+                          return_value="/dev/hugepages2m"):
             zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd")
-            cmd = _last_cmd()
-            assert cmd.startswith(zbsutils.ZBSADM_BIN_PATH + " vhost deploy")
-            assert "--host 10.0.0.9" in cmd
-            assert "--cpuset '[7]'" in cmd
-
-    def test_cpuset_is_inferred_on_target_not_local(self):
-        with patch.object(zbsutils.shell, 'call'), \
-             patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
-             patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, "8\n", "")) as ssh:
-            zbsutils.deploy_vhost("10.0.0.9", 2222, "root", "pwd")
-            assert ssh.call_args_list[0] == (
-                ("10.0.0.9", "pwd", "grep -c processor /proc/cpuinfo"),
-                {"user": "root", "port": 2222})
-
-    def test_single_cpu_host_falls_back_to_core0(self):
-        with patch.object(zbsutils.shell, 'call'), \
-             patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
-             patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, "1\n", "")):
-            zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd")
-            assert "--cpuset '[0]'" in _last_cmd()
+            assert _last_cmd() == (
+                "/usr/local/bin/zbsadm vhost deploy --host 10.0.0.9 --port 22 "
+                "-u root -p 'pwd' --cpuset '[4,5,6,7]' --silent "
+                "--hugepage-dir /dev/hugepages2m")
+            auto_cpuset.assert_called_once_with("10.0.0.9", 22, "root", "pwd")
 
     def test_uses_existing_2mb_hugetlbfs_mount_when_hugepage_dir_not_set(self):
         with patch.object(zbsutils.shell, 'call'), \
              patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
+             patch.object(zbsutils, 'vhost_auto_cpuset', return_value="[4,5,6,7]"), \
              patch.object(zbsutils.linux, 'sshpass_run', side_effect=[
-                 (0, "8\n", ""),
                  (0, "/dev/hugepages\n", ""),
              ]) as ssh:
             zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd")
             cmd = _last_cmd()
             assert "--hugepage-dir /dev/hugepages" in cmd
-            assert ssh.call_args_list[1][0][2].startswith("findmnt")
-            assert "\\$2" in ssh.call_args_list[1][0][2]
-            assert "\\$1" in ssh.call_args_list[1][0][2]
+            assert ssh.call_args_list[0][0][2].startswith("findmnt")
+            assert "\\$2" in ssh.call_args_list[0][0][2]
+            assert "\\$1" in ssh.call_args_list[0][0][2]
 
     def test_mounts_2mb_hugetlbfs_when_target_has_none(self):
         with patch.object(zbsutils.shell, 'call'), \
              patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
+             patch.object(zbsutils, 'vhost_auto_cpuset', return_value="[4,5,6,7]"), \
              patch.object(zbsutils.linux, 'sshpass_run', side_effect=[
-                 (0, "8\n", ""),
                  (0, "", ""),
                  (0, "", ""),
              ]) as ssh:
             zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd")
             cmd = _last_cmd()
             assert "--hugepage-dir /dev/hugepages2m" in cmd
-            assert "mount -t hugetlbfs -o pagesize=2M none '/dev/hugepages2m'" in ssh.call_args_list[2][0][2]
+            assert "mount -t hugetlbfs -o pagesize=2M none '/dev/hugepages2m'" in ssh.call_args_list[1][0][2]
 
     def test_explicit_cpuset_overrides_auto(self):
         with patch.object(zbsutils.shell, 'call'), \
              patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
-             patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, "8\n", "")):
+             patch.object(zbsutils, 'vhost_auto_cpuset') as auto_cpuset, \
+             patch.object(zbsutils, 'ensure_2m_hugetlbfs_mount',
+                          return_value="/dev/hugepages2m"):
             zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd", cpuset="[1-4]")
             cmd = _last_cmd()
             assert "--cpuset '[1-4]'" in cmd
-            assert "'[7]'" not in cmd
+            auto_cpuset.assert_not_called()
 
     def test_includes_hugepage_args_when_explicitly_set(self):
         with patch.object(zbsutils.shell, 'call'), \
              patch.object(zbsutils.linux, 'shellquote', side_effect=_real_quote), \
-             patch.object(zbsutils.linux, 'sshpass_run', return_value=(0, "8\n", "")):
+             patch.object(zbsutils, 'vhost_auto_cpuset', return_value="[4,5,6,7]"):
             zbsutils.deploy_vhost("10.0.0.9", 22, "root", "pwd",
                                   hugepage_size=2048, hugepage_dir="/dev/hugepages2m")
             cmd = _last_cmd()

--- a/zbsprimarystorage/zbsprimarystorage/zbsutils.py
+++ b/zbsprimarystorage/zbsprimarystorage/zbsutils.py
@@ -1,10 +1,12 @@
 __author__ = 'Xingwei Yu'
 
+from collections import defaultdict
 import os
 import time
 from zstacklib.utils.version import NumericVersion
 
 import zstacklib.utils.jsonobject as jsonobject
+from zstacklib.utils import form
 
 from zstacklib.utils.bash import *
 
@@ -28,6 +30,8 @@ VHOST_ADMIN_SOCK_NAME = "admin.sock"
 VHOST_DEPLOY_READY_RETRIES = 40
 VHOST_DEPLOY_READY_INTERVAL_SECONDS = 0.5
 DEFAULT_VHOST_TARGET_HUGEPAGE_DIR = "/dev/hugepages2m"
+DEFAULT_VHOST_TARGET_CPU_COUNT = 4
+VHOST_CPU_TOPOLOGY_CMD = "LC_ALL=C lscpu --online -e=CPU,NODE,SOCKET,CORE"
 
 
 class ClientInfo(object):
@@ -85,11 +89,46 @@ def deploy_client(ip, port, username, password):
         ZBSADM_BIN_PATH, ip, port, username, linux.shellquote(password)))
 
 
+def _select_vhost_cpus(topology):
+    numa_nodes = defaultdict(list)
+    for cpu_topology in topology:
+        numa_nodes[cpu_topology[1]].append(cpu_topology)
+
+    selected_node = max(
+        numa_nodes.values(),
+        key=lambda cpus: (len(cpus), max(cpu[0] for cpu in cpus)))
+    physical_cores = defaultdict(list)
+    for cpu, _, socket, core in selected_node:
+        physical_cores[(socket, core)].append(cpu)
+
+    selected = []
+    core_groups = sorted(physical_cores.values(), key=max, reverse=True)
+    for siblings in core_groups[:DEFAULT_VHOST_TARGET_CPU_COUNT]:
+        selected.append(max(siblings))
+
+    if len(selected) < DEFAULT_VHOST_TARGET_CPU_COUNT:
+        remaining = sorted(
+            (cpu[0] for cpu in selected_node if cpu[0] not in selected),
+            reverse=True)
+        selected.extend(remaining[:DEFAULT_VHOST_TARGET_CPU_COUNT - len(selected)])
+    return sorted(selected)
+
+
 def vhost_auto_cpuset(ip, port, username, password):
-    _, o, _ = linux.sshpass_run(ip, password, "grep -c processor /proc/cpuinfo", user=username, port=int(port))
-    n = int(o.strip()) if o and o.strip().isdigit() else 0
-    core = n - 1 if n > 1 else 0
-    return "[%d]" % core
+    ret, out, err = linux.sshpass_run(
+        ip, password, VHOST_CPU_TOPOLOGY_CMD, user=username, port=int(port))
+    if ret != 0:
+        detail = (err or "").strip() or (out or "").strip() or "no command output"
+        raise Exception("failed to query vhost CPU topology on host[%s], exit code[%s]: %s" %
+                        (ip, ret, detail))
+
+    try:
+        topology = [tuple(int(row[key]) for key in ("CPU", "NODE", "SOCKET", "CORE"))
+                    for row in form.load(out)]
+        cpus = _select_vhost_cpus(topology)
+    except (KeyError, TypeError, ValueError) as error:
+        raise Exception("failed to select vhost CPUs on host[%s]: %s" % (ip, error))
+    return "[%s]" % ",".join(str(cpu) for cpu in cpus)
 
 
 def find_2m_hugetlbfs_mount(ip, port, username, password):


### PR DESCRIPTION
## Summary

- Configure Docker with `iptables: false` before first startup so it cannot change the host `FORWARD` policy to `DROP`.
- Default vhost targets to at most four logical CPUs from one NUMA node, preferring distinct physical `(socket, core)` pairs before SMT siblings.
- Preserve explicit cpuset behavior and the existing 1024 MiB target memory allocation.

## Testing

- [x] `pytest -o addopts='' -q tests/unit/zbsprimarystorage` — 37 passed
- [x] `pytest -o addopts='' -q tests/unit/kvmagent` — 665 passed, 3 skipped, 2 xfailed
- [x] Real-environment hot deployment on all three ZBS MDS nodes
- [x] Vhost target verified with `[0,1,2,3]`, NUMA node 0, 1 GiB hugepage memory, and `FORWARD ACCEPT`
- [x] Temporary VM booted from a vhost-user root volume to the Ubuntu login screen and completed DHCP; VM and root volume were then expunged
- [ ] CI pipeline

Resolves: ZSTAC-86711

sync from gitlab !7495