### PR TITLE
<fix>[zstackctl]: ZSTAC-86502 release phantom inventory lock

### DIFF
--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -2608,12 +2608,22 @@ def get_management_node_pid():
 def release_mysql_lock(lock_name, mn_ip):
     result = mysql("select IS_USED_LOCK('%s')" % lock_name, db_hostname=mn_ip)
     result = result.strip().splitlines()
-
     connection_id = result[1].strip()
-    if connection_id == 'NULL' or connection_id == '-1' or connection_id == '0':
-        return
-    info("kill connection %s to release lock %s held by management node %s" % (connection_id, lock_name, mn_ip))
-    mysql("KILL %s" % connection_id, db_hostname=mn_ip)
+    if connection_id not in ('NULL', '-1', '0'):
+        info("kill connection %s to release lock %s" % (connection_id, lock_name))
+        mysql("KILL %s" % connection_id, db_hostname=mn_ip)
+    if check_ha():
+        zsha2_utils = Zsha2Utils()
+        peer_ip = zsha2_utils.config['peerip']
+        if peer_ip in ('NULL', '-1', '0'):
+            return
+        result = mysql("select IS_USED_LOCK('%s')" % lock_name, db_hostname=peer_ip)
+        result = result.strip().splitlines()
+        connection_id = result[1].strip()
+        if connection_id not in ('NULL', '-1', '0'):
+            info("kill connection %s to release lock %s" % (connection_id, lock_name))
+            mysql("KILL %s" % connection_id, db_hostname=peer_ip)
+
 
 def clear_management_node_leftovers():
     pid = get_management_node_pid()
@@ -3117,6 +3127,7 @@ class StopCmd(Command):
 
             shell('bash %s' % os.path.join(ctl.zstack_home, self.STOP_SCRIPT))
             if wait_stop():
+                clear_management_node_leftovers()
                 info_and_debug('successfully stopped management node')
                 return
 


### PR DESCRIPTION
## Summary
Backport zstackctl-side ZSTAC-80498 fix for ZSTAC-86502 to 5.4.12: enhance stop-node lock cleanup.

## Original Fix
- Jira: ZSTAC-80498
- MR: http://dev.zstack.io:9080/zstackio/zstack-utility/-/merge_requests/6532
- Commit: 3dcce03480057edf2d4178b58b550a15ae1e6fe2

## Testing
- [ ] Python 2 compile not run: Python 2 is unavailable on this host. Python 3 py_compile is not valid for this Python 2 style file.

Resolves: ZSTAC-86502

sync from gitlab !7537