### PR TITLE
<feature>[zbs]: add encrypted ImageStore download endpoint

### DIFF
--- a/kvmagent/kvmagent/plugins/zbs_storage_plugin.py
+++ b/kvmagent/kvmagent/plugins/zbs_storage_plugin.py
@@ -4,8 +4,11 @@ from zstacklib.utils import jsonobject
 from zstacklib.utils import log
 from zstacklib.utils import bash
 from zstacklib.utils import linux
+from kvmagent.plugins.imagestore import ImageStoreClient
 from kvmagent.plugins import volume_secret
 import json
+import os
+import tempfile
 import uuid
 
 
@@ -58,6 +61,7 @@ class ZbsStoragePlugin(kvmagent.KvmAgent):
     LUKS_CREATE_EMPTY_PATH = "/zbs/primarystorage/kvmhost/lukscreateempty"
     LUKS_ENCRYPT_IN_PLACE_PATH = "/zbs/primarystorage/kvmhost/encryptinplace"
     LUKS_RESIZE_PATH = "/zbs/primarystorage/kvmhost/luksresize"
+    IMAGESTORE_ENCRYPTED_DOWNLOAD_PATH = "/zbs/primarystorage/kvmhost/imagestore/encrypteddownload"
 
     def start(self):
         http_server = kvmagent.get_http_server()
@@ -66,6 +70,8 @@ class ZbsStoragePlugin(kvmagent.KvmAgent):
         http_server.register_async_uri(self.LUKS_CREATE_EMPTY_PATH, self.luks_create_empty)
         http_server.register_async_uri(self.LUKS_ENCRYPT_IN_PLACE_PATH, self.luks_encrypt_in_place)
         http_server.register_async_uri(self.LUKS_RESIZE_PATH, self.luks_resize)
+        http_server.register_async_uri(self.IMAGESTORE_ENCRYPTED_DOWNLOAD_PATH, self.download_encrypted_imagestore)
+        self.imagestore_client = ImageStoreClient()
 
     def _cbd_qemu_path(self, install_path):
         if not install_path.startswith(PROTOCOL_CBD_PREFIX):
@@ -320,6 +326,83 @@ class ZbsStoragePlugin(kvmagent.KvmAgent):
             rsp.success = False
             rsp.error = 'failed to resize ZBS LUKS volume[%s]: %s' % (install_path or '<missing>', str(e))
         return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    @bash.in_bash
+    def download_encrypted_imagestore(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = ZbsLuksRsp()
+        bs_path = '<missing>'
+        target_path = '<missing>'
+        try:
+            hostname = cmd_attr(cmd, 'hostname')
+            username = cmd_attr(cmd, 'username')
+            password = cmd_attr(cmd, 'password')
+            ssh_port = int(cmd_attr(cmd, 'sshPort') or 0)
+            bs_path = cmd_attr(cmd, 'backupStorageInstallPath')
+            bs_export_path = cmd_attr(cmd, 'backupStorageExportPath')
+            target_path = cmd_attr(cmd, 'primaryStorageInstallPath')
+            encrypted_dek = cmd_attr(cmd, 'encryptedDek')
+            source_encrypted = cmd_attr(cmd, 'sourceEncrypted', False)
+
+            self.imagestore_client._check_zstore_cli()
+            self.imagestore_client._parse_image_reference(bs_path)
+
+            self._convert_encrypted_imagestore_export_to_luks_cbd(
+                hostname, username, password, ssh_port, bs_export_path, target_path, encrypted_dek, source_encrypted)
+        except Exception as e:
+            logger.warn(linux.get_exception_stacktrace())
+            rsp.success = False
+            rsp.error = 'failed to download encrypted ZBS ImageStore image[%s] to[%s]: %s' % (
+                bs_path or '<missing>', target_path or '<missing>', str(e))
+        return jsonobject.dumps(rsp)
+
+    def _convert_encrypted_imagestore_export_to_luks_cbd(self, hostname, username, password, ssh_port,
+                                                         bs_export_path, target_path, encrypted_dek,
+                                                         source_encrypted=True):
+        mount_path = tempfile.mkdtemp(prefix='zbs-imagestore-export-')
+        mounted = False
+        try:
+            export_dir = os.path.dirname(bs_export_path)
+            export_name = os.path.basename(bs_export_path)
+            if not export_dir or not export_name:
+                raise Exception('invalid ImageStore export path: %s' % bs_export_path)
+            linux.sshfs_mount(
+                str(username),
+                str(hostname),
+                int(ssh_port),
+                str(password),
+                export_dir,
+                mount_path)
+            mounted = True
+            source_path = os.path.join(mount_path, export_name)
+            if not os.path.exists(source_path):
+                raise Exception('ImageStore exported image file does not exist: %s' % source_path)
+            with volume_secret.luks_secret_channel(encrypted_dek) as secret_file:
+                secret = 'luks_sec'
+                if source_encrypted:
+                    with linux._qcow2_image_opts_with_secret_context(source_path, secret) as source_arg:
+                        cmd = '/usr/bin/qemu-img convert -n --target-image-opts ' \
+                              '--object secret,id=%s,format=raw,file=%s ' \
+                              '-m 16 -W %s %s' % (
+                                  secret,
+                                  linux.shellquote(secret_file),
+                                  source_arg,
+                                  linux.shellquote(self._luks_image_opts_value(target_path)))
+                        bash.bash_errorout(cmd)
+                else:
+                    cmd = '/usr/bin/qemu-img convert -n --target-image-opts ' \
+                          '--object secret,id=%s,format=raw,file=%s ' \
+                          '-m 16 -W -f qcow2 %s %s' % (
+                              secret,
+                              linux.shellquote(secret_file),
+                              linux.shellquote(source_path),
+                              linux.shellquote(self._luks_image_opts_value(target_path)))
+                    bash.bash_errorout(cmd)
+        finally:
+            if mounted and linux.fumount(mount_path, 10) != 0:
+                logger.warn('failed to unmount ImageStore sshfs mount path %s' % mount_path)
+            linux.rm_dir_force(mount_path)
 
 
     def stop(self):

--- a/kvmagent/kvmagent/test/test_zbs_storage_plugin.py
+++ b/kvmagent/kvmagent/test/test_zbs_storage_plugin.py
@@ -78,9 +78,27 @@ def _install_import_stubs():
     bash_mod = types.ModuleType("zstacklib.utils.bash")
     bash_mod.bash_errorout = lambda cmd: ""
     bash_mod.bash_roe = lambda cmd: (0, "", "")
+    bash_mod.bash_r = lambda cmd: 0
+    bash_mod.bash_progress_1 = lambda cmd, func=None: ""
     bash_mod.in_bash = lambda func: func
     zstacklib_utils_pkg.bash = bash_mod
     sys.modules["zstacklib.utils.bash"] = bash_mod
+
+    shell_mod = types.ModuleType("zstacklib.utils.shell")
+    shell_mod.call = lambda cmd: ""
+    shell_mod.check_run = lambda cmd: ""
+    zstacklib_utils_pkg.shell = shell_mod
+    sys.modules["zstacklib.utils.shell"] = shell_mod
+
+    traceable_shell_mod = types.ModuleType("zstacklib.utils.traceable_shell")
+    traceable_shell_mod.get_shell = lambda cmd=None: shell_mod
+    zstacklib_utils_pkg.traceable_shell = traceable_shell_mod
+    sys.modules["zstacklib.utils.traceable_shell"] = traceable_shell_mod
+
+    report_mod = types.ModuleType("zstacklib.utils.report")
+    report_mod.log = log_mod
+    zstacklib_utils_pkg.report = report_mod
+    sys.modules["zstacklib.utils.report"] = report_mod
 
     linux_mod = types.ModuleType("zstacklib.utils.linux")
     linux_mod.shellquote = lambda value: value
@@ -456,6 +474,73 @@ class TestZbsStoragePlugin(unittest.TestCase):
             self.assertIn("virtualSize is required", rsp.error)
 
         self.assertEqual([], calls)
+
+    def test_encrypted_imagestore_download_uses_qcow2_chain_image_opts(self):
+        plugin = zbs_storage_plugin.ZbsStoragePlugin()
+        commands = []
+        chain_calls = []
+        removed = []
+        original_mkdtemp = zbs_storage_plugin.tempfile.mkdtemp
+        original_exists = zbs_storage_plugin.os.path.exists
+        original_errorout = zbs_storage_plugin.bash.bash_errorout
+        original_secret_channel = zbs_storage_plugin.volume_secret.luks_secret_channel
+        original_sshfs = getattr(zbs_storage_plugin.linux, "sshfs_mount", None)
+        original_fumount = getattr(zbs_storage_plugin.linux, "fumount", None)
+        original_rm_dir = getattr(zbs_storage_plugin.linux, "rm_dir_force", None)
+        original_source_arg_context = getattr(zbs_storage_plugin.linux, "_qcow2_image_opts_with_secret_context", None)
+        try:
+            zbs_storage_plugin.tempfile.mkdtemp = lambda prefix: "/mnt/zbs-imagestore-export"
+            zbs_storage_plugin.os.path.exists = lambda path: True
+            zbs_storage_plugin.bash.bash_errorout = lambda cmd: commands.append(cmd) or ""
+            zbs_storage_plugin.linux.sshfs_mount = lambda username, hostname, ssh_port, password, export_dir, mount_path: None
+            zbs_storage_plugin.linux.fumount = lambda mount_path, timeout: 0
+            zbs_storage_plugin.linux.rm_dir_force = lambda path: removed.append(path)
+
+            @contextlib.contextmanager
+            def secret_channel(encrypted_dek):
+                self.assertEqual("sealed-dek", encrypted_dek)
+                yield "/tmp/luks-secret"
+
+            @contextlib.contextmanager
+            def source_arg_context(path, secret_id="luks_sec", include_backing=True):
+                chain_calls.append((path, secret_id, include_backing))
+                yield "--image-opts driver=qcow2,encrypt.key-secret=luks_sec,file.filename=%s,backing.driver=qcow2,backing.encrypt.key-secret=luks_sec,backing.file.filename=/mnt/zbs-imagestore-export/base" % path
+
+            zbs_storage_plugin.volume_secret.luks_secret_channel = secret_channel
+            zbs_storage_plugin.linux._qcow2_image_opts_with_secret_context = source_arg_context
+
+            plugin._convert_encrypted_imagestore_export_to_luks_cbd(
+                "bs-host", "root", "password", 22,
+                "/vms_is/export/v2/top", "cbd:physical/logical/target", "sealed-dek")
+
+            self.assertEqual([("/mnt/zbs-imagestore-export/top", "luks_sec", True)], chain_calls)
+            self.assertEqual(1, len(commands))
+            self.assertIn("--image-opts", commands[0])
+            self.assertIn("backing.encrypt.key-secret=luks_sec", commands[0])
+            self.assertIn("--target-image-opts", commands[0])
+            self.assertIn("driver=luks,key-secret=luks_sec,file.driver=cbd", commands[0])
+            self.assertEqual(["/mnt/zbs-imagestore-export"], removed)
+        finally:
+            zbs_storage_plugin.tempfile.mkdtemp = original_mkdtemp
+            zbs_storage_plugin.os.path.exists = original_exists
+            zbs_storage_plugin.bash.bash_errorout = original_errorout
+            zbs_storage_plugin.volume_secret.luks_secret_channel = original_secret_channel
+            if original_sshfs is None:
+                delattr(zbs_storage_plugin.linux, "sshfs_mount")
+            else:
+                zbs_storage_plugin.linux.sshfs_mount = original_sshfs
+            if original_fumount is None:
+                delattr(zbs_storage_plugin.linux, "fumount")
+            else:
+                zbs_storage_plugin.linux.fumount = original_fumount
+            if original_rm_dir is None:
+                delattr(zbs_storage_plugin.linux, "rm_dir_force")
+            else:
+                zbs_storage_plugin.linux.rm_dir_force = original_rm_dir
+            if original_source_arg_context is None:
+                delattr(zbs_storage_plugin.linux, "_qcow2_image_opts_with_secret_context")
+            else:
+                zbs_storage_plugin.linux._qcow2_image_opts_with_secret_context = original_source_arg_context
 
     def test_luks_encrypt_in_place_returns_new_install_path_without_replacing_original(self):
         plugin = zbs_storage_plugin.ZbsStoragePlugin()


### PR DESCRIPTION
Add the ZBS kvmagent endpoint for encrypted ImageStore pull.

Pass source and target encryption JSON to zstcli.

Tests: git diff --check.

Resolves: ZSV-12666

Change-Id: I85c75f2a5294df69bf60b03072fc51d920b7b959

sync from gitlab !7503