### PR TITLE
<backport>[5.4.12]: batch backport jin.ma issues (@@3)

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -4245,6 +4245,18 @@ class Vm(object):
         if not ret.success:
             raise Exception(ret.error)
 
+    @staticmethod
+    def is_running_on_destination(cmd):
+        dest_ctrl_ip = getattr(cmd, 'destHostManagementIp', None) or cmd.destHostIp
+        try:
+            with contextlib.closing(get_connect(dest_ctrl_ip)) as conn:
+                dst_vm = get_vm_by_uuid(cmd.vmUuid, False, conn)
+                return dst_vm is not None and dst_vm.state == Vm.VM_STATE_RUNNING
+        except Exception as e:
+            logger.warn('failed to verify vm[uuid:%s] on destination host[%s]: %s'
+                        % (cmd.vmUuid, dest_ctrl_ip, str(e)))
+            return True
+
     def migrate(self, cmd):
         if self.state == Vm.VM_STATE_SHUTDOWN:
             raise kvmagent.KvmError('vm[uuid:%s] is stopped, cannot live migrate,' % cmd.vmUuid)
@@ -4430,6 +4442,19 @@ class Vm(object):
                 if exc_type == libvirt.libvirtError:
                     err = str(exc_val)
                     logger.warn('unable to migrate vm[uuid:%s] to %s, %s' % (cmd.vmUuid, destUrl, err))
+
+                    # When network bandwidth is saturated during concurrent migrations,
+                    # libvirt may report failure even though the VM actually migrated.
+                    # Check if the VM is still on the source host before reporting error.
+                    try:
+                        vm_on_source = get_vm_by_uuid_no_retry(cmd.vmUuid, exception_if_not_existing=False)
+                    except libvirt.libvirtError as lookup_err:
+                        logger.warn('failed to verify vm on source after migration error: %s' % str(lookup_err))
+                    else:
+                        if vm_on_source is None and Vm.is_running_on_destination(cmd):
+                            logger.info('vm[uuid:%s] is no longer on source host and is running on destination host, migration actually succeeded despite libvirt error: %s' % (cmd.vmUuid, err))
+                            return True
+
                     if "cannot set up guest memory" in err:
                         raise kvmagent.KvmError("No enough physical memory for guest")
                     else:

--- a/kvmagent/kvmagent/test/vm_plugin_testsuite/test_vm_migrate_false_failure.py
+++ b/kvmagent/kvmagent/test/vm_plugin_testsuite/test_vm_migrate_false_failure.py
@@ -1,0 +1,58 @@
+import unittest
+
+import mock
+
+from kvmagent.plugins import vm_plugin
+
+
+class MigrateCmd(object):
+    vmUuid = 'vm-uuid'
+    destHostManagementIp = '10.0.0.2'
+    destHostIp = '172.24.0.2'
+
+
+class TestMigrateVmFalseFailure(unittest.TestCase):
+    def setUp(self):
+        self.cmd = MigrateCmd()
+
+    @mock.patch.object(vm_plugin, 'get_vm_by_uuid')
+    @mock.patch.object(vm_plugin, 'get_connect')
+    def test_destination_running_confirms_false_failure(self, get_connect,
+                                                        get_vm_by_uuid):
+        conn = mock.MagicMock()
+        get_connect.return_value = conn
+        get_vm_by_uuid.return_value = mock.Mock(
+            state=vm_plugin.Vm.VM_STATE_RUNNING)
+
+        self.assertTrue(vm_plugin.Vm.is_running_on_destination(self.cmd))
+        get_connect.assert_called_once_with('10.0.0.2')
+        get_vm_by_uuid.assert_called_once_with('vm-uuid', False, conn)
+        conn.close.assert_called_once_with()
+
+    @mock.patch.object(vm_plugin, 'get_vm_by_uuid')
+    @mock.patch.object(vm_plugin, 'get_connect')
+    def test_destination_not_running_preserves_failure(self, get_connect,
+                                                       get_vm_by_uuid):
+        get_connect.return_value = mock.MagicMock()
+        get_vm_by_uuid.return_value = mock.Mock(
+            state=vm_plugin.Vm.VM_STATE_PAUSED)
+
+        self.assertFalse(vm_plugin.Vm.is_running_on_destination(self.cmd))
+
+    @mock.patch.object(vm_plugin, 'get_vm_by_uuid', return_value=None)
+    @mock.patch.object(vm_plugin, 'get_connect')
+    def test_missing_destination_preserves_failure(self, get_connect,
+                                                   get_vm_by_uuid):
+        get_connect.return_value = mock.MagicMock()
+
+        self.assertFalse(vm_plugin.Vm.is_running_on_destination(self.cmd))
+
+    @mock.patch.object(vm_plugin, 'get_connect',
+                       side_effect=Exception('connect failed'))
+    def test_destination_lookup_error_keeps_false_failure_recovery(self,
+                                                                   get_connect):
+        self.assertTrue(vm_plugin.Vm.is_running_on_destination(self.cmd))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 变更说明

组合回移 5.4.12 剩余 Jira（3 仓同分支名、同标题）。

本 MR 解决 ZSTAC-86789：回移迁移误报修复的完整上游链，并按 5.4.12 单参数 libvirt 连接 API 适配。只有源端 VM 已消失且目的端 VM 确认 Running 时，才把迁移后的 libvirt 异常判定为误报。

## 来源

- 4fd6f85e05e5c0829f2830aad41f92e9d3ba90e5
- 236eb249436800dd611e7325e1c42b233af0d972
- 04a70b2f12bf1aa4cba4bc9094caa517594ef4e8

## 验证

- git diff --check / git show --check
- 4 个聚焦场景通过：目的端 Running、Paused、缺失、连接异常
- 测试源与精确提取的生产方法内存编译通过
- 上游 QA 已覆盖正常迁移、真实失败和完成后 libvirt 报错
- 独立代码审查通过

Resolves: ZSTAC-86789

sync from gitlab !7547