### PR TITLE
<fix>[kvmagent]: preserve UEFI NVRAM across VM stop

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -2933,7 +2933,20 @@ class Vm(object):
         dumpformat = libvirt.VIR_DOMAIN_CORE_DUMP_FORMAT_KDUMP_ZLIB
         self.domain.coreDumpWithFormat(path, dumpformat, flags)
 
-    def stop(self, strategy='grace', timeout=5, undefine=True):
+    @staticmethod
+    def _get_undefine_flags(keep_nvram, include_cleanup_flags=True):
+        nvram_flag_name = "VIR_DOMAIN_UNDEFINE_KEEP_NVRAM" if keep_nvram else "VIR_DOMAIN_UNDEFINE_NVRAM"
+        attrs = [nvram_flag_name]
+        if include_cleanup_flags:
+            attrs = ["VIR_DOMAIN_UNDEFINE_MANAGED_SAVE", "VIR_DOMAIN_UNDEFINE_SNAPSHOTS_METADATA"] + attrs
+
+        flags = 0
+        for attr in attrs:
+            if hasattr(libvirt, attr):
+                flags |= getattr(libvirt, attr)
+        return flags
+
+    def stop(self, strategy='grace', timeout=5, undefine=True, keep_nvram=True):
         def cleanup_addons():
             for chan in self.domain_xmlobject.devices.get_child_node_as_list('channel'):
                 if chan.type_ == 'unix':
@@ -2972,7 +2985,11 @@ class Vm(object):
 
             def force_undefine():
                 try:
-                    self.domain.undefine()
+                    flags = self._get_undefine_flags(keep_nvram, include_cleanup_flags=False)
+                    if flags:
+                        self.domain.undefineFlags(flags)
+                    else:
+                        self.domain.undefine()
                 except:
                     logger.warn('cannot undefine the VM[uuid:%s]' % self.uuid)
                     pid = linux.find_process_by_cmdline(['qemu', self.uuid])
@@ -2981,11 +2998,7 @@ class Vm(object):
                         linux.kill_process(pid, is_exception=False)
 
             try:
-                flags = 0
-                for attr in [ "VIR_DOMAIN_UNDEFINE_MANAGED_SAVE", "VIR_DOMAIN_UNDEFINE_SNAPSHOTS_METADATA", "VIR_DOMAIN_UNDEFINE_NVRAM" ]:
-                    if hasattr(libvirt, attr):
-                        flags |= getattr(libvirt, attr)
-                self.domain.undefineFlags(flags)
+                self.domain.undefineFlags(self._get_undefine_flags(keep_nvram))
             except libvirt.libvirtError as ex:
                 logger.warn('undefine domain[%s] failed: %s' % (self.uuid, str(ex)))
                 force_undefine()
@@ -3042,7 +3055,7 @@ class Vm(object):
             raise kvmagent.KvmError('failed to stop vm, timeout after 60 secs')
 
     def destroy(self):
-        self.stop(strategy='cold')
+        self.stop(strategy='cold', keep_nvram=False)
 
     def pause(self, timeout=5):
         def loop_suspend(_):
@@ -5481,7 +5494,6 @@ class Vm(object):
                 e(os, 'type', 'hvm', attrib={'arch': 'loongarch64', 'machine': 'loongson7a'})
                 e(os, 'loader', '{}loongarch_bios.bin'.format(qemu.get_bin_dir()), attrib={'readonly': 'yes', 'type': 'rom'})
 
-            VmPlugin.clean_vm_firmware_flash(cmd.vmInstanceUuid)
             eval("on_{}".format(host_arch))()
 
             if cmd.useBootMenu:
@@ -7188,11 +7200,6 @@ class VmPlugin(kvmagent.KvmAgent):
 
     def _start_vm(self, cmd):
         try:
-            if os.path.exists(os.path.join(LIBVIRT_DEFINED_XML_DIR, cmd.vmInstanceUuid + ".xml")) \
-                    and not linux.get_vm_pid(cmd.vmInstanceUuid):
-                # undefine previous
-                shell.run("virsh undefine %s" % cmd.vmInstanceUuid)
-
             vm = get_vm_by_uuid_no_retry(cmd.vmInstanceUuid, False)
 
             if vm:
@@ -7203,7 +7210,7 @@ class VmPlugin(kvmagent.KvmAgent):
                     logger.debug('vm[uuid:%s, name:%s] is already running' % (cmd.vmInstanceUuid, vm.get_name()))
                     return
                 else:
-                    vm.destroy()
+                    vm.stop(strategy='cold')
 
             vm = Vm.from_StartVmCmd(cmd)
 
@@ -8210,7 +8217,7 @@ class VmPlugin(kvmagent.KvmAgent):
             self._record_operation(cmd.uuid, self.VM_OP_STOP)
             self._stop_vm(cmd)
             # notify vrouter agent nic removed from source host
-            for nic in cmd.vmNics:
+            for nic in cmd.vmNics or []:
                 if nic.type == 'TFVNIC':
                     vrouter_cmd = [
                         'vrouter-port-control',
@@ -8288,7 +8295,7 @@ class VmPlugin(kvmagent.KvmAgent):
                 if vmUseOpenvSwitch:
                     ovs.getOvsCtl(with_dpdk=True).destoryNicBackend(cmd.uuid)
                 # notify vrouter agent nic removed from source host
-                for nic in cmd.vmNics:
+                for nic in cmd.vmNics or []:
                     if nic.type == 'TFVNIC':
                         vrouter_cmd = [
                             'vrouter-port-control',
@@ -8297,6 +8304,7 @@ class VmPlugin(kvmagent.KvmAgent):
                         ]
                         notify_vrouter(vrouter_cmd)
                 logger.debug('successfully destroyed vm[uuid:%s]' % cmd.uuid)
+            self.clean_vm_firmware_flash(cmd.uuid)
         except kvmagent.KvmError as e:
             logger.warn(linux.get_exception_stacktrace())
             rsp.error = str(e)

--- a/kvmagent/kvmagent/test/vm_plugin_testsuite/test_vm_nvram_lifecycle.py
+++ b/kvmagent/kvmagent/test/vm_plugin_testsuite/test_vm_nvram_lifecycle.py
@@ -1,0 +1,99 @@
+import mock
+from unittest import TestCase
+
+from kvmagent.plugins import vm_plugin
+from kvmagent.test.utils import vm_utils
+from zstacklib.utils import http
+from zstacklib.utils import jsonobject
+
+
+class TestVmNvramLifecycle(TestCase):
+    def test_stop_endpoint_accepts_missing_vm_nics(self):
+        plugin = vm_plugin.VmPlugin()
+        req = {http.REQUEST_BODY: jsonobject.dumps({
+            'uuid': 'test-vm-uuid',
+            'type': 'cold',
+            'timeout': 5,
+            'debug': False,
+        })}
+
+        with mock.patch.object(plugin, '_record_operation'), \
+                mock.patch.object(plugin, '_stop_vm'):
+            rsp = jsonobject.loads(plugin.stop_vm(req))
+
+        self.assertTrue(rsp.success)
+
+    def test_destroy_endpoint_accepts_missing_vm_nics(self):
+        plugin = vm_plugin.VmPlugin()
+        vm_uuid = 'test-vm-uuid'
+        vm = mock.Mock()
+        req = {http.REQUEST_BODY: jsonobject.dumps({'uuid': vm_uuid})}
+
+        with mock.patch.object(plugin, '_record_operation'), \
+                mock.patch.object(plugin, 'clean_vm_firmware_flash'), \
+                mock.patch.object(vm_plugin, 'get_vm_by_uuid', return_value=vm), \
+                mock.patch.object(vm_plugin.ovs, 'isVmUseOpenvSwitch', return_value=False):
+            rsp = jsonobject.loads(plugin.destroy_vm(req))
+
+        self.assertTrue(rsp.success)
+        vm.destroy.assert_called_once_with()
+
+    def test_start_keeps_existing_uefi_nvram(self):
+        cmd = vm_utils.create_startvm_body_jsonobject()
+        cmd.bootMode = 'UEFI'
+
+        with mock.patch.object(vm_plugin.VmPlugin, 'clean_vm_firmware_flash') as clean_nvram:
+            vm = vm_plugin.Vm.from_StartVmCmd(cmd)
+
+        self.assertIn('/var/lib/libvirt/qemu/nvram/%s.fd' % cmd.vmInstanceUuid, vm.domain_xml)
+        clean_nvram.assert_not_called()
+
+    def test_start_keeps_nvram_when_cleaning_stale_domain(self):
+        plugin = vm_plugin.VmPlugin()
+        cmd = vm_utils.create_startvm_body_jsonobject()
+        stale_vm = mock.Mock()
+        stale_vm.state = vm_plugin.Vm.VM_STATE_SHUTDOWN
+        new_vm = mock.Mock()
+
+        with mock.patch.object(vm_plugin, 'get_vm_by_uuid_no_retry', return_value=stale_vm), \
+                mock.patch.object(vm_plugin.Vm, 'from_StartVmCmd', return_value=new_vm), \
+                mock.patch.object(plugin, '_prepare_ebtables_for_mocbr'):
+            plugin._start_vm(cmd)
+
+        stale_vm.stop.assert_called_once_with(strategy='cold')
+        stale_vm.destroy.assert_not_called()
+
+    def test_stop_and_destroy_use_different_nvram_flags(self):
+        keep_nvram = 1 << 20
+        remove_nvram = 1 << 21
+
+        with mock.patch.object(vm_plugin.libvirt, 'VIR_DOMAIN_UNDEFINE_KEEP_NVRAM', keep_nvram, create=True), \
+                mock.patch.object(vm_plugin.libvirt, 'VIR_DOMAIN_UNDEFINE_NVRAM', remove_nvram, create=True):
+            stop_flags = vm_plugin.Vm._get_undefine_flags(True)
+            destroy_flags = vm_plugin.Vm._get_undefine_flags(False)
+
+        self.assertTrue(stop_flags & keep_nvram)
+        self.assertFalse(stop_flags & remove_nvram)
+        self.assertTrue(destroy_flags & remove_nvram)
+        self.assertFalse(destroy_flags & keep_nvram)
+
+    def test_destroy_removes_nvram(self):
+        vm = vm_plugin.Vm()
+        vm.stop = mock.Mock()
+
+        vm.destroy()
+
+        vm.stop.assert_called_once_with(strategy='cold', keep_nvram=False)
+
+    def test_destroy_endpoint_cleans_nvram_after_vm_was_stopped(self):
+        plugin = vm_plugin.VmPlugin()
+        vm_uuid = 'test-vm-uuid'
+        req = {http.REQUEST_BODY: jsonobject.dumps({'uuid': vm_uuid})}
+
+        with mock.patch.object(plugin, '_record_operation'), \
+                mock.patch.object(plugin, 'clean_vm_firmware_flash') as clean_nvram, \
+                mock.patch.object(vm_plugin, 'get_vm_by_uuid', return_value=None):
+            rsp = jsonobject.loads(plugin.destroy_vm(req))
+
+        self.assertTrue(rsp.success)
+        clean_nvram.assert_called_once_with(vm_uuid)


### PR DESCRIPTION
## ZSTAC-81370

### Root Cause
The KVM agent undefined a VM with `VIR_DOMAIN_UNDEFINE_NVRAM` during an ordinary stop. Debian stores its installed boot entry in UEFI variable storage, so the next start recreated blank NVRAM and entered EFI Shell even though the guest disk was intact.

### Fix
- Keep NVRAM when a VM is stopped or rebooted.
- Remove NVRAM only when the VM is destroyed.
- Explicitly clean the firmware file on destroy even if the libvirt domain was already undefined.
- Stop deleting NVRAM while building a normal start XML.

### Verification
- Added lifecycle tests for UEFI start, stop, and destroy behavior.
- `python -m py_compile kvmagent/kvmagent/plugins/vm_plugin.py kvmagent/kvmagent/test/vm_plugin_testsuite/test_vm_nvram_lifecycle.py` passed.
- `git diff --check upstream/5.4.12..HEAD` passed.
- Local pytest execution is blocked because this Python 2 environment lacks the project test dependencies `mock` and `libvirt`; DevOps pipeline will provide the integration result.

Related: ZSTAC-81370

sync from gitlab !7523