### PR TITLE
<fix>[installer]: allow MySQL access through HA VIP

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -285,6 +285,21 @@ is_ipv6_address() {
     esac
 }
 
+get_zsha2_db_vip() {
+    command -v zsha2 >/dev/null 2>&1 || return
+    command -v python3 >/dev/null 2>&1 || return
+
+    zsha2 show-config 2>/dev/null | python3 -c '
+import ipaddress
+import json
+import sys
+
+dbvip = str(json.load(sys.stdin).get("dbvip", "")).strip()
+if dbvip:
+    print(ipaddress.ip_address(dbvip))
+' 2>/dev/null
+}
+
 is_ipv6_prefix_length() {
     local prefix="$1"
     case "$prefix" in
@@ -3379,6 +3394,7 @@ cs_append_iptables(){
     echo_subtitle "Append iptables"
     trap 'traplogger $LINENO "$BASH_COMMAND" $?'  DEBUG
     if [ "$NEED_SET_MN_IP" == "y" ]; then
+        local ha_db_vip=`get_zsha2_db_vip`
         ports=(3306)
         for port in ${ports[@]}
         do
@@ -3391,6 +3407,9 @@ cs_append_iptables(){
 
             iptables-save | grep -- "-A INPUT -p tcp -m tcp --dport $port -j REJECT" || iptables -A INPUT -p tcp --dport $port -j REJECT >>$ZSTACK_INSTALL_LOG 2>&1
             iptables-save | grep -- "-A INPUT -d $MANAGEMENT_IP/32 -p tcp -m tcp --dport $port -j ACCEPT" || iptables -I INPUT -p tcp --dport $port -d "$MANAGEMENT_IP" -j ACCEPT >>$ZSTACK_INSTALL_LOG 2>&1
+            if [ -n "$ha_db_vip" ] && ! is_ipv6_address "$ha_db_vip"; then
+                iptables-save | grep -- "-A INPUT -d $ha_db_vip/32 -p tcp -m tcp --dport $port -j ACCEPT" || iptables -I INPUT -p tcp --dport $port -d "$ha_db_vip" -j ACCEPT >>$ZSTACK_INSTALL_LOG 2>&1
+            fi
             iptables-save | grep -- "-A INPUT -d 127.0.0.1/32 -p tcp -m tcp --dport $port -j ACCEPT" || iptables -I INPUT -p tcp --dport $port -d 127.0.0.1 -j ACCEPT >>$ZSTACK_INSTALL_LOG 2>&1
         done
         if is_ipv6_address "$MANAGEMENT_IP"; then

--- a/tests/unit/installation/test_install_mysql_firewall.py
+++ b/tests/unit/installation/test_install_mysql_firewall.py
@@ -1,0 +1,105 @@
+import json
+import shlex
+import subprocess
+from pathlib import Path
+
+
+INSTALL_SCRIPT = Path(__file__).resolve().parents[3] / "installation" / "install.sh"
+
+
+def _shell_function(name):
+    lines = INSTALL_SCRIPT.read_text(encoding="utf-8").splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith("%s()" % name))
+    end = next(i for i in range(start + 1, len(lines)) if lines[i] == "}")
+    return "\n".join(lines[start:end + 1])
+
+
+def _run_mysql_firewall(management_ip, saved_rules, zsha2_config=None):
+    if zsha2_config is None:
+        zsha2 = "zsha2() { return 1; }"
+    else:
+        config = shlex.quote(json.dumps(zsha2_config))
+        zsha2 = f"zsha2() {{ printf '%s\\n' {config}; }}"
+
+    script = """
+{is_ipv6_address}
+{get_zsha2_db_vip}
+{cs_append_iptables}
+
+traplogger() {{ :; }}
+echo_subtitle() {{ :; }}
+pass() {{ :; }}
+service() {{ :; }}
+{zsha2}
+iptables-save() {{ printf '%s\\n' "$SAVED_RULES"; }}
+ip6tables-save() {{ printf '%s\\n' "$SAVED_RULES"; }}
+iptables() {{ printf 'iptables %s\\n' "$*" >> "$CALLS"; }}
+ip6tables() {{ printf 'ip6tables %s\\n' "$*" >> "$CALLS"; }}
+
+NEED_SET_MN_IP=y
+MANAGEMENT_IP={management_ip}
+ZSTACK_INSTALL_LOG=/dev/null
+SAVED_RULES={saved_rules}
+CALLS=`mktemp`
+cs_append_iptables >/dev/null
+trap - DEBUG
+cat "$CALLS"
+rm -f "$CALLS"
+""".format(
+        is_ipv6_address=_shell_function("is_ipv6_address"),
+        get_zsha2_db_vip=_shell_function("get_zsha2_db_vip"),
+        cs_append_iptables=_shell_function("cs_append_iptables"),
+        zsha2=zsha2,
+        management_ip=shlex.quote(management_ip),
+        saved_rules=shlex.quote(saved_rules),
+    )
+    return subprocess.run(
+        ["bash"], input=script, text=True, capture_output=True, check=True
+    ).stdout.splitlines()
+
+
+def test_zstac_86770_ha_vip_is_allowed_before_mysql_reject():
+    calls = _run_mysql_firewall(
+        "172.26.110.89",
+        "-A INPUT -p tcp -m tcp --dport 3306 -j REJECT",
+        {
+            "nodeip": "172.26.110.89",
+            "peerip": "172.26.108.210",
+            "dbvip": "172.26.195.158",
+        },
+    )
+
+    assert (
+        "iptables -I INPUT -p tcp --dport 3306 -d 172.26.195.158 -j ACCEPT"
+        in calls
+    )
+    assert "iptables -A INPUT -p tcp --dport 3306 -j REJECT" not in calls
+
+
+def test_zstac_86770_existing_ha_vip_rule_is_not_duplicated():
+    calls = _run_mysql_firewall(
+        "172.26.110.89",
+        "\n".join(
+            [
+                "-A INPUT -p tcp -m tcp --dport 3306 -j REJECT",
+                "-A INPUT -d 172.26.110.89/32 -p tcp -m tcp --dport 3306 -j ACCEPT",
+                "-A INPUT -d 172.26.195.158/32 -p tcp -m tcp --dport 3306 -j ACCEPT",
+                "-A INPUT -d 127.0.0.1/32 -p tcp -m tcp --dport 3306 -j ACCEPT",
+            ]
+        ),
+        {"dbvip": "172.26.195.158"},
+    )
+
+    assert calls == []
+
+
+def test_zstac_86770_non_ha_install_keeps_existing_firewall_behavior():
+    calls = _run_mysql_firewall(
+        "172.26.110.89",
+        "-A INPUT -p tcp -m tcp --dport 3306 -j REJECT",
+    )
+
+    assert calls == [
+        "iptables -I INPUT -p tcp --dport 3306 -d 172.26.110.89 -j ACCEPT",
+        "iptables -I INPUT -p tcp --dport 3306 -d 127.0.0.1 -j ACCEPT",
+    ]


### PR DESCRIPTION
## Root Cause

The installer only allows MySQL traffic to MANAGEMENT_IP/32 and loopback before adding a generic port 3306 REJECT rule. In MN HA deployments, dbvip was omitted, so traffic to the HA VIP was rejected even after MySQL grants were restored.

## Solution

Read and validate dbvip from `zsha2 show-config`, then idempotently insert an IPv4 HA VIP ACCEPT rule before the generic REJECT. Single-node and IPv6 management behavior remain unchanged.

## Test

- `bash -n installation/install.sh`
- 3 installer firewall regression tests passed
- 70 management IPv4/IPv6 tests passed

Resolves: ZSTAC-86770

sync from gitlab !7513