### PR TITLE
<fix>[zbs]: install MDS callback probe dependency

### DIFF
--- a/tests/unit/zbsprimarystorage/test_zbsp_ansible.py
+++ b/tests/unit/zbsprimarystorage/test_zbsp_ansible.py
@@ -1,0 +1,15 @@
+import ast
+from pathlib import Path
+
+
+def test_zbsp_installs_management_callback_probe():
+    script_path = Path(__file__).parents[3] / "zbsprimarystorage" / "ansible" / "zbsp.py"
+    tree = ast.parse(script_path.read_text())
+    assignment = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "install_rpm_list" for target in node.targets)
+    )
+    packages = set(ast.literal_eval(assignment.value).split())
+
+    assert "nmap" in packages, "MDS callback connectivity checks require nmap"

--- a/zbsprimarystorage/ansible/zbsp.py
+++ b/zbsprimarystorage/ansible/zbsp.py
@@ -92,7 +92,7 @@ else:
 
 
 # name: install dependencies
-install_rpm_list = "libcbd"
+install_rpm_list = "libcbd nmap"
 py3_rpms = " python3.11 python3.11-devel python3.11-pip libffi-devel openssl-devel"
 qemu_installed = yum_check_package("qemu-kvm", host_post_info)
 if not qemu_installed:


### PR DESCRIPTION
## Summary

ZBS MDS callback connectivity checks require `nc` or `nmap`, but the ZBS primary storage deployment did not install either dependency. Install `nmap` during MDS agent deployment so MN restarts do not misclassify missing probe tools as callback network failures.

## Changes

- Add `nmap` to the ZBS MDS Ansible dependency list.
- Add a regression test that keeps the callback probe dependency explicit.

## Testing

- [x] Regression test observed failing before the production change.
- [x] `PYTHONDONTWRITEBYTECODE=1 pytest -o addopts='' -p no:cacheprovider -q tests/unit/zbsprimarystorage` — 21 passed, 1 pre-existing warning.
- [x] Python 3 compile check for `zbsp.py`.
- [x] `git diff --check`.
- [ ] CI pipeline.
- [ ] KY10 SP3 three-MDS validation: verify the dependency on every MDS and restart MN twice.

Resolves: ZSTAC-86741

sync from gitlab !7498