### PR TITLE
<fix>[ai]: ZSTAC-70095 修复 SharedBlock LV dm table 设备不一致

### DIFF
--- a/kvmagent/kvmagent/plugins/shared_block_plugin.py
+++ b/kvmagent/kvmagent/plugins/shared_block_plugin.py
@@ -736,6 +736,7 @@ class SharedBlockPlugin(kvmagent.KvmAgent):
         # lvm.add_vg_tag(cmd.vgUuid, "%s::%s::%s::%s" % (HEARTBEAT_TAG, cmd.hostUuid, time.time(), linux.get_hostname()))
         self.clear_stalled_qmp_socket()
         lvm.check_missing_pv(cmd.vgUuid)
+        lvm.refresh_mismatched_lvs(cmd.vgUuid)
         lvm.update_lockspace_io_timeout_if_need(cmd.vgUuid, cmd.ioTimeout)
 
         self.connected(cmd.vgUuid)

--- a/kvmagent/kvmagent/test/shareblock_testsuite/test_sharedblock_metadata_auto_repair.py
+++ b/kvmagent/kvmagent/test/shareblock_testsuite/test_sharedblock_metadata_auto_repair.py
@@ -57,6 +57,7 @@ class TestSharedBlockPlugin(TestCase, SharedBlockPluginTestStub):
         self.assertEqual(True, rsp.success, o)
 
         self.lvm_repair_cmd_test()
+        self.dm_table_refresh_test()
 
         ver = lvm.get_sanlock_patch_version()
         if not (ver and ver.isdigit()) or int(ver) < 7:
@@ -78,6 +79,40 @@ class TestSharedBlockPlugin(TestCase, SharedBlockPluginTestStub):
         test_lv = "/dev/{}/testlv-new".format(vgUuid)
         lvm.deactive_lv(test_lv)
         lvm.delete_lv(test_lv)
+
+    def dm_table_refresh_test(self):
+        lv_name = "dm_table_refresh"
+        test_lv = "/dev/{}/{}".format(vgUuid, lv_name)
+        dm_name = "{}-{}".format(vgUuid, lv_name)
+        wrong_dm_name = "{}-wrong".format(dm_name)
+        lvm.create_lv_from_absolute_path(test_lv, 4194304, exact_size=True)
+        lvm.active_lv_with_check(test_lv, shared=True)
+        try:
+            original_table = bash.bash_o("dmsetup table %s" % dm_name).strip()
+            segments = original_table.splitlines()
+            self.assertEqual(1, len(segments), original_table)
+            tokens = segments[0].split()
+            self.assertEqual("linear", tokens[2], original_table)
+
+            bash.bash_errorout("dmsetup create %s --table %s" % (
+                wrong_dm_name, linux.shellquote("0 %s zero" % tokens[1])))
+            wrong_rdev = os.stat("/dev/mapper/%s" % wrong_dm_name).st_rdev
+            wrong_device = "%s:%s" % (os.major(wrong_rdev), os.minor(wrong_rdev))
+            self.assertNotEqual(tokens[3], wrong_device)
+            tokens[3] = wrong_device
+            tokens[4] = "0"
+            wrong_table = " ".join(tokens)
+
+            bash.bash_errorout("dmsetup reload %s --table %s" % (dm_name, linux.shellquote(wrong_table)))
+            bash.bash_errorout("dmsetup suspend %s && dmsetup resume %s" % (dm_name, dm_name))
+            self.assertEqual(wrong_table, bash.bash_o("dmsetup table %s" % dm_name).strip())
+
+            rsp = self.connect(blockUuids[0 : 1], blockUuids, vgUuid, hostUuid, hostId, forceWipe=False)
+            self.assertEqual(True, rsp.success, rsp.error)
+            self.assertEqual(original_table, bash.bash_o("dmsetup table %s" % dm_name).strip())
+        finally:
+            lvm.delete_lv(test_lv, raise_exception=False)
+            bash.bash_r("dmsetup remove %s" % wrong_dm_name)
 
     def lvlk_repair_test(self):
         volume_uuid = misc.uuid()

--- a/zstacklib/zstacklib/utils/lvm.py
+++ b/zstacklib/zstacklib/utils/lvm.py
@@ -1086,6 +1086,111 @@ def check_missing_pv(vgUuid):
                 raise Exception("vg %s was missing pv[name:%s, uuid:%s] , unable to restore" % (vgUuid, pv_name, pv_uuid))
             restore_missing_pv(pv_name)
 
+def list_lvs_expected_devices(vgUuid):
+    cmd = ("%s --segments --reportformat json --config report/mark_hidden_devices=0 "
+           "-o vg_name,pv_name,pv_major,pv_minor,lv_name,segtype -S %s" %
+           (subcmd("pvs"), linux.shellquote("lv_active=active && vg_name=%s" % vgUuid)))
+    return_code, output, _ = bash.bash_roe(cmd)
+    if return_code != 0:
+        logger.warn("failed to query LVM PV segments for VG %s, return code: %s" % (vgUuid, return_code))
+        return
+
+    reports = simplejson.loads(output).get("report") or []
+    rows = reports[0].get("pvseg") or [] if reports else []
+    if not rows:
+        logger.warn("skip LVM device mismatch detection because the PV segment report for VG %s is empty" % vgUuid)
+        return
+
+    lvs = {}
+    for row in rows:
+        lv_name = str(row.get("lv_name") or "").strip()
+        if not lv_name:
+            continue
+        vg_name = str(row.get("vg_name") or "").strip()
+        if not vg_name:
+            logger.warn("skip incomplete LVM PV segment in VG %s" % vgUuid)
+            continue
+
+        dm_name = "%s-%s" % (vg_name.replace("-", "--"), lv_name.replace("-", "--"))
+        lv = lvs.setdefault(dm_name, {
+            "path": "%s/%s" % (vg_name, lv_name),
+            "expected_devices": {},
+            "segtypes": set(),
+            "incomplete": False,
+        })
+        lv["segtypes"].add(str(row.get("segtype") or "").strip())
+        pv_name = str(row.get("pv_name") or "").strip()
+        device = "%s:%s" % (str(row.get("pv_major") or "").strip(),
+                             str(row.get("pv_minor") or "").strip())
+        if pv_name and device != "0:0" and re.match(r"^\d+:\d+$", device):
+            lv["expected_devices"][device] = pv_name
+        else:
+            lv["incomplete"] = True
+    return lvs
+
+def list_dm_actual_devices():
+    return_code, output, _ = bash.bash_roe("timeout -s SIGKILL 30 dmsetup table --concise")
+    if return_code != 0:
+        logger.warn("failed to query device-mapper tables, return code: %s" % return_code)
+        return
+
+    dm_tables = {}
+    for entry in (output or "").split(";"):
+        fields = entry.strip().split(",", 4)
+        if len(fields) != 5:
+            continue
+        devices = set()
+        complete = True
+        for segment in fields[4].split(","):
+            tokens = segment.split()
+            if len(tokens) < 4 or tokens[2] != "linear" or not re.match(r"^\d+:\d+$", tokens[3]):
+                complete = False
+                continue
+            devices.add(tokens[3])
+        dm_tables[fields[0].strip()] = (devices, complete)
+    return dm_tables
+
+def find_mismatched_lvs(lvs, dm_tables):
+    mismatched_lvs = []
+    for dm_name, lv in lvs.items():
+        if lv["segtypes"] != {"linear"}:
+            continue
+        if lv["incomplete"] or not lv["expected_devices"]:
+            logger.warn("skip %s because its LVM PV device report is incomplete" % lv["path"])
+            continue
+        dm_table = dm_tables.get(dm_name)
+        if not dm_table or not dm_table[0] or not dm_table[1]:
+            logger.warn("skip %s because its device-mapper table is missing or incomplete" % lv["path"])
+            continue
+        if not dm_table[0].issubset(set(lv["expected_devices"])):
+            logger.warn("LVM device mismatch for %s, dm table devices: [%s], expected devices: [%s]" %
+                        (lv["path"], ", ".join(sorted(dm_table[0])),
+                         ", ".join("%s(%s)" % (pv_name, device) for device, pv_name
+                                   in sorted(lv["expected_devices"].items()))))
+            mismatched_lvs.append(lv["path"])
+    return sorted(mismatched_lvs)
+
+@linux.ignoreerror
+def refresh_mismatched_lvs(vgUuid):
+    lvs = list_lvs_expected_devices(vgUuid)
+    if not lvs:
+        return
+    dm_tables = list_dm_actual_devices()
+    if dm_tables is None:
+        return
+    mismatched_lvs = find_mismatched_lvs(lvs, dm_tables)
+    if not mismatched_lvs:
+        return
+
+    cmd = "%s --refresh %s" % (subcmd("lvchange"),
+                                " ".join(linux.shellquote(path) for path in mismatched_lvs))
+    logger.warn("refresh mismatched LVs with command: %s" % cmd)
+    return_code, stdout, stderr = bash.bash_roe(cmd)
+    if return_code != 0:
+        logger.warn("failed to refresh mismatched LVs %s: %s" %
+                    (", ".join(mismatched_lvs),
+                     (stderr or "").strip() or (stdout or "").strip() or return_code))
+
 def stop_vg_lock(vgUuid):
     @linux.retry(times=3, sleep_time=random.uniform(0.1, 1))
     def vg_lock_not_exists(vgUuid):


### PR DESCRIPTION
SharedBlock connect 检测活动 linear LV（含 lvmlock）的 dm table 是否仍引用旧 PV 设备号，并按 VG 批量定向 refresh；查询或 refresh 失败不影响 connect。已通过 13 个定向回归、172.20.12.20 上 11 个单测及真实 stale-table/strace 验证。Resolves: ZSTAC-70095；关联 ZSTAC-70091、ZSTAC-63000。

sync from gitlab !7528