### PR TITLE
<fix>[kvm]: fix qga pushgateway auth

### DIFF
--- a/kvmagent/kvmagent/plugins/host_pushgateway.py
+++ b/kvmagent/kvmagent/plugins/host_pushgateway.py
@@ -1,0 +1,60 @@
+import glob
+import logging
+import re
+
+
+DEFAULT_HOST_PUSHGATEWAY_AUTH_HEADER = "Basic YWRtaW46enN0YWNrQDEyMw=="
+LIGHTTPD_CONF_GLOBS = [
+    "/var/lib/zstack/userdata/*/lighttpd.conf",
+    "/var/lib/zstack/tf_userdata/lighttpd.conf",
+]
+AUTH_HEADER_PATTERN = re.compile(r'Authorization"\s*=>\s*"([^"]+)"')
+logger = logging.getLogger(__name__)
+
+
+def _get_default_conf_paths():
+    conf_paths = []
+    seen_paths = set()
+    for pattern in LIGHTTPD_CONF_GLOBS:
+        for conf_path in sorted(glob.glob(pattern)):
+            if conf_path in seen_paths:
+                continue
+            seen_paths.add(conf_path)
+            conf_paths.append(conf_path)
+    return conf_paths
+
+
+def get_auth_header(conf_paths=None):
+    if conf_paths is None:
+        conf_paths = _get_default_conf_paths()
+
+    for conf_path in conf_paths:
+        try:
+            with open(conf_path, "r") as fd:
+                match = AUTH_HEADER_PATTERN.search(fd.read())
+                if match:
+                    return match.group(1)
+        except (IOError, OSError) as e:
+            logger.warning("failed to read host pushgateway auth config[%s]: %s" % (conf_path, e))
+
+    return DEFAULT_HOST_PUSHGATEWAY_AUTH_HEADER
+
+
+def make_push_metrics_headers():
+    return {
+        "Content-Type": "application/json",
+        "Authorization": get_auth_header()
+    }
+
+
+def make_get_metrics_headers():
+    return {
+        "Content-Type": "text/plain",
+        "Authorization": get_auth_header()
+    }
+
+
+def make_delete_metric_headers():
+    return {
+        "Authorization": get_auth_header()
+    }

--- a/kvmagent/kvmagent/plugins/qga_zwatch.py
+++ b/kvmagent/kvmagent/plugins/qga_zwatch.py
@@ -12,6 +12,7 @@ from zstacklib.utils import log
 from zstacklib.utils import shell
 from zstacklib.utils import thread
 from zstacklib.utils.qga import VmQga
+from kvmagent.plugins import host_pushgateway
 from kvmagent.plugins import vm_plugin
 
 log.configure_log('/var/log/zstack/zstack-kvmagent.log')
@@ -319,9 +320,7 @@ def get_guest_tools_states(domains):
 def push_metrics_to_gateway(url, uuid, metrics):
     url = url + uuid
     metrics += "\n\n"
-    headers = {
-        "Content-Type": "application/json"
-    }
+    headers = host_pushgateway.make_push_metrics_headers()
     rsp = http.json_post(url, body=metrics, headers=headers)
     logger.debug('vm[%s] push metric with rsp[%s]' % (uuid, rsp))
 
@@ -370,4 +369,3 @@ def get_nic_info_for_windows_2008(uuid, qga):
     mac_to_ip_json = json.dumps(mac_to_ip, indent=4)
     logger.debug('vm[%s] get nic info all: [%s]' % (uuid, mac_to_ip_json))
     return mac_to_ip_json
-

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -46,11 +46,13 @@ from kvmagent import kvmagent
 from kvmagent.plugins.baremetal_v2_gateway_agent import \
     BaremetalV2GatewayAgentPlugin as BmV2GwAgent
 from kvmagent.plugins.bmv2_gateway_agent import utils as bm_utils
+from kvmagent.plugins import host_pushgateway
 from kvmagent.plugins.imagestore import ImageStoreClient
 from kvmagent.plugins.nvram import nvram
 from kvmagent.plugins.vms import vm_host_file, vm_host_file_monitor, tpm
 from zstacklib.utils import bash, plugin, iscsi, qemu_nbd
 from zstacklib.utils.bash import in_bash
+from zstacklib.utils import http
 from zstacklib.utils import lvm
 from zstacklib.utils import ft
 from zstacklib.utils import shell
@@ -10761,7 +10763,7 @@ host side snapshot files chian:
             if bind_addresses:
                 port = bind_addresses[0].split(':')[-1]
                 url = 'http://localhost:%s/metrics' % port
-                result = http.json_post(url, body=None, headers={'Content-Type':'text/plain'}, method='GET')
+                result = http.json_post(url, body=None, headers=host_pushgateway.make_get_metrics_headers(), method='GET')
                 lines = filter(lambda line:
                         line.startswith('push_time_seconds') and line.find(vm_uuid) >= 0,
                         result.split('\n'))
@@ -12629,7 +12631,7 @@ host side snapshot files chian:
                     break
             vm_uuid = dom.name()
             url = "http://localhost:%s/metrics/job/zwatch_vm_agent/vmUuid/%s" % (port, vm_uuid)
-            shell.run('curl -X DELETE ' + url)
+            http.json_post(url, body=None, headers=host_pushgateway.make_delete_metric_headers(), method='DELETE')
         except Exception as e:
             logger.warn("delete pushgateway metric when vm stoped failed: %s" % e.message)
 

--- a/kvmagent/kvmagent/test/test_host_pushgateway.py
+++ b/kvmagent/kvmagent/test/test_host_pushgateway.py
@@ -1,0 +1,80 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from kvmagent.plugins import host_pushgateway
+
+
+class TestHostPushgateway(unittest.TestCase):
+    def test_get_auth_header_reads_lighttpd_config(self):
+        fd, path = tempfile.mkstemp()
+        try:
+            os.write(fd, b'setenv.add-request-header = ( "Authorization" => "Basic custom" )')
+            os.close(fd)
+
+            self.assertEqual("Basic custom", host_pushgateway.get_auth_header([path]))
+        finally:
+            if fd:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            os.remove(path)
+
+    def test_get_auth_header_falls_back_to_product_default(self):
+        self.assertEqual(
+            host_pushgateway.DEFAULT_HOST_PUSHGATEWAY_AUTH_HEADER,
+            host_pushgateway.get_auth_header([])
+        )
+
+    def test_get_auth_header_uses_deterministic_glob_priority(self):
+        temp_dir = tempfile.mkdtemp()
+        try:
+            low_priority_dir = os.path.join(temp_dir, "low")
+            high_priority_dir = os.path.join(temp_dir, "high")
+            os.makedirs(low_priority_dir)
+            os.makedirs(high_priority_dir)
+            low_priority_conf = os.path.join(low_priority_dir, "lighttpd.conf")
+            high_priority_conf = os.path.join(high_priority_dir, "lighttpd.conf")
+            with open(low_priority_conf, "w") as fd:
+                fd.write('setenv.add-request-header = ( "Authorization" => "Basic low" )')
+            with open(high_priority_conf, "w") as fd:
+                fd.write('setenv.add-request-header = ( "Authorization" => "Basic high" )')
+
+            with mock.patch.object(host_pushgateway, "LIGHTTPD_CONF_GLOBS", [
+                os.path.join(high_priority_dir, "lighttpd.conf"),
+                os.path.join(low_priority_dir, "lighttpd.conf"),
+            ]):
+                self.assertEqual("Basic high", host_pushgateway.get_auth_header())
+        finally:
+            shutil.rmtree(temp_dir)
+
+    def test_make_push_metrics_headers_adds_basic_auth(self):
+        with mock.patch.object(host_pushgateway, "get_auth_header", return_value="Basic test"):
+            headers = host_pushgateway.make_push_metrics_headers()
+
+        self.assertEqual("application/json", headers["Content-Type"])
+        self.assertEqual("Basic test", headers["Authorization"])
+
+    def test_make_get_metrics_headers_adds_basic_auth(self):
+        with mock.patch.object(host_pushgateway, "get_auth_header", return_value="Basic test"):
+            headers = host_pushgateway.make_get_metrics_headers()
+
+        self.assertEqual("text/plain", headers["Content-Type"])
+        self.assertEqual("Basic test", headers["Authorization"])
+
+    def test_make_delete_metric_headers_adds_basic_auth(self):
+        with mock.patch.object(host_pushgateway, "get_auth_header", return_value="Basic test"):
+            headers = host_pushgateway.make_delete_metric_headers()
+
+        self.assertEqual("Basic test", headers["Authorization"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add host pushgateway auth helpers for QGA zwatch metrics.
Cover status reads and VM stop metric cleanup.

Resolves: ZSTAC-70407
Relates: ZSV-12572

Change-Id: Ieddf4068353e5ff49550bb4572ce5fb4cb507abe
(cherry picked from commit 25c1494b16e0c7690ce570cb90c502be8ee9cdd5)

sync from gitlab !7505