### PR TITLE
<feature>[zbs]: ZSV-12664 support ZBS volume encryption conversion

### DIFF
--- a/kvmagent/kvmagent/plugins/ceph_storage_plugin.py
+++ b/kvmagent/kvmagent/plugins/ceph_storage_plugin.py
@@ -372,16 +372,10 @@ class CephStoragePlugin(kvmagent.KvmAgent):
                 target_format = "-O luks -o key-secret=luks_sec"
             else:
                 target_format = "-O raw"
-            shell.call(
-                "/usr/bin/qemu-img convert "
-                "--object secret,id=luks_sec,format=raw,file=%s "
-                "-m 16 -W %s %s %s" % (
-                    sec,
-                    src_arg,
-                    target_format,
-                    self._rbd_uri(target_path, conf, "rbd_cache=false:rbd_concurrent_management_ops=20"),
-                )
-            )
+            linux.convert_volume_encryption(
+                src_arg,
+                self._rbd_uri(target_path, conf, "rbd_cache=false:rbd_concurrent_management_ops=20"),
+                sec, shell.call, target_format_options=target_format)
 
         virtual_size = getattr(cmd, "virtualSize", None)
         if cmd.targetEncrypted and virtual_size:

--- a/kvmagent/kvmagent/plugins/zbs_storage_plugin.py
+++ b/kvmagent/kvmagent/plugins/zbs_storage_plugin.py
@@ -57,6 +57,7 @@ class ZbsStoragePlugin(kvmagent.KvmAgent):
     LUKS_CLONE_PATH = "/zbs/primarystorage/kvmhost/luksclone"
     LUKS_CREATE_EMPTY_PATH = "/zbs/primarystorage/kvmhost/lukscreateempty"
     LUKS_ENCRYPT_IN_PLACE_PATH = "/zbs/primarystorage/kvmhost/encryptinplace"
+    LUKS_CONVERT_PATH = "/zbs/primarystorage/kvmhost/luksconvert"
     LUKS_RESIZE_PATH = "/zbs/primarystorage/kvmhost/luksresize"
 
     def start(self):
@@ -65,6 +66,7 @@ class ZbsStoragePlugin(kvmagent.KvmAgent):
         http_server.register_async_uri(self.LUKS_CLONE_PATH, self.luks_clone)
         http_server.register_async_uri(self.LUKS_CREATE_EMPTY_PATH, self.luks_create_empty)
         http_server.register_async_uri(self.LUKS_ENCRYPT_IN_PLACE_PATH, self.luks_encrypt_in_place)
+        http_server.register_async_uri(self.LUKS_CONVERT_PATH, self.luks_convert)
         http_server.register_async_uri(self.LUKS_RESIZE_PATH, self.luks_resize)
 
     def _cbd_qemu_path(self, install_path):
@@ -259,6 +261,55 @@ class ZbsStoragePlugin(kvmagent.KvmAgent):
             logger.warn(linux.get_exception_stacktrace())
             rsp.success = False
             rsp.error = 'failed to clone ZBS LUKS volume from[%s] to[%s]: %s' % (
+                src_path or '<missing>', dst_path or '<missing>', str(e))
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    @bash.in_bash
+    def luks_convert(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = ZbsLuksRsp()
+        src_path = '<missing>'
+        dst_path = '<missing>'
+        try:
+            src_path = cmd_attr(cmd, 'installPath')
+            dst_path = cmd_attr(cmd, 'targetInstallPath')
+            if not src_path or not dst_path:
+                raise Exception('installPath and targetInstallPath are required')
+            encrypted_dek = cmd_attr(cmd, 'encryptedDek')
+            if not encrypted_dek:
+                raise Exception('encryptedDek is required')
+            virtual_size = int(cmd_attr(cmd, 'virtualSize') or 0)
+            if virtual_size <= 0:
+                raise Exception('virtualSize is required and must be greater than 0')
+            target_encrypted = cmd_attr(cmd, 'targetEncrypted')
+            if not isinstance(target_encrypted, bool):
+                raise Exception('targetEncrypted is required and must be a boolean')
+            source_is_luks = self._is_luks_volume(src_path)
+            if source_is_luks == bool(target_encrypted):
+                raise Exception('ZBS source format does not match requested encryption conversion')
+            secret_file_provider = lambda: volume_secret.luks_secret_channel(encrypted_dek)
+            if target_encrypted:
+                with secret_file_provider() as secret_file:
+                    self._initialize_luks_cbd_volume(dst_path, virtual_size, secret_file)
+                with secret_file_provider() as secret_file:
+                    linux.convert_volume_encryption(
+                        self._plain_image_arg(src_path),
+                        linux.shellquote(self._luks_image_opts_value(dst_path)),
+                        linux.shellquote(secret_file), bash.bash_errorout,
+                        target_is_precreated=True, use_target_image_opts=True)
+            else:
+                with secret_file_provider() as secret_file:
+                    linux.convert_volume_encryption(
+                        self._luks_image_opts(src_path),
+                        linux.shellquote(self._cbd_qemu_path(dst_path)),
+                        linux.shellquote(secret_file), bash.bash_errorout,
+                        target_format_options="-O raw", target_is_precreated=True)
+            rsp.actualSize = self._raw_cbd_actual_size(dst_path)
+        except Exception as e:
+            logger.warn(linux.get_exception_stacktrace())
+            rsp.success = False
+            rsp.error = 'failed to convert ZBS volume encryption from[%s] to[%s]: %s' % (
                 src_path or '<missing>', dst_path or '<missing>', str(e))
         return jsonobject.dumps(rsp)
 

--- a/kvmagent/kvmagent/test/test_ceph_storage_plugin_luks_convert.py
+++ b/kvmagent/kvmagent/test/test_ceph_storage_plugin_luks_convert.py
@@ -1,0 +1,175 @@
+import contextlib
+import json
+import os
+import sys
+import types
+import unittest
+
+
+def _install_import_stubs():
+    package_dir = os.path.dirname(os.path.dirname(__file__))
+
+    kvmagent_pkg = types.ModuleType("kvmagent")
+    kvmagent_pkg.__path__ = [package_dir]
+    kvmagent_mod = types.ModuleType("kvmagent.kvmagent")
+
+    class AgentCommand(object):
+        pass
+
+    class AgentResponse(object):
+        def __init__(self):
+            self.success = True
+            self.error = None
+
+    class KvmAgent(object):
+        pass
+
+    kvmagent_mod.AgentCommand = AgentCommand
+    kvmagent_mod.AgentResponse = AgentResponse
+    kvmagent_mod.KvmAgent = KvmAgent
+    kvmagent_mod.replyerror = lambda func: func
+    kvmagent_pkg.kvmagent = kvmagent_mod
+    sys.modules["kvmagent"] = kvmagent_pkg
+    sys.modules["kvmagent.kvmagent"] = kvmagent_mod
+
+    plugins_pkg = types.ModuleType("kvmagent.plugins")
+    plugins_pkg.__path__ = [os.path.join(package_dir, "plugins")]
+    sys.modules["kvmagent.plugins"] = plugins_pkg
+
+    imagestore_mod = types.ModuleType("kvmagent.plugins.imagestore")
+    imagestore_mod.ImageStoreClient = object
+    sys.modules["kvmagent.plugins.imagestore"] = imagestore_mod
+
+    volume_secret_mod = types.ModuleType("kvmagent.plugins.volume_secret")
+
+    @contextlib.contextmanager
+    def luks_secret_channel(encrypted_dek):
+        yield "/var/run/key-agent/secret"
+
+    volume_secret_mod.luks_secret_channel = luks_secret_channel
+    plugins_pkg.volume_secret = volume_secret_mod
+    sys.modules["kvmagent.plugins.volume_secret"] = volume_secret_mod
+
+    zstacklib_pkg = types.ModuleType("zstacklib")
+    utils_pkg = types.ModuleType("zstacklib.utils")
+    zstacklib_pkg.utils = utils_pkg
+    sys.modules["zstacklib"] = zstacklib_pkg
+    sys.modules["zstacklib.utils"] = utils_pkg
+
+    class AttrDict(dict):
+        def __getattr__(self, item):
+            try:
+                return self[item]
+            except KeyError:
+                raise AttributeError(item)
+
+    def to_attr(value):
+        if isinstance(value, dict):
+            return AttrDict((key, to_attr(item)) for key, item in value.items())
+        if isinstance(value, list):
+            return [to_attr(item) for item in value]
+        return value
+
+    http_mod = types.ModuleType("zstacklib.utils.http")
+    http_mod.REQUEST_BODY = "body"
+    utils_pkg.http = http_mod
+    sys.modules["zstacklib.utils.http"] = http_mod
+
+    jsonobject_mod = types.ModuleType("zstacklib.utils.jsonobject")
+    jsonobject_mod.loads = lambda value: to_attr(json.loads(value))
+    jsonobject_mod.dumps = lambda value: json.dumps(value.__dict__)
+    utils_pkg.jsonobject = jsonobject_mod
+    sys.modules["zstacklib.utils.jsonobject"] = jsonobject_mod
+
+    linux_mod = types.ModuleType("zstacklib.utils.linux")
+    linux_mod.rm_file_force = lambda path: None
+    utils_pkg.linux = linux_mod
+    sys.modules["zstacklib.utils.linux"] = linux_mod
+
+    class Logger(object):
+        def warn(self, message):
+            pass
+
+    log_mod = types.ModuleType("zstacklib.utils.log")
+    log_mod.get_logger = lambda name: Logger()
+    utils_pkg.log = log_mod
+    sys.modules["zstacklib.utils.log"] = log_mod
+
+    shell_mod = types.ModuleType("zstacklib.utils.shell")
+    shell_mod.call = lambda command: ""
+    utils_pkg.shell = shell_mod
+    sys.modules["zstacklib.utils.shell"] = shell_mod
+
+    qemu_img_mod = types.ModuleType("zstacklib.utils.qemu_img")
+    utils_pkg.qemu_img = qemu_img_mod
+    sys.modules["zstacklib.utils.qemu_img"] = qemu_img_mod
+
+
+_install_import_stubs()
+
+from kvmagent.plugins import ceph_storage_plugin
+from zstacklib.utils import jsonobject
+
+
+class TestCephStoragePluginLuksConvert(unittest.TestCase):
+    def _call_luks_convert(self, plugin, target_encrypted):
+        return jsonobject.loads(plugin.luks_convert({
+            "body": json.dumps({
+                "psUuid": "ps-uuid",
+                "installPath": "ceph://pool/source",
+                "targetInstallPath": "ceph://pool/target",
+                "targetEncrypted": target_encrypted,
+                "encryptedDek": "sealed-dek"
+            })
+        }))
+
+    def _assert_delegates_to_linux_helper(self, source_is_luks, target_encrypted,
+                                          expected_source, expected_target_format):
+        plugin = ceph_storage_plugin.CephStoragePlugin()
+        plugin._validate_luks_cmd = lambda cmd, rsp, encrypted_dek=False: \
+            "/var/lib/zstack/ceph/ps-uuid/ceph.conf"
+        plugin._is_luks_rbd = lambda install_path, conf_path: source_is_luks
+        calls = []
+        helper_name = "convert_volume_encryption"
+        original_helper = getattr(ceph_storage_plugin.linux, helper_name, None)
+        try:
+            setattr(ceph_storage_plugin.linux, helper_name,
+                    lambda *args, **kwargs: calls.append((args, kwargs)))
+
+            rsp = self._call_luks_convert(plugin, target_encrypted)
+
+            self.assertTrue(rsp.success)
+            self.assertEqual("ceph://pool/target", rsp.installPath)
+            self.assertEqual(1, len(calls))
+            args, kwargs = calls[0]
+            self.assertEqual(expected_source, args[0])
+            self.assertEqual(
+                "rbd:pool/target:conf=/var/lib/zstack/ceph/ps-uuid/ceph.conf:"
+                "rbd_cache=false:rbd_concurrent_management_ops=20", args[1])
+            self.assertEqual("/var/run/key-agent/secret", args[2])
+            self.assertIs(ceph_storage_plugin.shell.call, args[3])
+            self.assertEqual(expected_target_format, kwargs["target_format_options"])
+            self.assertNotIn("target_is_precreated", kwargs)
+            self.assertNotIn("use_target_image_opts", kwargs)
+        finally:
+            if original_helper is None:
+                delattr(ceph_storage_plugin.linux, helper_name)
+            else:
+                setattr(ceph_storage_plugin.linux, helper_name, original_helper)
+
+    def test_plain_to_encrypted_delegates_to_linux_helper(self):
+        self._assert_delegates_to_linux_helper(
+            False, True,
+            "-f raw rbd:pool/source:conf=/var/lib/zstack/ceph/ps-uuid/ceph.conf",
+            "-O luks -o key-secret=luks_sec")
+
+    def test_encrypted_to_plain_delegates_to_linux_helper(self):
+        self._assert_delegates_to_linux_helper(
+            True, False,
+            "--image-opts driver=luks,key-secret=luks_sec,file.driver=rbd,"
+            "file.pool=pool,file.image=source,file.conf=/var/lib/zstack/ceph/ps-uuid/ceph.conf",
+            "-O raw")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kvmagent/kvmagent/test/test_zbs_storage_plugin.py
+++ b/kvmagent/kvmagent/test/test_zbs_storage_plugin.py
@@ -89,6 +89,23 @@ def _install_import_stubs():
     linux_mod.catch_bad_alloc_exception = lambda ret, err: False
     linux_mod.read_luks_secret_material_file = lambda path: b"secret-material"
 
+    def convert_volume_encryption(source_image_arg, target_arg, secret_file_arg, command_runner,
+                                  target_format_options=None, target_is_precreated=False,
+                                  use_target_image_opts=False):
+        options = []
+        if target_is_precreated:
+            options.append("-n")
+        if use_target_image_opts:
+            options.append("--target-image-opts")
+        options.append("--object secret,id=luks_sec,format=raw,file=%s" % secret_file_arg)
+        options.extend(["-m 16 -W", source_image_arg])
+        if target_format_options:
+            options.append(target_format_options)
+        options.append(target_arg)
+        return command_runner("/usr/bin/qemu-img convert %s" % " ".join(options))
+
+    linux_mod.convert_volume_encryption = convert_volume_encryption
+
     @contextlib.contextmanager
     def temporary_luks_secret_file(secret_material):
         yield "/tmp/luks-secret-persistent"
@@ -119,6 +136,36 @@ from zstacklib.utils import jsonobject
 
 
 class TestZbsStoragePlugin(unittest.TestCase):
+    def _call_luks_convert(self, plugin, target_encrypted):
+        return jsonobject.loads(plugin.luks_convert({
+            "body": json.dumps({
+                "psUuid": "ps-uuid",
+                "installPath": "cbd:physical/logical/source",
+                "targetInstallPath": "cbd:physical/logical/target",
+                "targetEncrypted": target_encrypted,
+                "virtualSize": 13631488,
+                "encryptedDek": "sealed-dek"
+            })
+        }))
+
+    def test_start_registers_luks_convert_path(self):
+        plugin = zbs_storage_plugin.ZbsStoragePlugin()
+        paths = []
+
+        class HttpServer(object):
+            def register_async_uri(self, path, handler):
+                paths.append((path, handler.__name__))
+
+        original_get_http_server = zbs_storage_plugin.kvmagent.get_http_server
+        try:
+            zbs_storage_plugin.kvmagent.get_http_server = lambda: HttpServer()
+
+            plugin.start()
+
+            self.assertEqual(1, paths.count((plugin.LUKS_CONVERT_PATH, "luks_convert")))
+        finally:
+            zbs_storage_plugin.kvmagent.get_http_server = original_get_http_server
+
     def test_start_registers_luks_resize_path(self):
         plugin = zbs_storage_plugin.ZbsStoragePlugin()
         paths = []
@@ -150,6 +197,240 @@ class TestZbsStoragePlugin(unittest.TestCase):
         path = plugin._cbd_qemu_path("physical/logical/volume@1")
 
         self.assertEqual("cbd:physical/logical/volume@1_zbs_:/etc/zbs/client.conf", path)
+
+    def test_luks_convert_plain_to_encrypted_initializes_fixed_offset_target(self):
+        plugin = zbs_storage_plugin.ZbsStoragePlugin()
+        commands = []
+        original_errorout = zbs_storage_plugin.bash.bash_errorout
+        try:
+            zbs_storage_plugin.bash.bash_errorout = lambda cmd: commands.append(cmd) or ""
+            plugin._is_luks_volume = lambda install_path, encrypted_dek=None: False
+            plugin._new_luks_temp_path = lambda: "/tmp/zbs-luks-convert.img"
+            plugin._raw_cbd_actual_size = lambda install_path: 0
+
+            rsp = self._call_luks_convert(plugin, True)
+
+            self.assertTrue(rsp.success)
+            self.assertIn("/usr/bin/truncate -s 22020096 /tmp/zbs-luks-convert.img", commands[0])
+            self.assertIn("--align-payload=16384", commands[1])
+            self.assertIn("convert -n --target-image-opts", commands[-1])
+            self.assertIn("driver=luks,key-secret=luks_sec", commands[-1])
+        finally:
+            zbs_storage_plugin.bash.bash_errorout = original_errorout
+
+    def test_luks_convert_encrypted_to_plain_uses_luks_source_image_opts(self):
+        plugin = zbs_storage_plugin.ZbsStoragePlugin()
+        commands = []
+        original_errorout = zbs_storage_plugin.bash.bash_errorout
+        try:
+            zbs_storage_plugin.bash.bash_errorout = lambda cmd: commands.append(cmd) or ""
+            plugin._is_luks_volume = lambda install_path, encrypted_dek=None: True
+            plugin._raw_cbd_actual_size = lambda install_path: 0
+
+            rsp = self._call_luks_convert(plugin, False)
+
+            self.assertTrue(rsp.success)
+            self.assertEqual(1, len(commands))
+            self.assertIn("convert -n", commands[0])
+            self.assertIn("--image-opts driver=luks,key-secret=luks_sec", commands[0])
+            self.assertIn("-O raw", commands[0])
+            self.assertNotIn("truncate", commands[0])
+            self.assertNotIn("cryptsetup", commands[0])
+        finally:
+            zbs_storage_plugin.bash.bash_errorout = original_errorout
+
+    def test_luks_convert_plain_to_encrypted_delegates_copy_to_linux_helper(self):
+        plugin = zbs_storage_plugin.ZbsStoragePlugin()
+        calls = []
+        helper_name = "convert_volume_encryption"
+        original_helper = getattr(zbs_storage_plugin.linux, helper_name, None)
+        try:
+            setattr(zbs_storage_plugin.linux, helper_name,
+                    lambda *args, **kwargs: calls.append((args, kwargs)))
+            plugin._is_luks_volume = lambda install_path, encrypted_dek=None: False
+            plugin._initialize_luks_cbd_volume = lambda install_path, size, secret_file: None
+            plugin._raw_cbd_actual_size = lambda install_path: 0
+
+            rsp = self._call_luks_convert(plugin, True)
+
+            self.assertTrue(rsp.success)
+            self.assertEqual(1, len(calls))
+            args, kwargs = calls[0]
+            self.assertIn("-f raw cbd:physical/logical/source_zbs_:/etc/zbs/client.conf", args[0])
+            self.assertIn("driver=luks,key-secret=luks_sec,file.driver=cbd", args[1])
+            self.assertEqual("/tmp/luks-secret", args[2])
+            self.assertIs(zbs_storage_plugin.bash.bash_errorout, args[3])
+            self.assertTrue(kwargs["target_is_precreated"])
+            self.assertTrue(kwargs["use_target_image_opts"])
+            self.assertNotIn("target_format_options", kwargs)
+        finally:
+            if original_helper is None:
+                delattr(zbs_storage_plugin.linux, helper_name)
+            else:
+                setattr(zbs_storage_plugin.linux, helper_name, original_helper)
+
+    def test_luks_convert_encrypted_to_plain_delegates_copy_to_linux_helper(self):
+        plugin = zbs_storage_plugin.ZbsStoragePlugin()
+        calls = []
+        helper_name = "convert_volume_encryption"
+        original_helper = getattr(zbs_storage_plugin.linux, helper_name, None)
+        try:
+            setattr(zbs_storage_plugin.linux, helper_name,
+                    lambda *args, **kwargs: calls.append((args, kwargs)))
+            plugin._is_luks_volume = lambda install_path, encrypted_dek=None: True
+            plugin._raw_cbd_actual_size = lambda install_path: 0
+
+            rsp = self._call_luks_convert(plugin, False)
+
+            self.assertTrue(rsp.success)
+            self.assertEqual(1, len(calls))
+            args, kwargs = calls[0]
+            self.assertIn("--image-opts driver=luks,key-secret=luks_sec", args[0])
+            self.assertEqual("cbd:physical/logical/target_zbs_:/etc/zbs/client.conf", args[1])
+            self.assertEqual("/tmp/luks-secret", args[2])
+            self.assertIs(zbs_storage_plugin.bash.bash_errorout, args[3])
+            self.assertEqual("-O raw", kwargs["target_format_options"])
+            self.assertTrue(kwargs["target_is_precreated"])
+            self.assertNotIn("use_target_image_opts", kwargs)
+        finally:
+            if original_helper is None:
+                delattr(zbs_storage_plugin.linux, helper_name)
+            else:
+                setattr(zbs_storage_plugin.linux, helper_name, original_helper)
+
+    def test_luks_convert_requires_source_target_dek_and_virtual_size(self):
+        plugin = zbs_storage_plugin.ZbsStoragePlugin()
+        commands = []
+        original_errorout = zbs_storage_plugin.bash.bash_errorout
+        try:
+            zbs_storage_plugin.bash.bash_errorout = lambda cmd: commands.append(cmd) or ""
+            valid = {
+                "psUuid": "ps-uuid",
+                "installPath": "cbd:physical/logical/source",
+                "targetInstallPath": "cbd:physical/logical/target",
+                "targetEncrypted": True,
+                "virtualSize": 13631488,
+                "encryptedDek": "sealed-dek"
+            }
+            cases = []
+            for field in ["installPath", "targetInstallPath", "encryptedDek"]:
+                body = dict(valid)
+                del body[field]
+                cases.append(body)
+            body = dict(valid)
+            body["virtualSize"] = 0
+            cases.append(body)
+
+            for body in cases:
+                rsp = jsonobject.loads(plugin.luks_convert({"body": json.dumps(body)}))
+
+                self.assertFalse(rsp.success)
+
+            self.assertFalse(any("qemu-img convert" in cmd for cmd in commands))
+        finally:
+            zbs_storage_plugin.bash.bash_errorout = original_errorout
+
+    def test_luks_convert_requires_boolean_target_encrypted_before_probing_source(self):
+        plugin = zbs_storage_plugin.ZbsStoragePlugin()
+        probe_calls = []
+        original_helper = zbs_storage_plugin.linux.convert_volume_encryption
+        zbs_storage_plugin.linux.convert_volume_encryption = lambda *args, **kwargs: None
+        plugin._initialize_luks_cbd_volume = lambda install_path, size, secret_file: None
+        plugin._raw_cbd_actual_size = lambda install_path: 0
+        valid = {
+            "psUuid": "ps-uuid",
+            "installPath": "cbd:physical/logical/source",
+            "targetInstallPath": "cbd:physical/logical/target",
+            "virtualSize": 13631488,
+            "encryptedDek": "sealed-dek"
+        }
+        cases = [(dict(valid), True), (dict(valid, targetEncrypted="false"), False)]
+        try:
+            for body, source_is_luks in cases:
+                plugin._is_luks_volume = lambda install_path, encrypted_dek=None, value=source_is_luks: \
+                    probe_calls.append(install_path) or value
+                rsp = jsonobject.loads(plugin.luks_convert({"body": json.dumps(body)}))
+
+                self.assertFalse(rsp.success)
+                self.assertIn("targetEncrypted", rsp.error)
+            self.assertEqual([], probe_calls)
+        finally:
+            zbs_storage_plugin.linux.convert_volume_encryption = original_helper
+
+    def test_luks_convert_rejects_source_format_mismatch_before_writing(self):
+        plugin = zbs_storage_plugin.ZbsStoragePlugin()
+        commands = []
+        original_errorout = zbs_storage_plugin.bash.bash_errorout
+        try:
+            zbs_storage_plugin.bash.bash_errorout = lambda cmd: commands.append(cmd) or ""
+            for source_is_luks, target_encrypted in [(False, False), (True, True)]:
+                plugin._is_luks_volume = lambda install_path, encrypted_dek=None, value=source_is_luks: value
+
+                rsp = self._call_luks_convert(plugin, target_encrypted)
+
+                self.assertFalse(rsp.success)
+                self.assertIn("source format does not match", rsp.error)
+
+            self.assertEqual([], commands)
+        finally:
+            zbs_storage_plugin.bash.bash_errorout = original_errorout
+
+    def test_luks_convert_failure_returns_error_without_deleting_cbd_paths(self):
+        plugin = zbs_storage_plugin.ZbsStoragePlugin()
+        commands = []
+        original_errorout = zbs_storage_plugin.bash.bash_errorout
+        try:
+            def fail_convert(cmd):
+                commands.append(cmd)
+                raise Exception("qemu-img conversion failed")
+
+            zbs_storage_plugin.bash.bash_errorout = fail_convert
+            plugin._is_luks_volume = lambda install_path, encrypted_dek=None: True
+            source = "cbd:physical/logical/source"
+            target = "cbd:physical/logical/target"
+
+            rsp = jsonobject.loads(plugin.luks_convert({
+                "body": json.dumps({
+                    "psUuid": "ps-uuid",
+                    "installPath": source,
+                    "targetInstallPath": target,
+                    "targetEncrypted": False,
+                    "virtualSize": 13631488,
+                    "encryptedDek": "sealed-dek"
+                })
+            }))
+
+            self.assertFalse(rsp.success)
+            self.assertIn(source, rsp.error)
+            self.assertIn(target, rsp.error)
+            self.assertFalse(any("delete" in cmd.lower() for cmd in commands))
+        finally:
+            zbs_storage_plugin.bash.bash_errorout = original_errorout
+
+    def test_luks_convert_reports_target_actual_size(self):
+        target = "cbd:physical/logical/target"
+        for target_encrypted in (True, False):
+            plugin = zbs_storage_plugin.ZbsStoragePlugin()
+            calls = []
+            plugin._is_luks_volume = \
+                lambda install_path, encrypted_dek=None, value=target_encrypted: not value
+            plugin._initialize_luks_cbd_volume = lambda install_path, size, secret_file: None
+            original_helper = zbs_storage_plugin.linux.convert_volume_encryption
+            zbs_storage_plugin.linux.convert_volume_encryption = (
+                lambda *args, **kwargs: calls.append(("convert", target_encrypted)))
+            plugin._raw_cbd_actual_size = lambda install_path: calls.append(
+                ("actual-size", install_path)) or 4096
+            try:
+                rsp = self._call_luks_convert(plugin, target_encrypted)
+
+                self.assertTrue(rsp.success)
+                self.assertEqual(4096, rsp.actualSize)
+                self.assertEqual([
+                    ("convert", target_encrypted),
+                    ("actual-size", target)
+                ], calls)
+            finally:
+                zbs_storage_plugin.linux.convert_volume_encryption = original_helper
 
     def test_luks_clone_preserves_luks_source_bits(self):
         plugin = zbs_storage_plugin.ZbsStoragePlugin()

--- a/zstacklib/zstacklib/test/test_convert_volume_encryption.py
+++ b/zstacklib/zstacklib/test/test_convert_volume_encryption.py
@@ -1,0 +1,167 @@
+import os
+import shlex
+import shutil
+import tempfile
+import unittest
+
+from zstacklib.utils import linux
+
+
+class TestConvertVolumeEncryption(unittest.TestCase):
+    def setUp(self):
+        self.commands = []
+
+    def convert(self, *args, **kwargs):
+        converter = getattr(linux, "convert_volume_encryption", None)
+        self.assertTrue(callable(converter))
+        converter(*args, **kwargs)
+
+    def test_writes_into_precreated_luks_target_image_opts(self):
+        self.convert(
+            "-f raw cbd:source",
+            "'driver=luks,file.driver=cbd,file.filename=cbd:target'",
+            "'/tmp/luks-secret'", self.commands.append,
+            target_is_precreated=True, use_target_image_opts=True)
+
+        self.assertEqual([
+            "/usr/bin/qemu-img convert -n --target-image-opts "
+            "--object secret,id=luks_sec,format=raw,file='/tmp/luks-secret' "
+            "-m 16 -W -f raw cbd:source "
+            "'driver=luks,file.driver=cbd,file.filename=cbd:target'"
+        ], self.commands)
+
+    def test_writes_into_precreated_raw_target_path(self):
+        self.convert(
+            "--image-opts driver=luks,file.driver=cbd,file.filename=cbd:source",
+            "'cbd:target'", "'/tmp/luks-secret'", self.commands.append,
+            target_format_options="-O raw", target_is_precreated=True)
+
+        self.assertEqual([
+            "/usr/bin/qemu-img convert -n "
+            "--object secret,id=luks_sec,format=raw,file='/tmp/luks-secret' "
+            "-m 16 -W --image-opts driver=luks,file.driver=cbd,file.filename=cbd:source "
+            "-O raw 'cbd:target'"
+        ], self.commands)
+
+    def test_writes_luks_rbd_target(self):
+        self.convert(
+            "-f raw rbd:pool/source:conf=/var/lib/zstack/ceph/ps/ceph.conf",
+            "rbd:pool/target:conf=/var/lib/zstack/ceph/ps/ceph.conf:"
+            "rbd_cache=false:rbd_concurrent_management_ops=20",
+            "/var/run/key-agent/secret", self.commands.append,
+            target_format_options="-O luks -o key-secret=luks_sec")
+
+        self.assertEqual([
+            "/usr/bin/qemu-img convert "
+            "--object secret,id=luks_sec,format=raw,file=/var/run/key-agent/secret "
+            "-m 16 -W -f raw rbd:pool/source:conf=/var/lib/zstack/ceph/ps/ceph.conf "
+            "-O luks -o key-secret=luks_sec "
+            "rbd:pool/target:conf=/var/lib/zstack/ceph/ps/ceph.conf:"
+            "rbd_cache=false:rbd_concurrent_management_ops=20"
+        ], self.commands)
+
+    def test_writes_raw_rbd_target(self):
+        self.convert(
+            "--image-opts driver=luks,key-secret=luks_sec,file.driver=rbd,"
+            "file.pool=pool,file.image=source,file.conf=/var/lib/zstack/ceph/ps/ceph.conf",
+            "rbd:pool/target:conf=/var/lib/zstack/ceph/ps/ceph.conf:"
+            "rbd_cache=false:rbd_concurrent_management_ops=20",
+            "/var/run/key-agent/secret", self.commands.append,
+            target_format_options="-O raw")
+
+        self.assertEqual([
+            "/usr/bin/qemu-img convert "
+            "--object secret,id=luks_sec,format=raw,file=/var/run/key-agent/secret "
+            "-m 16 -W "
+            "--image-opts driver=luks,key-secret=luks_sec,file.driver=rbd,"
+            "file.pool=pool,file.image=source,file.conf=/var/lib/zstack/ceph/ps/ceph.conf "
+            "-O raw rbd:pool/target:conf=/var/lib/zstack/ceph/ps/ceph.conf:"
+            "rbd_cache=false:rbd_concurrent_management_ops=20"
+        ], self.commands)
+
+
+class TestConvertQcow2VolumeEncryption(unittest.TestCase):
+    def setUp(self):
+        self.workdir = tempfile.mkdtemp()
+        self.src = os.path.join(self.workdir, "source.qcow2")
+        self.dst = os.path.join(self.workdir, "target.qcow2")
+        with open(self.src, "wb") as fd:
+            fd.write("source")
+
+        self.commands = []
+        self.convert_targets = []
+        self.original_check_run = linux.shell.check_run
+        self.original_chain_has_luks = linux._qcow2_chain_has_luks_encrypted_image
+        self.original_is_block_device = linux._is_block_device
+        self.original_qemu_img_subcmd = linux.qemu_img.subcmd
+        self.original_chmod = os.chmod
+        linux.shell.check_run = self.run_command
+        linux._qcow2_chain_has_luks_encrypted_image = lambda _: False
+        linux.qemu_img.subcmd = lambda operation: "/usr/bin/qemu-img %s" % operation
+
+    def tearDown(self):
+        linux.shell.check_run = self.original_check_run
+        linux._qcow2_chain_has_luks_encrypted_image = self.original_chain_has_luks
+        linux._is_block_device = self.original_is_block_device
+        linux.qemu_img.subcmd = self.original_qemu_img_subcmd
+        os.chmod = self.original_chmod
+        shutil.rmtree(self.workdir)
+
+    def run_command(self, command):
+        self.commands.append(command)
+        args = shlex.split(command)
+        if "convert" in args:
+            target = args[-1]
+            self.convert_targets.append(target)
+            with open(target, "wb") as fd:
+                fd.write("converted")
+        elif args[0] == "mv":
+            os.rename(args[-2], args[-1])
+
+    def test_writes_file_target_directly_without_rename(self):
+        actual_size = linux.convert_qcow2_volume_encryption(self.src, self.dst, False)
+
+        self.assertEqual([self.dst], self.convert_targets)
+        self.assertFalse(any(shlex.split(command)[0] == "mv" for command in self.commands))
+        self.assertEqual(len("converted"), actual_size)
+
+    def test_removes_direct_target_when_finalization_fails(self):
+        def fail_chmod(*_):
+            raise Exception("chmod failed")
+
+        os.chmod = fail_chmod
+
+        with self.assertRaises(Exception):
+            linux.convert_qcow2_volume_encryption(self.src, self.dst, False)
+
+        self.assertEqual([self.dst], self.convert_targets)
+        self.assertFalse(os.path.exists(self.dst))
+        with open(self.src, "rb") as fd:
+            self.assertEqual("source", fd.read())
+
+    def test_keeps_existing_file_when_validation_fails(self):
+        with open(self.dst, "wb") as fd:
+            fd.write("existing")
+
+        with self.assertRaises(Exception):
+            linux.convert_qcow2_volume_encryption(
+                self.src, self.dst, False,
+                target_backing_file=os.path.join(self.workdir, "missing-backing.qcow2"))
+
+        self.assertEqual([], self.convert_targets)
+        with open(self.dst, "rb") as fd:
+            self.assertEqual("existing", fd.read())
+
+    def test_leaves_failed_block_target_for_caller_cleanup(self):
+        linux._is_block_device = lambda _: True
+
+        def fail_conversion(command):
+            self.run_command(command)
+            raise Exception("convert failed")
+
+        linux.shell.check_run = fail_conversion
+
+        with self.assertRaises(Exception):
+            linux.convert_qcow2_volume_encryption(self.src, self.dst, False)
+
+        self.assertTrue(os.path.exists(self.dst))

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -1888,6 +1888,21 @@ def qcow2_rebase_no_check_with_secret(backing_file, target, secret_material_file
     finally:
         rm_file_force(secret_material_file)
 
+def convert_volume_encryption(source_image_arg, target_arg, secret_file_arg, command_runner,
+                              target_format_options=None, target_is_precreated=False,
+                              use_target_image_opts=False):
+    options = []
+    if target_is_precreated:
+        options.append("-n")
+    if use_target_image_opts:
+        options.append("--target-image-opts")
+    options.append("--object secret,id=luks_sec,format=raw,file=%s" % secret_file_arg)
+    options.extend(["-m 16 -W", source_image_arg])
+    if target_format_options:
+        options.append(target_format_options)
+    options.append(target_arg)
+    command_runner("/usr/bin/qemu-img convert %s" % " ".join(options))
+
 def convert_qcow2_volume_encryption(src, dst, target_encrypted, secret_file_provider=None,
                                     target_backing_file=None):
     if not os.path.exists(src):
@@ -1902,7 +1917,9 @@ def convert_qcow2_volume_encryption(src, dst, target_encrypted, secret_file_prov
         os.makedirs(dst_dir)
 
     dst_is_block = _is_block_device(dst)
-    target_path = dst if dst_is_block else ("%s.creating.%s" % (dst, uuid.uuid4().hex))
+    if not dst_is_block and os.path.exists(dst):
+        raise Exception("target image %s already exists" % dst)
+    completed = False
     backing_arg = target_backing_file
     backing_fmt = None
     backing_needs_reset = False
@@ -1940,10 +1957,10 @@ def convert_qcow2_volume_encryption(src, dst, target_encrypted, secret_file_prov
                 with secret_file_provider() as secret_file:
                     secret_opt = "--object secret,id=luks_sec,format=raw,file=%s" % shellquote(secret_file)
                     shell.check_run("%s %s %s -O qcow2 %s %s %s" % (
-                        qemu_img.subcmd('convert'), secret_opt, src_arg, out_opt, backing_opt, shellquote(target_path)))
+                        qemu_img.subcmd('convert'), secret_opt, src_arg, out_opt, backing_opt, shellquote(dst)))
             else:
                 shell.check_run("%s %s -O qcow2 %s %s %s" % (
-                    qemu_img.subcmd('convert'), src_arg, out_opt, backing_opt, shellquote(target_path)))
+                    qemu_img.subcmd('convert'), src_arg, out_opt, backing_opt, shellquote(dst)))
 
         with src_arg_context() as src_arg:
             if backing_needs_reset:
@@ -1956,24 +1973,25 @@ def convert_qcow2_volume_encryption(src, dst, target_encrypted, secret_file_prov
             if target_encrypted:
                 with secret_file_provider() as reset_secret_file:
                     reset_secret_opt = "--object secret,id=luks_sec,format=raw,file=%s" % shellquote(reset_secret_file)
-                    with _qcow2_image_opts_with_secret_context(target_path, include_backing=False) as target_arg:
+                    with _qcow2_image_opts_with_secret_context(dst, include_backing=False) as target_arg:
                         shell.check_run("%s %s -F %s -u -b %s %s" % (
                             qemu_img.subcmd('rebase'), reset_secret_opt, backing_fmt,
                             shellquote(target_backing_file), target_arg))
             else:
                 reset_secret_opt = ""
-                target_arg = shellquote(target_path)
+                target_arg = shellquote(dst)
                 shell.check_run("%s %s -F %s -u -b %s %s" % (
                     qemu_img.subcmd('rebase'), reset_secret_opt, backing_fmt,
                     shellquote(target_backing_file), target_arg))
 
         if not dst_is_block:
-            shell.check_run("mv -f %s %s" % (shellquote(target_path), shellquote(dst)))
             os.chmod(dst, 0o660)
-        return os.path.getsize(dst)
+        actual_size = os.path.getsize(dst)
+        completed = True
+        return actual_size
     finally:
-        if not dst_is_block and os.path.exists(target_path):
-            rm_file_force(target_path)
+        if not completed and not dst_is_block and os.path.exists(dst):
+            rm_file_force(dst)
 
 def qcow2_create_with_backing_file(backing_file, dst, size=""):
     fmt = get_img_fmt(backing_file)


### PR DESCRIPTION
## Summary
为 ZBS/CBD 提供 KVM 侧 LUKS 云盘加密转换接口，支持明文与加密格式双向转换。

## Changes
- 新增 /zbs/primarystorage/kvmhost/luksconvert 接口。
- 按目标加密状态创建、转换并返回目标实际容量。
- 完整校验 source、target、direction、virtualSize、DEK 与 actualSize 请求契约。

## Testing
- [x] Python2 test_zbs_storage_plugin.py：26/26 通过
- [x] Python2 test_vm_plugin_luks_cbd_resize.py：1/1 通过
- [ ] CI pipeline

Resolves: ZSV-12664

sync from gitlab !7517