### PR TITLE
<fix>[lvm]: avoid global multipathd reload on wipe

### DIFF
--- a/kvmagent/kvmagent/plugins/storage_device.py
+++ b/kvmagent/kvmagent/plugins/storage_device.py
@@ -1187,8 +1187,7 @@ class StorageDevicePlugin(kvmagent.KvmAgent):
         return sum(filter(None, luns), [])
 
     def multipath_conf_cannot_change(self):
-        r, o, e = bash.bash_roe('''grep -rF "<disk type='block' device='lun'" /var/run/libvirt/qemu/* ''')
-        return r == 0
+        return lvm.is_running_vm_using_lun_passthrough()
 
     @kvmagent.replyerror
     @bash.in_bash

--- a/zstacklib/zstacklib/test/lvm/test_flush_mpath.py
+++ b/zstacklib/zstacklib/test/lvm/test_flush_mpath.py
@@ -1,0 +1,64 @@
+import unittest
+import mock
+
+from zstacklib.utils import bash
+from zstacklib.utils import lvm
+
+
+# ZSTAC-86075 / TIC-5912: adding a SharedBlock LUN must not run a host-wide
+# `systemctl reload multipathd` while a running VM passes a multipath LUN
+# through (device='lun'), because the global reload's device-mapper
+# suspend/resume window aborts in-flight IO on the in-use map -> guest
+# BLOCK_IO_ERROR. flush_mpath() re-creates only the wiped disk's own map in
+# that case, and keeps the original global reload otherwise.
+class TestFlushMpath(unittest.TestCase):
+
+    def _capture(self):
+        issued = []
+        bash.bash_roe = mock.Mock(side_effect=lambda cmd, *a, **k: issued.append(cmd))
+        return issued
+
+    def test_lun_passthrough_vm_running_uses_targeted_recreate(self):
+        issued = self._capture()
+        lvm.get_dm_wwid = mock.Mock(return_value="361449201002ef3fe11f8a16a00000011")
+        lvm.is_running_vm_using_lun_passthrough = mock.Mock(return_value=True)
+
+        lvm.flush_mpath("/dev/dm-38")
+
+        self.assertIn("multipath -f /dev/dm-38", issued)
+        self.assertIn("multipath 361449201002ef3fe11f8a16a00000011 && sleep 1", issued)
+        self.assertFalse(any("systemctl reload multipathd" in c for c in issued),
+                         "must not run host-wide multipathd reload when a LUN-passthrough VM is running")
+
+    def test_no_lun_passthrough_vm_keeps_global_reload(self):
+        issued = self._capture()
+        lvm.get_dm_wwid = mock.Mock(return_value="361449201002ef3fe11f8a16a00000011")
+        lvm.is_running_vm_using_lun_passthrough = mock.Mock(return_value=False)
+
+        lvm.flush_mpath("/dev/dm-38")
+
+        self.assertIn("multipath -f /dev/dm-38", issued)
+        self.assertTrue(any("systemctl reload multipathd.service && sleep 1" in c for c in issued))
+
+    def test_lun_passthrough_vm_but_unknown_wwid_falls_back_to_global_reload(self):
+        issued = self._capture()
+        lvm.get_dm_wwid = mock.Mock(return_value=None)
+        lvm.is_running_vm_using_lun_passthrough = mock.Mock(return_value=True)
+
+        lvm.flush_mpath("/dev/dm-38")
+
+        self.assertTrue(any("systemctl reload multipathd.service && sleep 1" in c for c in issued))
+
+    def test_is_running_vm_using_lun_passthrough_greps_live_xml(self):
+        bash.bash_r = mock.Mock(return_value=0)
+        self.assertTrue(lvm.is_running_vm_using_lun_passthrough())
+        called = bash.bash_r.call_args[0][0]
+        self.assertIn("device='lun'", called)
+        self.assertIn(lvm.LIVE_LIBVIRT_XML_DIR, called)
+
+        bash.bash_r = mock.Mock(return_value=1)
+        self.assertFalse(lvm.is_running_vm_using_lun_passthrough())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zstacklib/zstacklib/test/lvm/test_flush_mpath.py
+++ b/zstacklib/zstacklib/test/lvm/test_flush_mpath.py
@@ -15,7 +15,7 @@ class TestFlushMpath(unittest.TestCase):
 
     def _capture(self):
         issued = []
-        bash.bash_roe = mock.Mock(side_effect=lambda cmd, *a, **k: issued.append(cmd))
+        bash.bash_roe = mock.Mock(side_effect=lambda cmd, *a, **k: issued.append(cmd) or (0, '', ''))
         return issued
 
     def test_lun_passthrough_vm_running_uses_targeted_recreate(self):

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -1097,6 +1097,23 @@ def backup_super_block(disk_path):
 
 
 @bash.in_bash
+def is_running_vm_using_lun_passthrough():
+    return bash.bash_r('''grep -rlF "<disk type='block' device='lun'" %s/*''' % LIVE_LIBVIRT_XML_DIR) == 0
+
+
+@bash.in_bash
+def flush_mpath(disk):
+    wwid = get_dm_wwid(disk)
+    bash.bash_roe("multipath -f %s" % disk)
+    if is_running_vm_using_lun_passthrough() and wwid:
+        # re-create only this disk's map; a host-wide multipathd reload would
+        # suspend in-use maps and abort in-flight IO on LUN-passthrough guests
+        bash.bash_roe("multipath %s && sleep 1" % wwid)
+    else:
+        bash.bash_roe("systemctl reload multipathd.service && sleep 1")
+
+
+@bash.in_bash
 def wipe_fs(disks, expected_vg=None, with_lock=True):
     @bash.in_bash
     def clear_lvmlock(vg_name):
@@ -1135,7 +1152,7 @@ def wipe_fs(disks, expected_vg=None, with_lock=True):
             bash.bash_roe("dmsetup remove /dev/%s" % holder)
 
         if need_flush_mpath:
-            bash.bash_roe("multipath -f %s && systemctl reload multipathd.service && sleep 1" % disk)
+            flush_mpath(disk)
 
         if exists_vg is not None:
             bash.bash_r("grep -l %s /etc/drbd.d/* | xargs rm" % exists_vg)

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -1105,12 +1105,20 @@ def is_running_vm_using_lun_passthrough():
 def flush_mpath(disk):
     wwid = get_dm_wwid(disk)
     bash.bash_roe("multipath -f %s" % disk)
-    if is_running_vm_using_lun_passthrough() and wwid:
+    lun_passthrough_in_use = is_running_vm_using_lun_passthrough()
+    if lun_passthrough_in_use and wwid:
         # re-create only this disk's map; a host-wide multipathd reload would
         # suspend in-use maps and abort in-flight IO on LUN-passthrough guests
-        bash.bash_roe("multipath %s && sleep 1" % wwid)
+        logger.warn("re-create multipath map %s for %s without host-wide multipathd reload because a LUN-passthrough VM is running" % (wwid, disk))
+        r, o, e = bash.bash_roe("multipath %s && sleep 1" % wwid)
+        if r != 0:
+            logger.warn("failed to re-create multipath map %s for %s, return code: %s, stdout: %s, stderr: %s" % (wwid, disk, r, o, e))
     else:
-        bash.bash_roe("systemctl reload multipathd.service && sleep 1")
+        if lun_passthrough_in_use:
+            logger.warn("fall back to host-wide multipathd reload for %s because WWID is unknown while a LUN-passthrough VM is running" % disk)
+        r, o, e = bash.bash_roe("systemctl reload multipathd.service && sleep 1")
+        if r != 0:
+            logger.warn("failed to reload multipathd while flushing %s, return code: %s, stdout: %s, stderr: %s" % (disk, r, o, e))
 
 
 @bash.in_bash


### PR DESCRIPTION
wipe_fs() runs a host-wide `systemctl reload multipathd` when
initializing a new SharedBlock LUN. The reload reconfigures ALL
multipath maps; the device-mapper suspend/resume window aborts
in-flight IO on a map a running VM passes through (device='lun'),
surfacing as guest BLOCK_IO_ERROR.

flush_mpath() re-creates only the wiped disk's own map via
`multipath <wwid>` when a LUN-passthrough VM is running, and keeps
the original global reload otherwise. Same device='lun' guard as
storage_device.enable_multipath.

Resolves: ZSTAC-86075
Resolves: ZSV-12484

Change-Id: If106aaa248d651c94acec71feb215b80fc6784fc

sync from gitlab !7508