### PR TITLE
<fix>[qga_zwatch]: Go.exe fall back to powershell

### DIFF
--- a/kvmagent/kvmagent/plugins/qga_zwatch.py
+++ b/kvmagent/kvmagent/plugins/qga_zwatch.py
@@ -18,6 +18,32 @@ from kvmagent.plugins import vm_plugin
 log.configure_log('/var/log/zstack/zstack-kvmagent.log')
 logger = log.get_logger(__name__)
 
+# zs-tools nic-info lock-busy sentinel (must not equal real empty map "{}")
+NIC_INFO_SKIP_KEY = '__zs_nic_info_skip__'
+NIC_INFO_SKIP_LOCK_BUSY = 'lock-busy'
+NIC_INFO_SKIP_LOCK_BUSY_JSON = '{"__zs_nic_info_skip__":"lock-busy"}'
+
+
+def is_nic_info_skip(nic_info):
+    """Return True if stdout is zs-tools lock-busy skip, not a real nic snapshot.
+
+    Must run before updating vm_nic_info / send_nic_info_to_mn / PowerShell fallback.
+    """
+    if nic_info is None:
+        return False
+    # Normalize Windows CRLF / incidental whitespace from guest_exec stdout.
+    text = str(nic_info).replace('\r\n', '\n').replace('\r', '\n').strip()
+    if not text or NIC_INFO_SKIP_KEY not in text:
+        return False
+    try:
+        obj = json.loads(text)
+    except Exception:
+        return text == NIC_INFO_SKIP_LOCK_BUSY_JSON
+    if not isinstance(obj, dict):
+        return False
+    # Only the dedicated skip marker; never treat a real empty map "{}" as skip.
+    return obj.get(NIC_INFO_SKIP_KEY) == NIC_INFO_SKIP_LOCK_BUSY and len(obj) == 1
+
 
 class AgentRsp(object):
     def __init__(self):
@@ -41,6 +67,7 @@ class ZWatchMetricMonitor(kvmagent.KvmAgent):
     WIN_ZWATCH_VM_INFO_PATH = WIN_ZWATCH_BASE_PATH + "\\" + "vm.info"
     WIN_ZWATCH_VM_METRIC_PATH = WIN_ZWATCH_BASE_PATH + "\\" + "vm_metrics.prom"
     WIN_ZWATCH_GET_NIC_INFO_PATH = WIN_ZWATCH_BASE_PATH + "\\" + "zs-tools\\nic_info_win.ps1"
+    WIN_ZWATCH_GET_NIC_INFO_EXE_PATH = WIN_ZWATCH_BASE_PATH + "\\" + "zs-tools\\zs-tools.exe"
 
     PROMETHEUS_PUSHGATEWAY_URL = "http://127.0.0.1:9092/metrics/job/zwatch_vm_agent/vmUuid/"
 
@@ -57,6 +84,8 @@ class ZWatchMetricMonitor(kvmagent.KvmAgent):
         self.tools_state = {}
         self.running_vm_lock = threading.Lock()
         self.zwatch_qga_lock = threading.Lock()
+        self.vm_nic_inflight = set()
+        self.vm_nic_inflight_lock = threading.Lock()
 
     def configure(self, config):
         self.config = config
@@ -117,19 +146,43 @@ class ZWatchMetricMonitor(kvmagent.KvmAgent):
 
     @thread.AsyncThread
     def qga_get_vm_nic(self, uuid, qga):
+        with self.vm_nic_inflight_lock:
+            if uuid in self.vm_nic_inflight:
+                logger.debug('vm[%s] nic info collection still in flight, skip this round' % uuid)
+                return
+            self.vm_nic_inflight.add(uuid)
         try:
             if qga.os and 'mswindows' in qga.os:
                 zwatch_nic_info_path = self.WIN_ZWATCH_GET_NIC_INFO_PATH
             else:
                 zwatch_nic_info_path = self.ZWATCH_GET_NIC_INFO_PATH
             nicInfoStatus = qga.guest_file_is_exist(zwatch_nic_info_path)
+            if qga.os and 'mswindows' in qga.os:
+                nicInfoStatus = nicInfoStatus or qga.guest_file_is_exist(self.WIN_ZWATCH_GET_NIC_INFO_EXE_PATH)
             if not nicInfoStatus:
                 return
             if is_windows_2008(qga):
                 nicInfo = get_nic_info_for_windows_2008(uuid, qga)
+            elif qga.os and 'mswindows' in qga.os:
+                nicInfo = None
+                if qga.guest_file_is_exist(self.WIN_ZWATCH_GET_NIC_INFO_EXE_PATH):
+                    try:
+                        nicInfo = qga.guest_exec_program_no_exitcode(
+                            self.WIN_ZWATCH_GET_NIC_INFO_EXE_PATH, ['nic-info'])
+                    except Exception as e:
+                        logger.debug('vm[%s] read nic info by zs-tools.exe failed, fallback to powershell script due to [%s]' % (uuid, str(e)))
+                # Lock-busy skip must not fall back to PowerShell or clear MN cache.
+                if nicInfo is not None and is_nic_info_skip(nicInfo):
+                    logger.debug('vm[%s] nic info skipped: zs-tools lock busy' % uuid)
+                    return
+                if nicInfo is None:
+                    nicInfo = qga.guest_exec_cmd_no_exitcode(zwatch_nic_info_path)
             else:
                 nicInfo = qga.guest_exec_cmd_no_exitcode(zwatch_nic_info_path)
             nicInfo = str(nicInfo).strip()
+            if is_nic_info_skip(nicInfo):
+                logger.debug('vm[%s] nic info skipped: zs-tools lock busy' % uuid)
+                return
             need_update = False
             if not self.vm_nic_info.get(uuid):
                 need_update = True
@@ -141,6 +194,9 @@ class ZWatchMetricMonitor(kvmagent.KvmAgent):
         except Exception as e:
             logger.debug('vm[%s] read nic info by qga failed due to [%s]' % (uuid, str(e)))
             return
+        finally:
+            with self.vm_nic_inflight_lock:
+                self.vm_nic_inflight.discard(uuid)
 
     @thread.AsyncThread
     def zwatch_qga_monitor_vm(self, uuid, qga):

--- a/kvmagent/kvmagent/test/test_qga_zwatch.py
+++ b/kvmagent/kvmagent/test/test_qga_zwatch.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for Windows nic-info collection paths in qga_zwatch.
+
+Mock QGA only - no real VMs / libvirt.
+Compatible with Python 2 and Python 3 unittest discovery.
+"""
+from __future__ import absolute_import
+
+import os
+import sys
+import threading
+import types
+import unittest
+
+try:
+    from unittest import mock
+except ImportError:  # pragma: no cover
+    import mock
+
+
+qga_zwatch = None
+_modules_before = None
+
+
+def _ensure_module(name):
+    if name in sys.modules:
+        return sys.modules[name]
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    parent_name, _, child = name.rpartition('.')
+    if parent_name:
+        parent = _ensure_module(parent_name)
+        setattr(parent, child, mod)
+    return mod
+
+
+def _load_module_from_path(name, path):
+    """Load a module file on both Python 2 and Python 3."""
+    try:
+        import importlib.util as importlib_util
+    except ImportError:  # Python 2
+        import imp
+        mod = imp.load_source(name, path)
+        sys.modules[name] = mod
+        return mod
+
+    spec = importlib_util.spec_from_file_location(name, path)
+    mod = importlib_util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _restore_sys_modules(before):
+    """Undo sys.modules mutations so discovery order cannot leak stubs."""
+    before_keys = set(before)
+    after_keys = set(sys.modules)
+    for key in after_keys - before_keys:
+        sys.modules.pop(key, None)
+    for key in before_keys:
+        prev = before[key]
+        if sys.modules.get(key) is not prev:
+            sys.modules[key] = prev
+
+
+def _load_qga_zwatch():
+    """Load qga_zwatch.py with dependency stubs (avoids full kvmagent runtime)."""
+    sys.modules['libvirt'] = mock.MagicMock()
+    sys.modules['libvirt_qemu'] = mock.MagicMock()
+
+    bare_log = _ensure_module('log')
+    bare_log.get_logger = mock.Mock(return_value=mock.Mock())
+    bare_log.configure_log = mock.Mock()
+
+    log_mod = _ensure_module('zstacklib.utils.log')
+    log_mod.configure_log = mock.Mock()
+    log_mod.get_logger = mock.Mock(return_value=mock.Mock())
+
+    thread_mod = _ensure_module('zstacklib.utils.thread')
+    lock_mod = _ensure_module('zstacklib.utils.lock')
+    _ensure_module('zstacklib.utils.http').json_dump_post = mock.Mock()
+    _ensure_module('zstacklib.utils.jsonobject')
+    _ensure_module('zstacklib.utils.shell')
+
+    qga_stub = _ensure_module('zstacklib.utils.qga')
+
+    class VmQga(object):
+        QGA_STATE_RUNNING = 'running'
+        ZS_TOOLS_PATN_WIN = r'C:\Program Files\GuestTools\zs-tools\zs-tools.exe'
+
+    qga_stub.VmQga = VmQga
+
+    def AsyncThread(f):
+        """Identity decorator so methods stay normal bound methods in tests."""
+        return f
+
+    thread_mod.AsyncThread = AsyncThread
+
+    def _lock_decorator(*_a, **_k):
+        def deco(f):
+            return f
+        return deco
+
+    lock_mod.lock = _lock_decorator
+
+    kvmagent_mod = _ensure_module('kvmagent.kvmagent')
+
+    class KvmAgent(object):
+        pass
+
+    class KvmError(Exception):
+        pass
+
+    def replyerror(func):
+        return func
+
+    kvmagent_mod.KvmAgent = KvmAgent
+    kvmagent_mod.KvmError = KvmError
+    kvmagent_mod.replyerror = replyerror
+    kvmagent_mod.get_http_server = mock.Mock()
+    kvmagent_mod.SEND_COMMAND_URL = 'SEND_COMMAND_URL'
+    _ensure_module('kvmagent').kvmagent = kvmagent_mod
+
+    vm_plugin = _ensure_module('kvmagent.plugins.vm_plugin')
+
+    def LibvirtAutoReconnect(func):
+        return func
+
+    class Vm(object):
+        VIR_DOMAIN_RUNNING = 1
+
+    vm_plugin.LibvirtAutoReconnect = LibvirtAutoReconnect
+    vm_plugin.Vm = Vm
+    _ensure_module('kvmagent.plugins.host_pushgateway')
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    plugin_path = os.path.abspath(os.path.join(here, '..', 'plugins', 'qga_zwatch.py'))
+    # Flat module name avoids polluting kvmagent.plugins package namespace.
+    mod = _load_module_from_path('qga_zwatch_under_test', plugin_path)
+    return mod
+
+
+def setUpModule():
+    global qga_zwatch, _modules_before
+    _modules_before = sys.modules.copy()
+    qga_zwatch = _load_qga_zwatch()
+
+
+def tearDownModule():
+    global qga_zwatch, _modules_before
+    if _modules_before is not None:
+        _restore_sys_modules(_modules_before)
+        _modules_before = None
+    qga_zwatch = None
+
+
+NIC_JSON = '{"fa:11:22:33:44:55":["10.0.0.2/24","gateway:10.0.0.1"]}'
+PS_JSON = '{"fa:11:22:33:44:55":["10.0.0.2/24"]}'
+
+
+class TestQgaGetVmNic(unittest.TestCase):
+    def setUp(self):
+        self.monitor = qga_zwatch.ZWatchMetricMonitor()
+        self.monitor.send_nic_info_to_mn = mock.Mock()
+        self.uuid = 'vm-uuid-1'
+        self.qga = mock.Mock()
+        self.qga.os = 'mswindows'
+        self.qga.os_version = '10'  # not 2008r2
+        self.exe = self.monitor.WIN_ZWATCH_GET_NIC_INFO_EXE_PATH
+        self.ps1 = self.monitor.WIN_ZWATCH_GET_NIC_INFO_PATH
+
+    def _exist_map(self, mapping):
+        def _exist(path):
+            return bool(mapping.get(path))
+        return _exist
+
+    def test_exe_success_does_not_fallback_to_powershell(self):
+        self.qga.guest_file_is_exist.side_effect = self._exist_map({
+            self.ps1: True,
+            self.exe: True,
+        })
+        self.qga.guest_exec_program_no_exitcode.return_value = NIC_JSON
+
+        self.monitor.qga_get_vm_nic(self.uuid, self.qga)
+
+        self.qga.guest_exec_program_no_exitcode.assert_called_once_with(self.exe, ['nic-info'])
+        self.qga.guest_exec_cmd_no_exitcode.assert_not_called()
+        self.assertEqual(self.monitor.vm_nic_info[self.uuid], NIC_JSON)
+        self.monitor.send_nic_info_to_mn.assert_called_once_with(self.uuid, NIC_JSON)
+        self.assertNotIn(self.uuid, self.monitor.vm_nic_inflight)
+
+    def test_exe_nonzero_falls_back_to_powershell(self):
+        self.qga.guest_file_is_exist.side_effect = self._exist_map({
+            self.ps1: True,
+            self.exe: True,
+        })
+        self.qga.guest_exec_program_no_exitcode.side_effect = Exception('exitcode 1')
+        self.qga.guest_exec_cmd_no_exitcode.return_value = PS_JSON
+
+        self.monitor.qga_get_vm_nic(self.uuid, self.qga)
+
+        self.qga.guest_exec_program_no_exitcode.assert_called_once()
+        self.qga.guest_exec_cmd_no_exitcode.assert_called_once_with(self.ps1)
+        self.assertEqual(self.monitor.vm_nic_info[self.uuid], PS_JSON)
+        self.assertNotIn(self.uuid, self.monitor.vm_nic_inflight)
+
+    def test_ps1_only_when_exe_missing(self):
+        self.qga.guest_file_is_exist.side_effect = self._exist_map({
+            self.ps1: True,
+            self.exe: False,
+        })
+        self.qga.guest_exec_cmd_no_exitcode.return_value = PS_JSON
+
+        self.monitor.qga_get_vm_nic(self.uuid, self.qga)
+
+        self.qga.guest_exec_program_no_exitcode.assert_not_called()
+        self.qga.guest_exec_cmd_no_exitcode.assert_called_once_with(self.ps1)
+        self.assertEqual(self.monitor.vm_nic_info[self.uuid], PS_JSON)
+
+    def test_concurrent_second_call_skipped_and_inflight_cleared(self):
+        started = threading.Event()
+        release = threading.Event()
+
+        self.qga.guest_file_is_exist.side_effect = self._exist_map({
+            self.ps1: True,
+            self.exe: True,
+        })
+
+        def _slow_exe(_path, _args):
+            started.set()
+            self.assertTrue(release.wait(timeout=2), 'test deadlock waiting for release')
+            return NIC_JSON
+
+        self.qga.guest_exec_program_no_exitcode.side_effect = _slow_exe
+
+        t = threading.Thread(target=self.monitor.qga_get_vm_nic, args=(self.uuid, self.qga))
+        t.start()
+        self.assertTrue(started.wait(timeout=2))
+
+        self.monitor.qga_get_vm_nic(self.uuid, self.qga)
+        self.assertEqual(self.qga.guest_exec_program_no_exitcode.call_count, 1)
+
+        release.set()
+        t.join(timeout=2)
+        self.assertFalse(t.is_alive())
+        self.assertNotIn(self.uuid, self.monitor.vm_nic_inflight)
+
+        self.qga.guest_exec_program_no_exitcode.side_effect = None
+        self.qga.guest_exec_program_no_exitcode.return_value = NIC_JSON
+        self.monitor.qga_get_vm_nic(self.uuid, self.qga)
+        self.assertEqual(self.qga.guest_exec_program_no_exitcode.call_count, 2)
+        self.assertNotIn(self.uuid, self.monitor.vm_nic_inflight)
+
+    def test_lock_busy_skip_keeps_cache_and_does_not_send_or_fallback(self):
+        """Cross-repo: zs-tools lock-busy sentinel must skip (cache/MN/PS unchanged)."""
+        cached = NIC_JSON
+        self.monitor.vm_nic_info[self.uuid] = cached
+        self.qga.guest_file_is_exist.side_effect = self._exist_map({
+            self.ps1: True,
+            self.exe: True,
+        })
+        # Simulate zs-tools stdout including Windows CRLF.
+        self.qga.guest_exec_program_no_exitcode.return_value = (
+            qga_zwatch.NIC_INFO_SKIP_LOCK_BUSY_JSON + '\r\n'
+        )
+
+        self.monitor.qga_get_vm_nic(self.uuid, self.qga)
+
+        self.qga.guest_exec_program_no_exitcode.assert_called_once_with(self.exe, ['nic-info'])
+        self.assertEqual(self.qga.guest_exec_cmd_no_exitcode.call_count, 0)
+        self.assertEqual(self.monitor.vm_nic_info[self.uuid], cached)
+        self.assertEqual(self.monitor.send_nic_info_to_mn.call_count, 0)
+        self.assertNotIn(self.uuid, self.monitor.vm_nic_inflight)
+        self.assertTrue(qga_zwatch.is_nic_info_skip(
+            qga_zwatch.NIC_INFO_SKIP_LOCK_BUSY_JSON + '\r\n'))
+        self.assertFalse(qga_zwatch.is_nic_info_skip('{}'))
+        self.assertFalse(qga_zwatch.is_nic_info_skip(cached))
+
+    def test_empty_map_is_not_treated_as_lock_busy_skip(self):
+        """Real empty nic snapshot "{}" must still update cache / report."""
+        self.monitor.vm_nic_info[self.uuid] = NIC_JSON
+        self.qga.guest_file_is_exist.side_effect = self._exist_map({
+            self.ps1: True,
+            self.exe: True,
+        })
+        self.qga.guest_exec_program_no_exitcode.return_value = '{}'
+
+        self.monitor.qga_get_vm_nic(self.uuid, self.qga)
+
+        self.qga.guest_exec_cmd_no_exitcode.assert_not_called()
+        self.assertEqual(self.monitor.vm_nic_info[self.uuid], '{}')
+        self.monitor.send_nic_info_to_mn.assert_called_once_with(self.uuid, '{}')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zstacklib/zstacklib/test/test_qga_guest_exec_program.py
+++ b/zstacklib/zstacklib/test/test_qga_guest_exec_program.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for VmQga.guest_exec_program helpers.
+
+Compatible with Python 2 and Python 3 unittest discovery.
+"""
+from __future__ import absolute_import
+
+import os
+import sys
+import types
+import unittest
+import warnings
+
+try:
+    from unittest import mock
+except ImportError:  # pragma: no cover
+    import mock
+
+
+qga_mod = None
+VmQga = None
+_modules_before = None
+
+
+def _ensure_module(name):
+    if name in sys.modules:
+        return sys.modules[name]
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    parent_name, _, child = name.rpartition('.')
+    if parent_name:
+        parent = _ensure_module(parent_name)
+        setattr(parent, child, mod)
+    return mod
+
+
+def _load_module_from_path(name, path):
+    """Load a module file on both Python 2 and Python 3."""
+    try:
+        import importlib.util as importlib_util
+    except ImportError:  # Python 2
+        import imp
+        mod = imp.load_source(name, path)
+        sys.modules[name] = mod
+        return mod
+
+    spec = importlib_util.spec_from_file_location(name, path)
+    mod = importlib_util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _restore_sys_modules(before):
+    """Undo sys.modules mutations so discovery order cannot leak stubs."""
+    before_keys = set(before)
+    after_keys = set(sys.modules)
+    for key in after_keys - before_keys:
+        sys.modules.pop(key, None)
+    for key in before_keys:
+        prev = before[key]
+        if sys.modules.get(key) is not prev:
+            sys.modules[key] = prev
+
+
+def _load_qga_module():
+    sys.modules['libvirt'] = mock.MagicMock()
+    sys.modules['libvirt_qemu'] = mock.MagicMock()
+
+    # qga.py uses bare `import log`
+    log_mod = _ensure_module('log')
+    if not hasattr(log_mod, 'get_logger'):
+        log_mod.get_logger = mock.Mock(return_value=mock.Mock())
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    qga_path = os.path.abspath(os.path.join(here, '..', 'utils', 'qga.py'))
+    # Flat module name avoids Parent module RuntimeWarning and package pollution.
+    return _load_module_from_path('qga_under_test', qga_path)
+
+
+def setUpModule():
+    global qga_mod, VmQga, _modules_before
+    _modules_before = sys.modules.copy()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        qga_mod = _load_qga_module()
+        parent_warns = [
+            w for w in caught
+            if issubclass(w.category, RuntimeWarning)
+            and 'Parent module' in str(w.message)
+        ]
+        if parent_warns:
+            raise AssertionError(
+                'unexpected Parent module RuntimeWarning during qga load: %s'
+                % parent_warns[0].message
+            )
+    VmQga = qga_mod.VmQga
+
+
+def tearDownModule():
+    global qga_mod, VmQga, _modules_before
+    if _modules_before is not None:
+        _restore_sys_modules(_modules_before)
+        _modules_before = None
+    qga_mod = None
+    VmQga = None
+
+
+def _make_qga():
+    obj = VmQga.__new__(VmQga)
+    obj.vm_uuid = 'test-vm'
+    obj.os = 'mswindows'
+    return obj
+
+
+class TestGuestExecProgram(unittest.TestCase):
+    def setUp(self):
+        self.qga = _make_qga()
+
+    def test_guest_exec_program_success(self):
+        self.qga.guest_exec = mock.Mock(return_value={'pid': 7})
+        self.qga.guest_exec_status = mock.Mock(
+            return_value={'exited': True, 'exitcode': 0, 'out-data': b'hello'}
+        )
+        with mock.patch.object(qga_mod.time, 'sleep', mock.Mock()):
+            with mock.patch.object(
+                qga_mod,
+                'decode_with_fallback',
+                side_effect=lambda x: x.decode('utf-8') if isinstance(x, bytes) else x,
+            ):
+                code, data = self.qga.guest_exec_program('C:\\a.exe', ['nic-info'], wait=0, retry=1)
+
+        self.assertEqual(code, 0)
+        self.assertEqual(data, 'hello')
+        self.qga.guest_exec.assert_called_once()
+
+    def test_guest_exec_program_no_exitcode_nonzero_raises(self):
+        self.qga.guest_exec = mock.Mock(return_value={'pid': 7})
+        self.qga.guest_exec_status = mock.Mock(
+            return_value={'exited': True, 'exitcode': 2, 'err-data': b'fail'}
+        )
+        with mock.patch.object(qga_mod.time, 'sleep', mock.Mock()):
+            with mock.patch.object(
+                qga_mod,
+                'decode_with_fallback',
+                side_effect=lambda x: x.decode('utf-8') if isinstance(x, bytes) else x,
+            ):
+                with self.assertRaises(Exception) as ctx:
+                    self.qga.guest_exec_program_no_exitcode('C:\\a.exe', ['nic-info'])
+        self.assertIn('exitcode', str(ctx.exception))
+
+    def test_guest_exec_program_timeout(self):
+        self.qga.guest_exec = mock.Mock(return_value={'pid': 7})
+        self.qga.guest_exec_status = mock.Mock(return_value={'exited': False})
+
+        with mock.patch.object(qga_mod.time, 'sleep', mock.Mock()):
+            with self.assertRaises(Exception) as ctx:
+                self.qga.guest_exec_program('C:\\a.exe', ['nic-info'], wait=0, retry=2)
+        self.assertIn('timeout', str(ctx.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zstacklib/zstacklib/utils/qga.py
+++ b/zstacklib/zstacklib/utils/qga.py
@@ -108,8 +108,8 @@ class VmQga(object):
     VM_OS_LINUX_ALMALINUX = "almalinux"
     VM_OS_WINDOWS = "mswindows"
 
-    ZS_TOOLS_PATN_WIN = "C:\Program Files\GuestTools\zs-tools\zs-tools.exe"
-    ZS_TOOLS_VERSION_PATN_WIN = "C:\Program Files\Common Files\GuestTools\VERSION"
+    ZS_TOOLS_PATN_WIN = r"C:\Program Files\GuestTools\zs-tools\zs-tools.exe"
+    ZS_TOOLS_VERSION_PATN_WIN = r"C:\Program Files\Common Files\GuestTools\VERSION"
 
     def __init__(self, domain):
         self.domain = domain
@@ -189,6 +189,47 @@ class VmQga(object):
 
     def guest_exec(self, args):
         return self.call_qga_command("guest-exec", args=args)
+
+    def guest_exec_program(self, path, args=None, output=True, wait=qga_exec_wait_interval, retry=qga_exec_wait_retry):
+        if args is None:
+            args = []
+        ret = self.guest_exec(
+            {"path": path, "arg": args, "capture-output": output})
+        if ret and "pid" in ret:
+            pid = ret["pid"]
+        else:
+            raise Exception('qga exec program {} failed for vm {}'.format(path, self.vm_uuid))
+
+        if not output:
+            logger.warn("run qga program: {} failed, no output".format(path))
+            return 0, None
+
+        ret = None
+        for i in range(retry):
+            time.sleep(wait)
+            ret = self.guest_exec_status(pid)
+            if ret['exited']:
+                break
+
+        if not ret or not ret.get('exited'):
+            raise Exception('qga exec program {} timeout for vm {}'.format(path, self.vm_uuid))
+
+        exit_code = ret.get('exitcode')
+        ret_data = None
+        if 'out-data' in ret:
+            ret_data = decode_with_fallback(ret['out-data'])
+        elif 'err-data' in ret:
+            ret_data = decode_with_fallback(ret['err-data'])
+
+        return exit_code, ret_data
+
+    def guest_exec_program_no_exitcode(self, path, args=None, exception=True, output=True):
+        exitcode, ret_data = self.guest_exec_program(path, args, output)
+        if exitcode != 0:
+            if exception:
+                raise Exception('program {}, args {}, exitcode {}, ret {}'.format(path, args, exitcode, ret_data))
+            return None
+        return ret_data
 
     def guest_exec_bash_no_exitcode(self, cmd, exception=True, output=True):
         exitcode, ret_data = self.guest_exec_bash(cmd, output)
@@ -352,7 +393,7 @@ class VmQga(object):
         cmd = "& '{}'".format("' '".join([part for part in cmd_parts]))
 
         ret = self.guest_exec(
-            {"path": "powershell.exe", "arg": ["-ExecutionPolicy", "Bypass", "-Command", cmd], "capture-output": output})
+            {"path": "powershell.exe", "arg": ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", cmd], "capture-output": output})
         if ret and "pid" in ret:
             pid = ret["pid"]
         else:


### PR DESCRIPTION
when nic_info.go run error to read nic-info
it fall back to powershell. When it fail obtain Lock and then
skip this round.

Resolves: ZSV-9783

Change-Id: I7878676d66677375706d73617a746c6269737775

sync from gitlab !7549