### PR TITLE
<fix>[kvmagent]: handle detached cache cancellation

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -2413,29 +2413,23 @@ class DetachBlockCacheTaskDaemon(plugin.TaskDaemon):
         self.progress = 0            # type: int
         self.progress_file = linux.create_temp_file()
         self.detach_lock = threading.Lock()
+        self.shell_id = '%s-detach-cache' % self.api_id
 
     def _finish_detached_cache(self):
         if self.progress == 100:
             return True
 
         cache = self.volume.cache
-        if not cache.installPath:
-            return False
-
-        try:
-            caches = qmp.execute_qmp_command(self.vm_uuid, "query-block-cache", raise_exception=False)
-        except Exception as e:
-            logger.warn('failed to query block cache for vm[uuid:%s]: %s' % (self.vm_uuid, str(e)))
-            return False
+        caches = qmp.execute_qmp_command(self.vm_uuid, "query-block-cache", raise_exception=False)
 
         if caches is None:
             return False
 
-        target_cache = next((c for c in caches if c.get('file') == cache.installPath), None)
-        if target_cache is None:
+        target_caches = list(filter(lambda c: c['file'] == cache.installPath, caches))
+        if not target_caches:
             self.progress = 100
             return True
-        if target_cache.get('status') != 'detached':
+        if target_caches[0]['status'] != 'detached':
             return False
 
         virsh.block_cache_detach(
@@ -2455,7 +2449,7 @@ class DetachBlockCacheTaskDaemon(plugin.TaskDaemon):
             if self._finish_detached_cache():
                 raise Exception('block cache is already detached, cancel detach task failed')
 
-            traceable_shell.cancel_job_by_api(self.api_id, sig=signal.SIGINT)
+            traceable_shell.cancel_job_by_api(self.shell_id, sig=signal.SIGINT)
             self.result.fail('detach block-cache task cancelled')
 
     def _get_percent(self):
@@ -2500,7 +2494,8 @@ class DetachBlockCacheTaskDaemon(plugin.TaskDaemon):
                     path=self.disk_name,
                     timeout=timeout,
                     delete=delete,
-                    cmd_shell=traceable_shell.get_shell(self.task_spec),
+                    cmd_shell=traceable_shell.TraceableShell(
+                        self.shell_id, self.deadline if self.timeout else None),
                     progress_output=self.progress_file)
         except Exception:
             with self.detach_lock:

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -2412,11 +2412,51 @@ class DetachBlockCacheTaskDaemon(plugin.TaskDaemon):
         self.disk_name = disk_name   # type: str
         self.progress = 0            # type: int
         self.progress_file = linux.create_temp_file()
+        self.detach_lock = threading.Lock()
+
+    def _finish_detached_cache(self):
+        if self.progress == 100:
+            return True
+
+        cache = self.volume.cache
+        if not cache.installPath:
+            return False
+
+        try:
+            caches = qmp.execute_qmp_command(self.vm_uuid, "query-block-cache", raise_exception=False)
+        except Exception as e:
+            logger.warn('failed to query block cache for vm[uuid:%s]: %s' % (self.vm_uuid, str(e)))
+            return False
+
+        if caches is None:
+            return False
+
+        target_cache = next((c for c in caches if c.get('file') == cache.installPath), None)
+        if target_cache is None:
+            self.progress = 100
+            return True
+        if target_cache.get('status') != 'detached':
+            return False
+
+        virsh.block_cache_detach(
+                domain=self.vm_uuid,
+                path=self.disk_name,
+                timeout=int(cache.timeout) if cache.timeout else None,
+                delete=bool(cache.delete),
+                cmd_shell=traceable_shell.TraceableShell(
+                    None, self.deadline if self.timeout else None),
+                progress_output=self.progress_file)
+        self.progress = 100
+        return True
 
     def _cancel(self):
         # type: () -> None
-        traceable_shell.cancel_job_by_api(self.api_id, sig=signal.SIGINT)
-        self.result.fail('detach block-cache task cancelled')
+        with self.detach_lock:
+            if self._finish_detached_cache():
+                raise Exception('block cache is already detached, cancel detach task failed')
+
+            traceable_shell.cancel_job_by_api(self.api_id, sig=signal.SIGINT)
+            self.result.fail('detach block-cache task cancelled')
 
     def _get_percent(self):
         # type: () -> int
@@ -2463,10 +2503,14 @@ class DetachBlockCacheTaskDaemon(plugin.TaskDaemon):
                     cmd_shell=traceable_shell.get_shell(self.task_spec),
                     progress_output=self.progress_file)
         except Exception:
+            with self.detach_lock:
+                if self.result.success and self._finish_detached_cache():
+                    return
             self._raise_if_cancelled()
             raise
-        self._raise_if_cancelled()
-        self.progress = 100
+        with self.detach_lock:
+            self._raise_if_cancelled()
+            self.progress = 100
 
 
 class VmVolumesRecoveryTask(plugin.TaskDaemon):

--- a/tests/unit/kvmagent/test_volume_cache_cancel.py
+++ b/tests/unit/kvmagent/test_volume_cache_cancel.py
@@ -408,7 +408,7 @@ class VolumeCacheCancelCase(unittest.TestCase):
                 patch.object(volume_cache_plugin.report, "get_exact_percent", side_effect=lambda percent, _: int(percent)):
             self.assertEqual(75, daemon._get_percent())
 
-    def test_detach_block_cache_cancel_uses_traceable_shell_sigint(self):
+    def test_detach_block_cache_cancel_uses_private_shell_sigint(self):
         vm_plugin = _import_with_plugin_stub("kvmagent.plugins.vm_plugin")
 
         cache_path = "/cache/volume-1.qcow2"
@@ -425,7 +425,7 @@ class VolumeCacheCancelCase(unittest.TestCase):
                 patch.object(vm_plugin.traceable_shell, "cancel_job_by_api", create=True) as cancel, \
                 patch.object(vm_plugin.virsh, "block_cache_detach") as detach:
             daemon._cancel()
-            cancel.assert_called_once_with("api-volume-cache-cancel", sig=signal.SIGINT)
+            cancel.assert_called_once_with(daemon.shell_id, sig=signal.SIGINT)
             detach.assert_not_called()
 
     def test_detach_block_cache_cancel_rejects_after_cache_node_removed(self):
@@ -461,25 +461,8 @@ class VolumeCacheCancelCase(unittest.TestCase):
                 patch.object(vm_plugin.traceable_shell, "cancel_job_by_api", create=True) as cancel:
             daemon._cancel()
 
-        cancel.assert_called_once_with("api-volume-cache-cancel", sig=signal.SIGINT)
+        cancel.assert_called_once_with(daemon.shell_id, sig=signal.SIGINT)
         self.assertFalse(daemon.result.success)
-
-    def test_detach_block_cache_cancel_logs_cache_query_exception(self):
-        vm_plugin = _import_with_plugin_stub("kvmagent.plugins.vm_plugin")
-
-        volume = _Obj(
-            installPath="/primary/volume-1",
-            cache=_Obj(installPath="/cache/volume-1.qcow2", timeout=30, delete=False),
-        )
-        daemon = vm_plugin.DetachBlockCacheTaskDaemon(_task_spec(), "vm-1", volume, "vdb")
-
-        with patch.object(vm_plugin.qmp, "execute_qmp_command", side_effect=ValueError("invalid qmp json")), \
-                patch.object(vm_plugin.logger, "warn") as warn, \
-                patch.object(vm_plugin.traceable_shell, "cancel_job_by_api", create=True):
-            daemon._cancel()
-
-        warn.assert_called_once_with(
-            "failed to query block cache for vm[uuid:vm-1]: invalid qmp json")
 
     def test_detach_block_cache_cancel_finishes_detached_cache_and_rejects_cancel(self):
         vm_plugin = _import_with_plugin_stub("kvmagent.plugins.vm_plugin")
@@ -510,7 +493,6 @@ class VolumeCacheCancelCase(unittest.TestCase):
                     "status": "detached",
                 }]), \
                 patch.object(vm_plugin.traceable_shell, "cancel_job_by_api", create=True) as cancel, \
-                patch.object(vm_plugin.traceable_shell, "get_shell", return_value="trace-shell"), \
                 patch.object(vm_plugin.traceable_shell, "TraceableShell", create=True,
                              side_effect=lambda api_id, deadline: _Obj(id=api_id, deadline=deadline)), \
                 patch.object(vm_plugin.virsh, "block_cache_detach", side_effect=_detach) as detach:
@@ -527,6 +509,7 @@ class VolumeCacheCancelCase(unittest.TestCase):
                 detach_future.result(timeout=3)
 
         self.assertEqual(2, detach.call_count)
+        self.assertEqual(daemon.shell_id, detach.call_args_list[0][1]["cmd_shell"].id)
         terminal_kwargs = detach.call_args_list[1][1]
         self.assertEqual("vm-1", terminal_kwargs["domain"])
         self.assertEqual("vdb", terminal_kwargs["path"])
@@ -548,10 +531,11 @@ class VolumeCacheCancelCase(unittest.TestCase):
         )
         daemon = vm_plugin.DetachBlockCacheTaskDaemon(_task_spec(), "vm-1", volume, "vdb")
 
-        with patch.object(vm_plugin.traceable_shell, "get_shell", return_value="trace-shell"), \
+        with patch.object(vm_plugin.traceable_shell, "TraceableShell", return_value="trace-shell") as shell, \
                 patch.object(vm_plugin.virsh, "block_cache_detach") as detach:
             daemon.detach()
 
+        shell.assert_called_once_with(daemon.shell_id, None)
         detach.assert_called_once_with(
             domain="vm-1",
             path="vdb",
@@ -566,15 +550,16 @@ class VolumeCacheCancelCase(unittest.TestCase):
 
         volume = _Obj(
             installPath="/primary/volume-1",
-            cache=_Obj(installPath=None, timeout=30, delete=False),
+            cache=_Obj(installPath="/cache/volume-1.qcow2", timeout=30, delete=False),
         )
         daemon = vm_plugin.DetachBlockCacheTaskDaemon(_task_spec(), "vm-1", volume, "vdb")
 
         def _detach(**kwargs):
             daemon._cancel()
 
-        with patch.object(vm_plugin.traceable_shell, "cancel_job_by_api", create=True), \
-                patch.object(vm_plugin.traceable_shell, "get_shell", return_value="trace-shell"), \
+        with patch.object(vm_plugin.qmp, "execute_qmp_command", return_value=None), \
+                patch.object(vm_plugin.traceable_shell, "cancel_job_by_api", create=True), \
+                patch.object(vm_plugin.traceable_shell, "TraceableShell", return_value="trace-shell"), \
                 patch.object(vm_plugin.virsh, "block_cache_detach", side_effect=_detach):
             with self.assertRaises(Exception) as exc:
                 daemon.detach()
@@ -586,7 +571,7 @@ class VolumeCacheCancelCase(unittest.TestCase):
 
         volume = _Obj(
             installPath="/primary/volume-1",
-            cache=_Obj(installPath=None, timeout=30, delete=False),
+            cache=_Obj(installPath="/cache/volume-1.qcow2", timeout=30, delete=False),
         )
         daemon = vm_plugin.DetachBlockCacheTaskDaemon(_task_spec(), "vm-1", volume, "vdb")
 
@@ -594,8 +579,9 @@ class VolumeCacheCancelCase(unittest.TestCase):
             daemon._cancel()
             raise Exception("virsh block-cache-detach return code: 130")
 
-        with patch.object(vm_plugin.traceable_shell, "cancel_job_by_api", create=True), \
-                patch.object(vm_plugin.traceable_shell, "get_shell", return_value="trace-shell"), \
+        with patch.object(vm_plugin.qmp, "execute_qmp_command", return_value=None), \
+                patch.object(vm_plugin.traceable_shell, "cancel_job_by_api", create=True), \
+                patch.object(vm_plugin.traceable_shell, "TraceableShell", return_value="trace-shell"), \
                 patch.object(vm_plugin.virsh, "block_cache_detach", side_effect=_detach):
             with self.assertRaises(Exception) as exc:
                 daemon.detach()

--- a/tests/unit/kvmagent/test_volume_cache_cancel.py
+++ b/tests/unit/kvmagent/test_volume_cache_cancel.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from concurrent.futures import ThreadPoolExecutor
 import importlib
 import os
 import platform
@@ -7,6 +8,7 @@ import shutil
 import signal
 import sys
 import tempfile
+import threading
 import types
 import unittest
 from unittest.mock import PropertyMock, patch
@@ -80,6 +82,8 @@ class _TaskDaemonStub(object):
     def __init__(self, task_spec, *args, **kwargs):
         self.api_id = getattr(getattr(task_spec, "threadContext", None), "api", None)
         self.stage = None
+        self.timeout = 0
+        self.deadline = None
         self.result = _TaskResultStub()
 
     def __enter__(self):
@@ -407,15 +411,133 @@ class VolumeCacheCancelCase(unittest.TestCase):
     def test_detach_block_cache_cancel_uses_traceable_shell_sigint(self):
         vm_plugin = _import_with_plugin_stub("kvmagent.plugins.vm_plugin")
 
+        cache_path = "/cache/volume-1.qcow2"
         volume = _Obj(
             installPath="/primary/volume-1",
-            cache=_Obj(timeout=30, delete=False),
+            cache=_Obj(installPath=cache_path, timeout=30, delete=False),
         )
         daemon = vm_plugin.DetachBlockCacheTaskDaemon(_task_spec(), "vm-1", volume, "vdb")
 
-        with patch.object(vm_plugin.traceable_shell, "cancel_job_by_api", create=True) as cancel:
+        with patch.object(vm_plugin.qmp, "execute_qmp_command", return_value=[
+                    {"file": "/cache/other.qcow2", "status": "detached"},
+                    {"file": cache_path, "status": "flushing"},
+                ]), \
+                patch.object(vm_plugin.traceable_shell, "cancel_job_by_api", create=True) as cancel, \
+                patch.object(vm_plugin.virsh, "block_cache_detach") as detach:
             daemon._cancel()
             cancel.assert_called_once_with("api-volume-cache-cancel", sig=signal.SIGINT)
+            detach.assert_not_called()
+
+    def test_detach_block_cache_cancel_rejects_after_cache_node_removed(self):
+        vm_plugin = _import_with_plugin_stub("kvmagent.plugins.vm_plugin")
+
+        volume = _Obj(
+            installPath="/primary/volume-1",
+            cache=_Obj(installPath="/cache/volume-1.qcow2", timeout=30, delete=False),
+        )
+        daemon = vm_plugin.DetachBlockCacheTaskDaemon(_task_spec(), "vm-1", volume, "vdb")
+
+        with patch.object(vm_plugin.qmp, "execute_qmp_command", return_value=[]), \
+                patch.object(vm_plugin.traceable_shell, "cancel_job_by_api", create=True) as cancel, \
+                patch.object(vm_plugin.virsh, "block_cache_detach") as detach:
+            with self.assertRaisesRegex(Exception, "already detached"):
+                daemon._cancel()
+
+        self.assertTrue(daemon.result.success)
+        self.assertEqual(100, daemon.progress)
+        cancel.assert_not_called()
+        detach.assert_not_called()
+
+    def test_detach_block_cache_cancel_falls_back_when_cache_query_fails(self):
+        vm_plugin = _import_with_plugin_stub("kvmagent.plugins.vm_plugin")
+
+        volume = _Obj(
+            installPath="/primary/volume-1",
+            cache=_Obj(installPath="/cache/volume-1.qcow2", timeout=30, delete=False),
+        )
+        daemon = vm_plugin.DetachBlockCacheTaskDaemon(_task_spec(), "vm-1", volume, "vdb")
+
+        with patch.object(vm_plugin.qmp, "execute_qmp_command", return_value=None), \
+                patch.object(vm_plugin.traceable_shell, "cancel_job_by_api", create=True) as cancel:
+            daemon._cancel()
+
+        cancel.assert_called_once_with("api-volume-cache-cancel", sig=signal.SIGINT)
+        self.assertFalse(daemon.result.success)
+
+    def test_detach_block_cache_cancel_logs_cache_query_exception(self):
+        vm_plugin = _import_with_plugin_stub("kvmagent.plugins.vm_plugin")
+
+        volume = _Obj(
+            installPath="/primary/volume-1",
+            cache=_Obj(installPath="/cache/volume-1.qcow2", timeout=30, delete=False),
+        )
+        daemon = vm_plugin.DetachBlockCacheTaskDaemon(_task_spec(), "vm-1", volume, "vdb")
+
+        with patch.object(vm_plugin.qmp, "execute_qmp_command", side_effect=ValueError("invalid qmp json")), \
+                patch.object(vm_plugin.logger, "warn") as warn, \
+                patch.object(vm_plugin.traceable_shell, "cancel_job_by_api", create=True):
+            daemon._cancel()
+
+        warn.assert_called_once_with(
+            "failed to query block cache for vm[uuid:vm-1]: invalid qmp json")
+
+    def test_detach_block_cache_cancel_finishes_detached_cache_and_rejects_cancel(self):
+        vm_plugin = _import_with_plugin_stub("kvmagent.plugins.vm_plugin")
+
+        cache_path = "/cache/volume-1.qcow2"
+        volume = _Obj(
+            installPath="/primary/volume-1",
+            cache=_Obj(installPath=cache_path, timeout=30, delete=False),
+        )
+        daemon = vm_plugin.DetachBlockCacheTaskDaemon(_task_spec(), "vm-1", volume, "vdb")
+        daemon.timeout = 300
+        daemon.deadline = 2147483647
+        first_detach_started = threading.Event()
+        finish_first_detach = threading.Event()
+        terminal_detach_started = threading.Event()
+        finish_terminal_detach = threading.Event()
+
+        def _detach(**kwargs):
+            if detach.call_count == 1:
+                first_detach_started.set()
+                self.assertTrue(finish_first_detach.wait(3))
+                raise Exception("original virsh process was terminated")
+            terminal_detach_started.set()
+            self.assertTrue(finish_terminal_detach.wait(3))
+
+        with patch.object(vm_plugin.qmp, "execute_qmp_command", return_value=[{
+                    "file": cache_path,
+                    "status": "detached",
+                }]), \
+                patch.object(vm_plugin.traceable_shell, "cancel_job_by_api", create=True) as cancel, \
+                patch.object(vm_plugin.traceable_shell, "get_shell", return_value="trace-shell"), \
+                patch.object(vm_plugin.traceable_shell, "TraceableShell", create=True,
+                             side_effect=lambda api_id, deadline: _Obj(id=api_id, deadline=deadline)), \
+                patch.object(vm_plugin.virsh, "block_cache_detach", side_effect=_detach) as detach:
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                detach_future = executor.submit(daemon.detach)
+                self.assertTrue(first_detach_started.wait(3))
+                cancel_future = executor.submit(daemon._cancel)
+                self.assertTrue(terminal_detach_started.wait(3))
+                finish_first_detach.set()
+                self.assertFalse(detach_future.done())
+                finish_terminal_detach.set()
+                with self.assertRaisesRegex(Exception, "already detached"):
+                    cancel_future.result(timeout=3)
+                detach_future.result(timeout=3)
+
+        self.assertEqual(2, detach.call_count)
+        terminal_kwargs = detach.call_args_list[1][1]
+        self.assertEqual("vm-1", terminal_kwargs["domain"])
+        self.assertEqual("vdb", terminal_kwargs["path"])
+        self.assertEqual(30, terminal_kwargs["timeout"])
+        self.assertFalse(terminal_kwargs["delete"])
+        self.assertIsNone(terminal_kwargs["cmd_shell"].id)
+        self.assertEqual(daemon.deadline, terminal_kwargs["cmd_shell"].deadline)
+        self.assertEqual(daemon.progress_file, terminal_kwargs["progress_output"])
+        self.assertTrue(daemon.result.success)
+        self.assertEqual(100, daemon.progress)
+        cancel.assert_not_called()
 
     def test_detach_block_cache_uses_traceable_shell_and_progress_file(self):
         vm_plugin = _import_with_plugin_stub("kvmagent.plugins.vm_plugin")
@@ -444,7 +566,7 @@ class VolumeCacheCancelCase(unittest.TestCase):
 
         volume = _Obj(
             installPath="/primary/volume-1",
-            cache=_Obj(timeout=30, delete=False),
+            cache=_Obj(installPath=None, timeout=30, delete=False),
         )
         daemon = vm_plugin.DetachBlockCacheTaskDaemon(_task_spec(), "vm-1", volume, "vdb")
 
@@ -464,7 +586,7 @@ class VolumeCacheCancelCase(unittest.TestCase):
 
         volume = _Obj(
             installPath="/primary/volume-1",
-            cache=_Obj(timeout=30, delete=False),
+            cache=_Obj(installPath=None, timeout=30, delete=False),
         )
         daemon = vm_plugin.DetachBlockCacheTaskDaemon(_task_spec(), "vm-1", volume, "vdb")
 


### PR DESCRIPTION
## Summary
Handle the live volume-cache detach boundary where QEMU has finished flushing and reports the cache as `detached`, but the cache node has not yet been removed. In this state cancellation is rejected and the original detach task is allowed to finish successfully.

## Changes
- Query the matching cache path when canceling `virsh block-cache-detach`.
- Serialize cancel and virsh exception recovery; if QEMU reports `status=detached`, issue one terminal `block-cache-detach` to remove the node.
- Preserve the existing SIGINT cancellation behavior for non-detached states.

## Testing
- [x] Focused reversible/detached cancel tests (`2 passed`)
- [x] `tests/unit/kvmagent/test_volume_cache_cancel.py` (`14 passed`)
- [x] Python 3.11 `py_compile`
- [x] `git diff --check`
- [ ] Real-QEMU verification of the exact detached-before-node-delete timing window
- [ ] CI pipeline

Resolves: ZSTAC-85911

sync from gitlab !7507