### PR TITLE
<fix>[kvmagent]: ZSTAC-86867 avoid NVIDIA query contention during dGPU operations

### DIFF
--- a/kvmagent/kvmagent/plugins/host_plugin.py
+++ b/kvmagent/kvmagent/plugins/host_plugin.py
@@ -3242,6 +3242,8 @@ done
 
     def _get_nvidia_vfio_mdev_info(self, to):
         addr = to.pciDeviceAddress
+        if to.type == "Audio_Controller":
+            return False
         check_mdev_folder = '/sys/bus/pci/devices/%s/mdev_supported_types' % addr
         legacy_mdev_dir_exists = os.path.isdir(check_mdev_folder)
         check_virtfn_folder = '/sys/bus/pci/devices/%s/virtfn0/mdev_supported_types' % addr

--- a/kvmagent/kvmagent/plugins/tensorfusion/base_executor.py
+++ b/kvmagent/kvmagent/plugins/tensorfusion/base_executor.py
@@ -48,7 +48,7 @@ class WorkerExecutor(object):
         raise NotImplementedError
 
     def reap_dead(self, worker):
-        """Clean up a dead worker's resources (zombie process or stopped container)."""
+        """Clean up a dead worker's resources. Return False when cleanup must be deferred."""
         raise NotImplementedError
 
     def cleanup_residual_workers_by_vm(self, vm_uuid, known_workers=None):

--- a/kvmagent/kvmagent/plugins/tensorfusion/container_executor.py
+++ b/kvmagent/kvmagent/plugins/tensorfusion/container_executor.py
@@ -65,7 +65,7 @@ def _remove_shared_memory_file(path):
         return True
     except OSError as e:
         if e.errno == errno.ENOENT:
-            return False
+            return True
         raise
 
 
@@ -94,6 +94,9 @@ class ContainerExecutor(WorkerExecutor):
     DOCKER_CMD_TIMEOUT = 30
     DOCKER_RUN_TIMEOUT = 90
     DOCKER_REAP_TIMEOUT = 5
+    ROLLBACK_RETRY_WINDOW_SEC = 5
+    ROLLBACK_RETRY_INTERVAL_SEC = 0.5
+    ROLLBACK_REMOVE_TIMEOUT_SEC = 1
 
     # Docker labels used for filtering and identification.
     LABEL_MARKER = 'tf-worker'
@@ -141,8 +144,10 @@ class ContainerExecutor(WorkerExecutor):
         enable_log = request.enable_log if request.enable_log is not None else self.DEFAULT_ENABLE_LOG
         log_level = request.log_level or self.DEFAULT_LOG_LEVEL
 
-        if not self._remove_container_and_shared_memory(container_name, shm_path):
+        if not self._remove_container(container_name):
             raise Exception('failed to remove existing worker container %s' % container_name)
+        if not self._remove_shared_memory(shm_path):
+            raise Exception('failed to remove existing worker shared memory %s' % shm_path)
 
         cmd = self._build_run_cmd(
             device_uuid=device_uuid,
@@ -260,11 +265,9 @@ class ContainerExecutor(WorkerExecutor):
         except Exception as e:
             logger.warning('docker stop failed for %s: %s, forcing removal' % (target, e))
 
-        shm_path = getattr(worker, 'shared_memory_path', None)
-        if not shm_path:
-            shm_path = self.SHM_PREFIX + 'tf_%s' % worker.device_uuid
-        if not self._remove_container_and_shared_memory(target, shm_path):
+        if not self._remove_container(target):
             raise Exception('failed to remove worker container %s' % target)
+        self._remove_shared_memory(self._worker_shared_memory_path(worker))
 
     @classmethod
     def is_alive(cls, worker):
@@ -337,11 +340,15 @@ class ContainerExecutor(WorkerExecutor):
         container_id = getattr(worker, 'container_id', None)
         container_name = getattr(worker, 'container_name', None)
         target = container_id or container_name
-        shm_path = getattr(worker, 'shared_memory_path', None)
         if not target:
             return False
-        if not self._remove_container_and_shared_memory(target, shm_path):
+        if self.is_alive(worker):
+            logger.warning('skip reaping worker %s container %s: container is still running' %
+                           (worker.device_uuid, target))
+            return False
+        if not self._remove_container(target):
             raise Exception('failed to reap worker container %s' % target)
+        self._remove_shared_memory(self._worker_shared_memory_path(worker))
         logger.debug('reaped dead worker container %s (id=%s, name=%s)' %
                      (target, container_id, container_name))
         return True
@@ -349,11 +356,15 @@ class ContainerExecutor(WorkerExecutor):
     def cleanup_residual_workers_by_vm(self, vm_uuid, known_workers=None):
         # type: (str, list) -> int
         """Remove residual containers for a VM that are not in known_workers."""
-        known_names = set()
+        known_ids = set()
+        known_names_without_id = set()
         for w in (known_workers or []):
+            container_id = getattr(w, 'container_id', None)
             name = getattr(w, 'container_name', None)
-            if name:
-                known_names.add(name)
+            if container_id:
+                known_ids.add(container_id)
+            elif name:
+                known_names_without_id.add(name)
 
         try:
             output = self._docker([
@@ -376,7 +387,8 @@ class ContainerExecutor(WorkerExecutor):
                 if not info:
                     continue
                 name = info.get('Name', '').lstrip('/')
-                if name in known_names:
+                actual_id = info.get('Id') or cid
+                if actual_id in known_ids or name in known_names_without_id:
                     continue
 
                 # Extract device_uuid from env for shm cleanup.
@@ -385,7 +397,8 @@ class ContainerExecutor(WorkerExecutor):
                 device_uuid = env.get('TF_DEVICE_UUID')
 
                 shm_path = self.SHM_PREFIX + 'tf_%s' % device_uuid if device_uuid else None
-                if self._remove_container_and_shared_memory(cid, shm_path):
+                if self._remove_container(cid):
+                    self._remove_shared_memory(shm_path)
                     cleaned += 1
             except Exception as e:
                 logger.warning('cleanup_residual: failed to clean container %s: %s' % (cid, e))
@@ -470,12 +483,31 @@ class ContainerExecutor(WorkerExecutor):
             return None
 
     def _rollback_failed_start(self, container_name, shm_path):
-        return self._remove_container_and_shared_memory(container_name, shm_path)
+        deadline = time.time() + self.ROLLBACK_RETRY_WINDOW_SEC
+        removed = False
+        while True:
+            removed = self._remove_container(
+                container_name, timeout=self.ROLLBACK_REMOVE_TIMEOUT_SEC)
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                break
+            time.sleep(min(self.ROLLBACK_RETRY_INTERVAL_SEC, remaining))
 
-    def _remove_container_and_shared_memory(self, container_target, shm_path):
+        if not removed:
+            logger.warning('worker container %s cleanup remains pending after failed start' %
+                           container_name)
+            return False
+        self._remove_shared_memory(shm_path)
+        return True
+
+    def _remove_container(self, container_target, timeout=None):
         removed = False
         try:
-            self._docker(['rm', '-f', container_target])
+            args = ['rm', '-f', container_target]
+            if timeout is None:
+                self._docker(args)
+            else:
+                self._docker(args, timeout=timeout)
             removed = True
         except DockerCommandError as e:
             stderr_lower = e.stderr.lower()
@@ -486,19 +518,25 @@ class ContainerExecutor(WorkerExecutor):
                            (container_target, e))
 
         if not removed:
-            logger.warning('retaining shared memory %s because container %s removal is unconfirmed' %
-                           (shm_path, container_target))
+            logger.warning('worker container %s removal is unconfirmed' % container_target)
             return False
+        return True
 
-        shared_memory_removed = True
-        if shm_path:
-            try:
-                _remove_shared_memory_file(shm_path)
-            except OSError as e:
-                shared_memory_removed = False
-                logger.warning('failed to remove shared memory file %s: %s' %
-                               (shm_path, e))
-        return removed and shared_memory_removed
+    @classmethod
+    def _worker_shared_memory_path(cls, worker):
+        return (getattr(worker, 'shared_memory_path', None) or
+                cls.SHM_PREFIX + 'tf_%s' % worker.device_uuid)
+
+    @staticmethod
+    def _remove_shared_memory(shm_path):
+        if not shm_path:
+            return True
+        try:
+            return _remove_shared_memory_file(shm_path)
+        except OSError as e:
+            logger.warning('failed to remove shared memory file %s: %s' %
+                           (shm_path, e))
+            return False
 
     def _image_exists(self):
         """Check if the worker Docker image is available locally."""

--- a/kvmagent/kvmagent/plugins/tensorfusion/container_executor.py
+++ b/kvmagent/kvmagent/plugins/tensorfusion/container_executor.py
@@ -7,10 +7,12 @@ strategy into TensorFusionService.
 @author: tensorfusion
 '''
 
+import errno
 import json
 import os
 import subprocess
 import threading
+import time
 
 from zstacklib.utils import log
 from zstacklib.utils.pci import normalize_pci_address
@@ -19,6 +21,52 @@ from kvmagent.plugins.tensorfusion.models import Worker
 from kvmagent.plugins.tensorfusion.base_executor import WorkerExecutor
 
 logger = log.get_logger(__name__)
+
+SENSITIVE_ENV_KEYS = frozenset(('TF_LICENSE', 'TF_LICENSE_SIGN'))
+
+
+def _command_for_log(cmd):
+    sanitized = []
+    for arg in cmd:
+        key, separator, _ = arg.partition('=')
+        if separator and key in SENSITIVE_ENV_KEYS:
+            sanitized.append('%s=*****' % key)
+        else:
+            sanitized.append(arg)
+    return ' '.join(sanitized)
+
+
+def _redact_sensitive_values(text, cmd, env=None):
+    redacted = text
+    sensitive_values = []
+    for arg in cmd:
+        key, separator, value = arg.partition('=')
+        if separator and key in SENSITIVE_ENV_KEYS and value:
+            sensitive_values.append(value)
+    for key in SENSITIVE_ENV_KEYS:
+        value = (env or {}).get(key)
+        if value:
+            sensitive_values.append(value)
+    for value in sorted(sensitive_values, key=len, reverse=True):
+        redacted = redacted.replace(value, '*****')
+    return redacted
+
+
+def _shared_memory_ready(path, expected_size):
+    try:
+        return os.path.getsize(path) >= expected_size
+    except OSError:
+        return False
+
+
+def _remove_shared_memory_file(path):
+    try:
+        os.remove(path)
+        return True
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            return False
+        raise
 
 
 class DockerCommandError(Exception):
@@ -40,9 +88,12 @@ class ContainerExecutor(WorkerExecutor):
 
     WORKER_IMAGE = 'tf-worker:latest'
     CONTAINER_PREFIX = 'tf-worker-'
-    STARTUP_WAIT_SEC = 5
+    STARTUP_WAIT_SEC = 10
+    STARTUP_POLL_INTERVAL_SEC = 0.2
     STOP_TIMEOUT_SEC = 5
     DOCKER_CMD_TIMEOUT = 30
+    DOCKER_RUN_TIMEOUT = 90
+    DOCKER_REAP_TIMEOUT = 5
 
     # Docker labels used for filtering and identification.
     LABEL_MARKER = 'tf-worker'
@@ -69,6 +120,7 @@ class ContainerExecutor(WorkerExecutor):
         cuda_index = detail['cuda_index']
         device_uuid = request.device_uuid
         container_name = self._container_name(request.vm_uuid)
+        shm_path = self.SHM_PREFIX + 'tf_%s' % device_uuid
 
         # Verify the worker image is available locally.
         if not self._image_exists():
@@ -89,8 +141,8 @@ class ContainerExecutor(WorkerExecutor):
         enable_log = request.enable_log if request.enable_log is not None else self.DEFAULT_ENABLE_LOG
         log_level = request.log_level or self.DEFAULT_LOG_LEVEL
 
-        # Clean up any leftover container with the same name.
-        self._docker_quiet(['rm', '-f', container_name])
+        if not self._remove_container_and_shared_memory(container_name, shm_path):
+            raise Exception('failed to remove existing worker container %s' % container_name)
 
         cmd = self._build_run_cmd(
             device_uuid=device_uuid,
@@ -104,23 +156,30 @@ class ContainerExecutor(WorkerExecutor):
             log_file=log_file,
             enable_log=enable_log,
             log_level=log_level,
-            license_value=request.license,
-            license_sign=request.license_sign,
             protocol=request.protocol or 'shmem',
         )
+        docker_env = {
+            'TF_LICENSE': request.license or '',
+            'TF_LICENSE_SIGN': request.license_sign or '',
+        }
 
-        logger.info('starting worker container: docker %s' % ' '.join(cmd))
+        logger.info('starting worker container: %s' % _command_for_log(['docker'] + cmd))
 
+        run_error = None
         try:
-            container_id = self._docker(cmd).strip()
+            container_id = self._docker(
+                cmd, timeout=self.DOCKER_RUN_TIMEOUT, env=docker_env).strip()
         except Exception as e:
-            self._docker_quiet(['rm', '-f', container_name])
-            raise Exception('failed to start worker container %s: %s' % (container_name, e)) from e
+            run_error = _redact_sensitive_values(str(e), cmd, docker_env)
+        if run_error is not None:
+            self._rollback_failed_start(container_name, shm_path)
+            raise Exception('failed to start worker container %s: %s' %
+                            (container_name, run_error))
 
         # Verify the container is actually running.
         info = self._inspect_container(container_name)
         if not info:
-            self._docker_quiet(['rm', '-f', container_name])
+            self._rollback_failed_start(container_name, shm_path)
             raise Exception('container %s started but inspect failed' % container_name)
 
         state = info.get('State', {})
@@ -137,13 +196,33 @@ class ContainerExecutor(WorkerExecutor):
                         worker_logs = ''.join(lines[-20:])
             except Exception:
                 pass
-            self._docker_quiet(['rm', '-f', container_name])
-            diag = docker_logs or worker_logs or '<empty>'
+            self._rollback_failed_start(container_name, shm_path)
+            diag = _redact_sensitive_values(
+                docker_logs or worker_logs or '<empty>', cmd, docker_env)
             raise Exception(
                 'worker container %s exited immediately (exit_code=%s). logs:\n%s' %
                 (container_name, exit_code, diag))
 
-        shm_path = self.SHM_PREFIX + 'tf_%s' % device_uuid
+        if (request.protocol or 'shmem') == 'shmem':
+            expected_shm_size = shm_size_mb * self.BYTES_PER_MB
+            deadline = time.time() + self.STARTUP_WAIT_SEC
+            while time.time() < deadline and not _shared_memory_ready(shm_path, expected_shm_size):
+                time.sleep(self.STARTUP_POLL_INTERVAL_SEC)
+            if not _shared_memory_ready(shm_path, expected_shm_size):
+                docker_logs = self._docker_quiet(['logs', '--tail', '20', container_name])
+                self._rollback_failed_start(container_name, shm_path)
+                diag = _redact_sensitive_values(docker_logs or '<empty>', cmd, docker_env)
+                raise Exception(
+                    'worker container %s did not create shared memory %s within %ds. logs:\n%s' %
+                    (container_name, shm_path, self.STARTUP_WAIT_SEC, diag))
+            ready_info = self._inspect_container(container_name)
+            if not ready_info or not ready_info.get('State', {}).get('Running', False):
+                docker_logs = self._docker_quiet(['logs', '--tail', '20', container_name])
+                self._rollback_failed_start(container_name, shm_path)
+                diag = _redact_sensitive_values(docker_logs or '<empty>', cmd, docker_env)
+                raise Exception(
+                    'worker container %s exited before shared memory became ready. logs:\n%s' %
+                    (container_name, diag))
 
         worker = Worker()
         worker.device_uuid = device_uuid
@@ -169,30 +248,23 @@ class ContainerExecutor(WorkerExecutor):
 
     def stop(self, worker):
         """Stop and remove a Worker container, then clean up shared memory."""
-        container_name = worker.container_name
-        if not container_name:
-            logger.warning('stop: worker %s has no container_name, skipping' % worker.device_uuid)
-            return
+        container_id = getattr(worker, 'container_id', None)
+        container_name = getattr(worker, 'container_name', None)
+        target = container_id or container_name
+        if not target:
+            raise Exception('worker %s has no container identity' % worker.device_uuid)
 
-        logger.info('stopping worker container %s (device=%s)' % (container_name, worker.device_uuid))
-
+        logger.info('stopping worker container %s (device=%s)' % (target, worker.device_uuid))
         try:
-            self._docker(['stop', '-t', str(self.STOP_TIMEOUT_SEC), container_name])
+            self._docker(['stop', '-t', str(self.STOP_TIMEOUT_SEC), target])
         except Exception as e:
-            logger.warning('docker stop failed for %s: %s, forcing removal' % (container_name, e))
+            logger.warning('docker stop failed for %s: %s, forcing removal' % (target, e))
 
-        self._docker_quiet(['rm', '-f', container_name])
-
-        # Clean up shared memory file.
         shm_path = getattr(worker, 'shared_memory_path', None)
         if not shm_path:
             shm_path = self.SHM_PREFIX + 'tf_%s' % worker.device_uuid
-        if os.path.exists(shm_path):
-            try:
-                os.remove(shm_path)
-                logger.debug('removed shared memory file: %s' % shm_path)
-            except OSError as e:
-                logger.warning('failed to remove shared memory file %s: %s' % (shm_path, e))
+        if not self._remove_container_and_shared_memory(target, shm_path):
+            raise Exception('failed to remove worker container %s' % target)
 
     @classmethod
     def is_alive(cls, worker):
@@ -265,11 +337,14 @@ class ContainerExecutor(WorkerExecutor):
         container_id = getattr(worker, 'container_id', None)
         container_name = getattr(worker, 'container_name', None)
         target = container_id or container_name
+        shm_path = getattr(worker, 'shared_memory_path', None)
         if not target:
-            return
-        self._docker_quiet(['rm', '-f', target])
+            return False
+        if not self._remove_container_and_shared_memory(target, shm_path):
+            raise Exception('failed to reap worker container %s' % target)
         logger.debug('reaped dead worker container %s (id=%s, name=%s)' %
                      (target, container_id, container_name))
+        return True
 
     def cleanup_residual_workers_by_vm(self, vm_uuid, known_workers=None):
         # type: (str, list) -> int
@@ -309,17 +384,9 @@ class ContainerExecutor(WorkerExecutor):
                 env = {e.split('=', 1)[0]: e.split('=', 1)[1] for e in env_list if '=' in e}
                 device_uuid = env.get('TF_DEVICE_UUID')
 
-                self._docker_quiet(['rm', '-f', cid])
-
-                if device_uuid:
-                    shm_path = self.SHM_PREFIX + 'tf_%s' % device_uuid
-                    if os.path.exists(shm_path):
-                        try:
-                            os.remove(shm_path)
-                        except OSError:
-                            pass
-
-                cleaned += 1
+                shm_path = self.SHM_PREFIX + 'tf_%s' % device_uuid if device_uuid else None
+                if self._remove_container_and_shared_memory(cid, shm_path):
+                    cleaned += 1
             except Exception as e:
                 logger.warning('cleanup_residual: failed to clean container %s: %s' % (cid, e))
 
@@ -332,51 +399,54 @@ class ContainerExecutor(WorkerExecutor):
     # Docker command helpers
     # ------------------------------------------------------------------
 
-    def _docker(self, args, timeout=None):
+    def _docker(self, args, timeout=None, env=None):
         """Execute a docker command and return stdout. Raises on failure."""
         timeout = timeout or self.DOCKER_CMD_TIMEOUT
-        cmd = ['docker'] + args
-        try:
-            proc = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                close_fds=True)
-            stdout, stderr = proc.communicate(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait()
-            raise Exception('docker command timed out (%ds): %s' % (timeout, ' '.join(cmd)))
+        return self._execute_docker(args, timeout, env)
 
-        stdout_str = stdout.decode('utf-8', 'ignore').strip() if stdout else ''
-        stderr_str = stderr.decode('utf-8', 'ignore').strip() if stderr else ''
-
-        if proc.returncode != 0:
-            raise DockerCommandError(proc.returncode, ' '.join(cmd), stderr_str)
-        return stdout_str
-
-    def _docker_quiet(self, args, timeout=None):
+    def _docker_quiet(self, args, timeout=None, env=None):
         """Execute a docker command, returning stdout. Errors are logged but not raised."""
         try:
-            return self._docker(args, timeout=timeout)
+            return self._docker(args, timeout=timeout, env=env)
         except Exception as e:
             logger.debug('docker command (quiet) failed: %s' % e)
             return ''
 
     @classmethod
-    def _docker_class(cls, args, timeout=30):
+    def _docker_class(cls, args, timeout=30, env=None):
         """Class-level docker command for use in classmethods (e.g. is_alive)."""
+        return cls._execute_docker(args, timeout, env)
+
+    @classmethod
+    def _execute_docker(cls, args, timeout, env=None):
         cmd = ['docker'] + args
+        command_for_log = _command_for_log(cmd)
+        process_env = None
+        if env is not None:
+            process_env = os.environ.copy()
+            process_env.update(env)
+        timed_out = False
         try:
             proc = subprocess.Popen(
                 cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                close_fds=True)
+                close_fds=True, env=process_env)
             stdout, stderr = proc.communicate(timeout=timeout)
         except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait()
-            raise
+            timed_out = True
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=cls.DOCKER_REAP_TIMEOUT)
+            except Exception:
+                pass
+        if timed_out:
+            raise Exception('docker command timed out (%ds): %s' % (timeout, command_for_log))
         if proc.returncode != 0:
             stderr_str = stderr.decode('utf-8', 'ignore').strip() if stderr else ''
-            raise DockerCommandError(proc.returncode, ' '.join(cmd), stderr_str)
+            stderr_str = _redact_sensitive_values(stderr_str, cmd, env)
+            raise DockerCommandError(proc.returncode, command_for_log, stderr_str)
         return stdout.decode('utf-8', 'ignore').strip() if stdout else ''
 
     # ------------------------------------------------------------------
@@ -398,6 +468,37 @@ class ContainerExecutor(WorkerExecutor):
             return None
         except Exception:
             return None
+
+    def _rollback_failed_start(self, container_name, shm_path):
+        return self._remove_container_and_shared_memory(container_name, shm_path)
+
+    def _remove_container_and_shared_memory(self, container_target, shm_path):
+        removed = False
+        try:
+            self._docker(['rm', '-f', container_target])
+            removed = True
+        except DockerCommandError as e:
+            stderr_lower = e.stderr.lower()
+            removed = ('no such object' in stderr_lower or
+                       'no such container' in stderr_lower)
+        except Exception as e:
+            logger.warning('failed to remove worker container %s: %s' %
+                           (container_target, e))
+
+        if not removed:
+            logger.warning('retaining shared memory %s because container %s removal is unconfirmed' %
+                           (shm_path, container_target))
+            return False
+
+        shared_memory_removed = True
+        if shm_path:
+            try:
+                _remove_shared_memory_file(shm_path)
+            except OSError as e:
+                shared_memory_removed = False
+                logger.warning('failed to remove shared memory file %s: %s' %
+                               (shm_path, e))
+        return removed and shared_memory_removed
 
     def _image_exists(self):
         """Check if the worker Docker image is available locally."""
@@ -424,8 +525,7 @@ class ContainerExecutor(WorkerExecutor):
 
     def _build_run_cmd(self, device_uuid, vm_uuid, pci_address, cuda_index,
                        container_name, memory_mb, sm_percent_limit, shm_size_mb,
-                       log_file, enable_log, log_level, license_value, license_sign,
-                       protocol='shmem'):
+                       log_file, enable_log, log_level, protocol='shmem'):
         """Build the full ``docker run`` argument list."""
         cmd = [
             'run', '-d',
@@ -449,8 +549,8 @@ class ContainerExecutor(WorkerExecutor):
             '-e', 'TF_LOG_LEVEL=%s' % log_level,
             '-e', 'TF_LOG_PATH=%s' % log_file,
             # License.
-            '-e', 'TF_LICENSE=%s' % (license_value or ''),
-            '-e', 'TF_LICENSE_SIGN=%s' % (license_sign or ''),
+            '-e', 'TF_LICENSE',
+            '-e', 'TF_LICENSE_SIGN',
             # Resource limits.
             '-e', 'TF_GPU_MEMORY_LIMIT=%d' % (memory_mb or 0),
             '-e', 'TF_CUDA_SM_PERCENT_LIMIT=%d' % (sm_percent_limit or 0),

--- a/kvmagent/kvmagent/plugins/tensorfusion/monitor.py
+++ b/kvmagent/kvmagent/plugins/tensorfusion/monitor.py
@@ -229,6 +229,7 @@ class WorkerRestartMonitor(object):
             if reaped is False:
                 logger.warning('WorkerRestartMonitor: worker %s (%s) is still running, skipping restart' %
                             (device_uuid, _worker_label(w)))
+                self.clear(device_uuid)
                 self._store.set_restarting(device_uuid, False, expected_worker=w)
                 return
 
@@ -296,6 +297,7 @@ class WorkerRestartMonitor(object):
                 if reaped is False:
                     logger.warning('WorkerRestartMonitor: worker %s is still running during give_up' %
                                 device_uuid)
+                    self.clear(device_uuid)
                     self._store.set_restarting(device_uuid, False, expected_worker=w)
                     return False
 

--- a/kvmagent/kvmagent/plugins/tensorfusion/monitor.py
+++ b/kvmagent/kvmagent/plugins/tensorfusion/monitor.py
@@ -17,6 +17,7 @@ import threading
 import time
 
 from zstacklib.utils import log
+from zstacklib.gpu.operation_gate import gpu_operation_gate
 from kvmagent.plugins.tensorfusion.base_executor import WorkerExecutor
 
 logger = log.get_logger(__name__)
@@ -156,8 +157,8 @@ class WorkerRestartMonitor(object):
                 'WorkerRestartMonitor: worker %s exceeded max retries '
                 '(%d crashes within %ds window), giving up' % (
                     device_uuid, count, CrashState.CRASH_WINDOW))
-            current_worker = self._store.remove(device_uuid, expected_worker=w)
-            if current_worker is None:
+            current_worker = self._store.get(device_uuid)
+            if current_worker is not w:
                 self.clear(device_uuid)
                 logger.info('WorkerRestartMonitor: worker %s changed before give-up, skipping stale fault handling' %
                             device_uuid)
@@ -168,7 +169,7 @@ class WorkerRestartMonitor(object):
                     self._notified_events.add(device_uuid)
                 self._push_event(current_worker, count, 'fault')
 
-            self._give_up(current_worker, already_removed=True)
+            self._give_up(current_worker)
             return
 
         logger.warning(
@@ -204,12 +205,32 @@ class WorkerRestartMonitor(object):
                             device_uuid)
                 return
 
+            current_worker = self._store.get(device_uuid)
+            if current_worker is not w:
+                self.clear(device_uuid)
+                logger.info('WorkerRestartMonitor: worker %s changed during backoff, skipping stale restart' %
+                            device_uuid)
+                return
+
             # Reap the old dead process to prevent zombie.
             try:
-                self._executor.reap_dead(w)
+                with gpu_operation_gate.critical():
+                    if self._store.get(device_uuid) is not w:
+                        self.clear(device_uuid)
+                        logger.info('WorkerRestartMonitor: worker %s changed during backoff, skipping stale restart' %
+                                    device_uuid)
+                        return
+                    reaped = self._executor.reap_dead(w)
             except Exception as e:
                 logger.warning('WorkerRestartMonitor: failed to reap dead worker %s (%s): %s' %
                             (device_uuid, _worker_label(w), e))
+                self._store.set_restarting(device_uuid, False, expected_worker=w)
+                return
+            if reaped is False:
+                logger.warning('WorkerRestartMonitor: worker %s (%s) is still running, skipping restart' %
+                            (device_uuid, _worker_label(w)))
+                self._store.set_restarting(device_uuid, False, expected_worker=w)
+                return
 
             # Guard: worker may have been intentionally destroyed or replaced while we waited.
             current_worker = self._store.get(device_uuid)
@@ -261,30 +282,44 @@ class WorkerRestartMonitor(object):
                 if thread is threading.current_thread():
                     self._restart_threads.pop(device_uuid, None)
 
-    def _give_up(self, w, already_removed=False):
+    def _give_up(self, w):
         device_uuid = w.device_uuid
-        if not already_removed:
-            current_worker = self._store.remove(device_uuid, expected_worker=w)
-            if current_worker is None:
-                self.clear(device_uuid)
-                logger.info('WorkerRestartMonitor: worker %s changed before give-up cleanup, skipping stale purge' %
-                            device_uuid)
-                return
-            w = current_worker
-
         # Reap the dead process to prevent zombie.
         try:
-            self._executor.reap_dead(w)
+            with gpu_operation_gate.critical():
+                if self._store.get(device_uuid) is not w:
+                    self.clear(device_uuid)
+                    logger.info('WorkerRestartMonitor: worker %s changed before give-up cleanup, skipping stale purge' %
+                                device_uuid)
+                    return False
+                reaped = self._executor.reap_dead(w)
+                if reaped is False:
+                    logger.warning('WorkerRestartMonitor: worker %s is still running during give_up' %
+                                device_uuid)
+                    self._store.set_restarting(device_uuid, False, expected_worker=w)
+                    return False
+
+                removed = self._store.remove(device_uuid, expected_worker=w)
+                if removed is not None:
+                    self._tracker.release(removed.pci_address, device_uuid)
         except Exception as e:
             logger.warning('WorkerRestartMonitor: failed to reap dead worker %s '
                         'during give_up: %s' % (device_uuid, e))
-        self._tracker.release(w.pci_address, device_uuid)
+            self._store.set_restarting(device_uuid, False, expected_worker=w)
+            return False
+        if removed is None:
+            self.clear(device_uuid)
+            logger.info('WorkerRestartMonitor: worker %s changed before give-up cleanup, skipping stale purge' %
+                        device_uuid)
+            return False
+
         with self._lock:
             self._states.pop(device_uuid, None)
             self._notified_events.discard(device_uuid)
         logger.error(
             'WorkerRestartMonitor: purged dead worker %s, '
             'GPU memory released; management plane will confirm Fault on next sync' % device_uuid)
+        return True
 
     def _push_event(self, w, crash_count, event_type):
         """Push event notification to management node. No-op if no notifier configured."""

--- a/kvmagent/kvmagent/plugins/tensorfusion/plugin.py
+++ b/kvmagent/kvmagent/plugins/tensorfusion/plugin.py
@@ -6,6 +6,7 @@ TensorFusion KVM Agent Plugin - HTTP API for GPU virtualization worker managemen
 
 import threading
 import time
+import traceback
 
 from kvmagent import kvmagent
 from zstacklib.utils import http
@@ -19,9 +20,18 @@ from kvmagent.plugins.tensorfusion.service import TensorFusionService
 logger = log.get_logger(__name__)
 
 
+def _redact_worker_credentials(text, cmd):
+    redacted = text
+    values = [value for value in (cmd.license, cmd.licenseSign) if value]
+    for value in sorted(values, key=len, reverse=True):
+        redacted = redacted.replace(value, '*****')
+    return redacted
+
+
 # --- Request / Response classes ---
 
 class CreateWorkerCmd(kvmagent.AgentCommand):
+    @log.sensitive_fields('license', 'licenseSign')
     def __init__(self):
         super(CreateWorkerCmd, self).__init__()
         self.vmUuid = None
@@ -180,7 +190,7 @@ class TensorFusionPlugin(kvmagent.KvmAgent):
         http_server = kvmagent.get_http_server()
 
         # All endpoints registered as async
-        http_server.register_async_uri(self.CREATE_WORKER, self.create_worker)
+        http_server.register_async_uri(self.CREATE_WORKER, self.create_worker, cmd=CreateWorkerCmd())
         http_server.register_async_uri(self.DESTROY_WORKER, self.destroy_worker)
         http_server.register_async_uri(self.DESTROY_WORKERS_BY_VM, self.destroy_workers_by_vm)
         http_server.register_async_uri(self.CLEANUP, self.cleanup)
@@ -348,16 +358,28 @@ class TensorFusionPlugin(kvmagent.KvmAgent):
 
     # --- Async handlers ---
 
-    @kvmagent.replyerror
     def create_worker(self, req):
-        cmd = jsonobject.loads(req[http.REQUEST_BODY])
-        rsp = CreateWorkerRsp()
+        cmd = None
+        try:
+            cmd = jsonobject.loads(req[http.REQUEST_BODY])
+            rsp = CreateWorkerRsp()
 
-        create_req = self._to_create_request(cmd)
-        worker = self._service.create_worker(create_req)
-        rsp.worker = worker.to_dict()
+            create_req = self._to_create_request(cmd)
+            worker = self._service.create_worker(create_req)
+            rsp.worker = worker.to_dict()
+            return jsonobject.dumps(rsp)
+        except Exception as e:
+            error = str(e)
+            content = traceback.format_exc()
+            if cmd is not None:
+                error = _redact_worker_credentials(error, cmd)
+                content = _redact_worker_credentials(content, cmd)
 
-        return jsonobject.dumps(rsp)
+            rsp = kvmagent.AgentResponse()
+            rsp.success = False
+            rsp.error = error
+            logger.warn('%s\n%s' % (error, content))
+            return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror
     def destroy_worker(self, req):

--- a/kvmagent/kvmagent/plugins/tensorfusion/process_executor.py
+++ b/kvmagent/kvmagent/plugins/tensorfusion/process_executor.py
@@ -367,15 +367,43 @@ class ProcessExecutor(WorkerExecutor):
             return
         proc = self._get_proc(pid)
         if proc is not None:
+            if proc.poll() is None:
+                logger.warning('skip reaping worker %s pid %d: process is still running' %
+                               (worker.device_uuid, pid))
+                return False
             self._reap_process(proc)
         else:
             # No Popen object tracked — try os.waitpid directly as fallback.
             try:
-                os.waitpid(pid, os.WNOHANG)
-            except (OSError, ChildProcessError):
-                pass
+                reaped_pid, _ = os.waitpid(pid, os.WNOHANG)
+                if reaped_pid == 0:
+                    logger.warning('skip reaping worker %s pid %d: process is still running' %
+                                   (worker.device_uuid, pid))
+                    return False
+            except (OSError, ChildProcessError) as e:
+                wait_errno = getattr(e, 'errno', None)
+                if wait_errno == errno.ESRCH:
+                    wait_errno = None
+                elif wait_errno not in (None, errno.ECHILD):
+                    raise
+                if wait_errno == errno.ECHILD or wait_errno is None:
+                    try:
+                        os.kill(pid, 0)
+                    except OSError as kill_error:
+                        if kill_error.errno != errno.ESRCH:
+                            logger.warning('skip reaping worker %s pid %d: cannot confirm process exit: %s' %
+                                           (worker.device_uuid, pid, kill_error))
+                            return False
+                    else:
+                        if not self._is_linux_zombie(pid):
+                            verified, reason = self._verify_worker_pid(pid, worker)
+                            if verified or not self._is_worker_process_gone_or_replaced(reason):
+                                logger.warning('skip reaping worker %s pid %d: %s' %
+                                               (worker.device_uuid, pid, reason))
+                                return False
         self._forget_proc(pid)
         logger.debug('reaped dead worker process pid=%d' % pid)
+        return True
 
     def scan_running(self):
         # type: () -> list

--- a/kvmagent/kvmagent/plugins/tensorfusion/service.py
+++ b/kvmagent/kvmagent/plugins/tensorfusion/service.py
@@ -9,6 +9,7 @@ import threading
 
 from zstacklib.utils import log
 from zstacklib.utils.pci import normalize_pci_address
+from zstacklib.gpu.operation_gate import gpu_operation_gate
 from zstacklib.gpu.vendors.nvidia import NVIDIA
 
 from kvmagent.plugins.tensorfusion.models import WorkerCreateRequest, GPUHardwareInfo
@@ -77,7 +78,7 @@ class TensorFusionService(object):
                 logger.warning('TensorFusionService: killing orphan worker %s '
                             '(%s, vm=%s not running)' % (w.device_uuid, WorkerExecutor.worker_label(w), w.vm_uuid))
                 try:
-                    self._executor.stop(w)
+                    self._stop_worker_runtime(w)
                 except Exception as e:
                     logger.warning('TensorFusionService: failed to stop orphan worker %s: %s' %
                                 (w.device_uuid, e))
@@ -159,12 +160,15 @@ class TensorFusionService(object):
             if vm_state is not False:
                 continue
 
-            logger.warning('TensorFusionService: orphan scan: killing worker %s '
-                        '(%s, vm=%s not running, tracked=%s)' %
-                        (w.device_uuid, WorkerExecutor.worker_label(w), w.vm_uuid,
-                         self._store.get(w.device_uuid) is not None))
+            tracked = None
             try:
-                self._executor.stop(w)
+                with gpu_operation_gate.critical():
+                    tracked = self._store.get(w.device_uuid)
+                    logger.warning('TensorFusionService: orphan scan: killing worker %s '
+                                '(%s, vm=%s not running, tracked=%s)' %
+                                (w.device_uuid, WorkerExecutor.worker_label(w), w.vm_uuid,
+                                 tracked is not None))
+                    self._stop_worker_runtime(w)
             except Exception as e:
                 logger.warning('TensorFusionService: orphan scan: failed to stop worker %s: %s' %
                             (w.device_uuid, e))
@@ -172,9 +176,9 @@ class TensorFusionService(object):
                     continue
 
             # Clean up StateStore entry if present
-            tracked = self._store.get(w.device_uuid)
-            if tracked:
-                self._remove_worker_state(tracked)
+            if (tracked and self._is_same_worker_runtime(w, tracked) and
+                    self._remove_worker_state(tracked) is None):
+                continue
             killed += 1
 
         # Clean up stale StateStore entries whose workers are already dead
@@ -189,20 +193,32 @@ class TensorFusionService(object):
             logger.info('TensorFusionService: orphan scan: cleaned up %d orphan workers' % killed)
 
     def _remove_worker_state(self, worker):
-        removed = self._store.remove(worker.device_uuid, expected_worker=worker)
-        if removed is None:
-            logger.info('TensorFusionService: worker %s changed before state cleanup, skipping stale cleanup' %
-                        worker.device_uuid)
-            return None
+        with gpu_operation_gate.critical():
+            if self._store.get(worker.device_uuid) is not worker:
+                logger.info('TensorFusionService: worker %s changed before state cleanup, skipping stale cleanup' %
+                            worker.device_uuid)
+                return None
 
-        # Reap the dead worker to clean up resources (zombie process or stopped container).
-        try:
-            self._executor.reap_dead(removed)
-        except Exception as e:
-            logger.warning('TensorFusionService: failed to reap worker %s: %s' %
-                        (removed.device_uuid, e))
+            try:
+                reaped = self._reap_dead_worker_runtime(worker)
+            except Exception as e:
+                logger.warning('TensorFusionService: failed to reap worker %s: %s' %
+                            (worker.device_uuid, e))
+                return None
+            if reaped is False:
+                logger.warning('TensorFusionService: worker %s is still running, preserving state' %
+                            worker.device_uuid)
+                return None
+
+            removed = self._store.remove(worker.device_uuid, expected_worker=worker)
+            if removed is None:
+                logger.info('TensorFusionService: worker %s changed before state cleanup, skipping stale cleanup' %
+                            worker.device_uuid)
+                return None
+
+            self._tracker.release(removed.pci_address, removed.device_uuid)
+
         self._monitor.clear(removed.device_uuid)
-        self._tracker.release(removed.pci_address, removed.device_uuid)
         return removed
 
     @staticmethod
@@ -224,18 +240,32 @@ class TensorFusionService(object):
         normalized = normalize_pci_address(pci_address)
         return normalized or pci_address
 
+    @staticmethod
+    def _is_same_worker_runtime(first, second):
+        first_container_id = getattr(first, 'container_id', None)
+        second_container_id = getattr(second, 'container_id', None)
+        if first_container_id or second_container_id:
+            return bool(first_container_id and first_container_id == second_container_id)
+
+        first_pid = getattr(first, 'pid', None)
+        second_pid = getattr(second, 'pid', None)
+        if first_pid is not None or second_pid is not None:
+            return first_pid is not None and first_pid == second_pid
+        return first is second
+
     def refresh_gpu_details(self):
         # type: () -> bool
-        try:
-            gpu_details = NVIDIA.query_gpu_details()
-        except Exception as e:
-            logger.warning('TensorFusionService: failed to query GPU details, continuing with current inventory: %s' % e)
-            return False
+        with gpu_operation_gate.critical():
+            try:
+                gpu_details = NVIDIA.query_gpu_details()
+            except Exception as e:
+                logger.warning('TensorFusionService: failed to query GPU details, continuing with current inventory: %s' % e)
+                return False
 
-        self._gpu_details.clear()
-        self._gpu_details.update(gpu_details)
-        self._tracker.refresh_gpu_details(self._gpu_details)
-        return True
+            self._gpu_details.clear()
+            self._gpu_details.update(gpu_details)
+            self._tracker.refresh_gpu_details(self._gpu_details)
+            return True
 
     def _get_create_lock(self, pci_address):
         with self._create_lock_guard:
@@ -244,6 +274,14 @@ class TensorFusionService(object):
                 lock = threading.Lock()
                 self._create_locks[pci_address] = lock
             return lock
+
+    def _stop_worker_runtime(self, worker):
+        with gpu_operation_gate.critical():
+            self._executor.stop(worker)
+
+    def _reap_dead_worker_runtime(self, worker):
+        with gpu_operation_gate.critical():
+            return self._executor.reap_dead(worker)
 
     def create_worker(self, request):
         # type: (WorkerCreateRequest) -> object
@@ -254,7 +292,7 @@ class TensorFusionService(object):
         request.pci_address = self._normalize_pci_address(request.pci_address)
         pci = request.pci_address
         create_lock = self._get_create_lock(pci)
-        with create_lock:
+        with create_lock, gpu_operation_gate.critical():
             # Always refresh: cuda_index may change after GPU passthrough.
             self.refresh_gpu_details()
 
@@ -269,15 +307,9 @@ class TensorFusionService(object):
                     raise Exception('worker %s already exists for vm %s on %s' %
                                     (request.device_uuid, existing.vm_uuid, existing.pci_address))
 
-                # Clean up the dead worker: reap zombie, release resources, remove state.
-                try:
-                    self._executor.reap_dead(existing)
-                except Exception as e:
-                    logger.warning('TensorFusionService: failed to reap dead worker %s: %s' %
-                                (request.device_uuid, e))
-                self._monitor.clear(request.device_uuid)
-                self._tracker.release(existing.pci_address, request.device_uuid)
-                self._store.remove(request.device_uuid)
+                if self._remove_worker_state(existing) is None:
+                    raise Exception('failed to clean up existing worker %s before create' %
+                                    request.device_uuid)
 
             if not self._tracker.can_allocate(pci, request.memory_mb):
                 avail = self._tracker.get_available_memory(pci)
@@ -290,7 +322,7 @@ class TensorFusionService(object):
                 self._tracker.allocate(pci, worker.device_uuid, worker.allocated_memory_mb)
             except Exception:
                 try:
-                    self._executor.stop(worker)
+                    self._stop_worker_runtime(worker)
                 except Exception as stop_error:
                     logger.warning('TensorFusionService: failed to rollback worker %s after create error: %s' % (
                         request.device_uuid, stop_error))
@@ -335,7 +367,7 @@ class TensorFusionService(object):
         req.pci_address = self._normalize_pci_address(req.pci_address)
         pci = req.pci_address
         create_lock = self._get_create_lock(pci)
-        with create_lock:
+        with create_lock, gpu_operation_gate.critical():
             # Always refresh: cuda_index may change after GPU passthrough.
             self.refresh_gpu_details()
             if pci not in self._gpu_details:
@@ -350,7 +382,7 @@ class TensorFusionService(object):
             replaced = self._store.replace(new_worker, expected_worker=current_worker)
             if replaced is None:
                 try:
-                    self._executor.stop(new_worker)
+                    self._stop_worker_runtime(new_worker)
                 except Exception as stop_error:
                     logger.warning('TensorFusionService: failed to stop orphan worker %s after restart CAS miss: %s' % (
                         current_worker.device_uuid, stop_error))
@@ -404,19 +436,21 @@ class TensorFusionService(object):
             self._monitor.clear(device_uuid)
 
             try:
-                self._executor.stop(worker)
+                self._stop_worker_runtime(worker)
             except Exception:
                 if self._executor.is_alive(worker):
                     self._store.set_restarting(device_uuid, False, expected_worker=worker)
                 else:
                     removed = self._remove_worker_state(worker)
                     if removed is None:
+                        self._store.set_restarting(device_uuid, False, expected_worker=worker)
                         logger.warning('TensorFusionService: worker %s changed during destroy after stop failure' %
                                     device_uuid)
                 raise
 
             removed = self._remove_worker_state(worker)
             if removed is None:
+                self._store.set_restarting(device_uuid, False, expected_worker=worker)
                 logger.warning('TensorFusionService: worker %s changed during destroy, refusing success' %
                             device_uuid)
                 return False
@@ -447,10 +481,13 @@ class TensorFusionService(object):
                 continue
             if destroyed:
                 count += 1
+            else:
+                failures.append('%s: runtime cleanup incomplete' % w.device_uuid)
 
         try:
             survivors = self._store.list_by_vm(vm_uuid)
-            count += self._executor.cleanup_residual_workers_by_vm(vm_uuid, known_workers=survivors)
+            with gpu_operation_gate.critical():
+                count += self._executor.cleanup_residual_workers_by_vm(vm_uuid, known_workers=survivors)
         except Exception as e:
             failures.append('residual cleanup: %s' % str(e))
 
@@ -467,8 +504,9 @@ class TensorFusionService(object):
         if worker and not getattr(worker, 'restarting', False) and not self._executor.is_alive(worker):
             logger.warning('TensorFusionService: worker %s (%s) is dead, cleaning up' %
                         (device_uuid, WorkerExecutor.worker_label(worker)))
-            self._remove_worker_state(worker)
-            return None
+            if self._remove_worker_state(worker) is not None:
+                return None
+            return self._store.get(device_uuid)
         return worker
 
     def list_workers(self):
@@ -508,8 +546,8 @@ class TensorFusionService(object):
             if not self._executor.is_alive(w):
                 logger.warning('TensorFusionService: cleaning up dead worker %s (%s)' %
                             (w.device_uuid, WorkerExecutor.worker_label(w)))
-                self._remove_worker_state(w)
-                cleaned.append(w.device_uuid)
+                if self._remove_worker_state(w) is not None:
+                    cleaned.append(w.device_uuid)
         if cleaned:
             logger.info('TensorFusionService: cleaned up %d dead workers' % len(cleaned))
         return cleaned

--- a/kvmagent/kvmagent/plugins/tensorfusion/service.py
+++ b/kvmagent/kvmagent/plugins/tensorfusion/service.py
@@ -142,9 +142,8 @@ class TensorFusionService(object):
     def _scan_and_cleanup_orphans(self):
         """Reconcile running workers against libvirt VM state.
 
-        Scans ALL running tensor-fusion-workers (regardless of whether
-        they are tracked in StateStore) and kills any whose VM no longer exists
-        in libvirt.  Also cleans up stale StateStore entries for dead workers.
+        Kills workers only when their VM is confirmed not running, and cleans
+        stale StateStore entries for runtimes that are confirmed dead.
         """
         try:
             running = self._executor.scan_running()
@@ -152,7 +151,6 @@ class TensorFusionService(object):
             logger.warning('TensorFusionService: orphan scan: failed to scan running workers: %s' % e)
             return
 
-        running_device_uuids = {w.device_uuid for w in running}
         killed = 0
 
         for w in running:
@@ -163,7 +161,12 @@ class TensorFusionService(object):
             tracked = None
             try:
                 with gpu_operation_gate.critical():
-                    tracked = self._store.get(w.device_uuid)
+                    current = self._store.get(w.device_uuid)
+                    if current and self._is_same_worker_runtime(w, current):
+                        tracked = self._store.set_restarting(
+                            w.device_uuid, True, expected_worker=current)
+                        if tracked is not None:
+                            self._monitor.clear(w.device_uuid)
                     logger.warning('TensorFusionService: orphan scan: killing worker %s '
                                 '(%s, vm=%s not running, tracked=%s)' %
                                 (w.device_uuid, WorkerExecutor.worker_label(w), w.vm_uuid,
@@ -173,17 +176,20 @@ class TensorFusionService(object):
                 logger.warning('TensorFusionService: orphan scan: failed to stop worker %s: %s' %
                             (w.device_uuid, e))
                 if self._executor.is_alive(w):
+                    if tracked is not None:
+                        self._store.set_restarting(w.device_uuid, False, expected_worker=tracked)
                     continue
-
-            # Clean up StateStore entry if present
-            if (tracked and self._is_same_worker_runtime(w, tracked) and
-                    self._remove_worker_state(tracked) is None):
-                continue
+                if tracked is not None and self._remove_worker_state(tracked) is None:
+                    self._store.set_restarting(w.device_uuid, False, expected_worker=tracked)
+                    continue
+            else:
+                if tracked is not None:
+                    self._finalize_worker_state(tracked)
             killed += 1
 
         # Clean up stale StateStore entries whose workers are already dead
         for w in self._store.list_all():
-            if w.device_uuid not in running_device_uuids:
+            if not any(self._is_same_worker_runtime(w, current) for current in running):
                 if not self._executor.is_alive(w):
                     logger.info('TensorFusionService: orphan scan: removing stale entry %s '
                                 '(%s already dead)' % (w.device_uuid, WorkerExecutor.worker_label(w)))
@@ -210,6 +216,10 @@ class TensorFusionService(object):
                             worker.device_uuid)
                 return None
 
+            return self._finalize_worker_state(worker)
+
+    def _finalize_worker_state(self, worker):
+        with gpu_operation_gate.critical():
             removed = self._store.remove(worker.device_uuid, expected_worker=worker)
             if removed is None:
                 logger.info('TensorFusionService: worker %s changed before state cleanup, skipping stale cleanup' %
@@ -279,6 +289,20 @@ class TensorFusionService(object):
         with gpu_operation_gate.critical():
             self._executor.stop(worker)
 
+    def _start_worker_runtime(self, request):
+        with gpu_operation_gate.critical():
+            try:
+                return self._executor.start(request)
+            except Exception:
+                try:
+                    known_workers = self._store.list_by_vm(request.vm_uuid)
+                    self._executor.cleanup_residual_workers_by_vm(
+                        request.vm_uuid, known_workers=known_workers)
+                except Exception as cleanup_error:
+                    logger.warning('TensorFusionService: failed to reconcile residual worker for VM %s '
+                                'after start failure: %s' % (request.vm_uuid, cleanup_error))
+                raise
+
     def _reap_dead_worker_runtime(self, worker):
         with gpu_operation_gate.critical():
             return self._executor.reap_dead(worker)
@@ -316,7 +340,7 @@ class TensorFusionService(object):
                 raise Exception('insufficient GPU memory on %s: requested %dMB, available %dMB' %
                                 (pci, request.memory_mb, avail))
 
-            worker = self._executor.start(request)
+            worker = self._start_worker_runtime(request)
             try:
                 self._store.add(worker)
                 self._tracker.allocate(pci, worker.device_uuid, worker.allocated_memory_mb)
@@ -377,7 +401,7 @@ class TensorFusionService(object):
             if existing is not current_worker:
                 return None
 
-            new_worker = self._executor.start(req)
+            new_worker = self._start_worker_runtime(req)
             new_worker.restarting = False
             replaced = self._store.replace(new_worker, expected_worker=current_worker)
             if replaced is None:
@@ -440,15 +464,16 @@ class TensorFusionService(object):
             except Exception:
                 if self._executor.is_alive(worker):
                     self._store.set_restarting(device_uuid, False, expected_worker=worker)
+                    raise
                 else:
                     removed = self._remove_worker_state(worker)
                     if removed is None:
                         self._store.set_restarting(device_uuid, False, expected_worker=worker)
                         logger.warning('TensorFusionService: worker %s changed during destroy after stop failure' %
                                     device_uuid)
-                raise
-
-            removed = self._remove_worker_state(worker)
+                        raise
+            else:
+                removed = self._finalize_worker_state(worker)
             if removed is None:
                 self._store.set_restarting(device_uuid, False, expected_worker=worker)
                 logger.warning('TensorFusionService: worker %s changed during destroy, refusing success' %

--- a/kvmagent/kvmagent/test/test_host_plugin.py
+++ b/kvmagent/kvmagent/test/test_host_plugin.py
@@ -88,6 +88,16 @@ class TestHostPluginVirtStatusFallback(unittest.TestCase):
         self.assertEqual(to.virtStatus, "UNVIRTUALIZABLE")
         self.assertEqual(to.virtState, "UNVIRTUALIZABLE")
 
+    def test_nvidia_audio_function_skips_legacy_vfio_probe(self):
+        plugin = host_plugin.HostPlugin()
+        to = self._make_to()
+        to.pciDeviceAddress = "0000:1d:00.1"
+        to.vendor = host_plugin.VendorEnum.NVIDIA
+        to.type = "Audio_Controller"
+        with mock.patch.object(host_plugin, 'bash_roe') as bash_roe:
+            self.assertFalse(plugin._get_vfio_mdev_info(to))
+        bash_roe.assert_not_called()
+
     def test_fallback_both_supported_virtualizable(self):
         """No virtStatus, both supported -> VFIO_MDEV_VIRTUALIZABLE."""
         plugin = host_plugin.HostPlugin()

--- a/kvmagent/kvmagent/test/test_tensorfusion.py
+++ b/kvmagent/kvmagent/test/test_tensorfusion.py
@@ -4,6 +4,8 @@ Unit tests for TensorFusion plugin components.
 Run: python -m pytest kvmagent/kvmagent/test/test_tensorfusion.py -v
 '''
 
+import errno
+import json
 import os
 import re
 import sys
@@ -12,6 +14,7 @@ import time
 import types
 import unittest
 import importlib
+from contextlib import contextmanager
 
 try:
     import builtins
@@ -90,6 +93,17 @@ class _MockNVIDIA(object):
 
 _mock_nvidia_mod.NVIDIA = _MockNVIDIA
 
+_mock_operation_gate_mod = types.ModuleType('zstacklib.gpu.operation_gate')
+
+
+class _MockGPUOperationGate(object):
+    @contextmanager
+    def critical(self):
+        yield
+
+
+_mock_operation_gate_mod.gpu_operation_gate = _MockGPUOperationGate()
+
 def _build_mock_modules():
     zstacklib_mod = types.ModuleType('zstacklib')
     zstacklib_utils_mod = types.ModuleType('zstacklib.utils')
@@ -112,6 +126,7 @@ def _build_mock_modules():
         'zstacklib.gpu': zstacklib_gpu_mod,
         'zstacklib.gpu.vendors': zstacklib_gpu_vendors_mod,
         'zstacklib.gpu.vendors.nvidia': _mock_nvidia_mod,
+        'zstacklib.gpu.operation_gate': _mock_operation_gate_mod,
         'libvirt': libvirt_mod,
     }
 
@@ -122,6 +137,7 @@ def _preload_tensorfusion_modules():
         importlib.import_module('kvmagent.plugins.tensorfusion.store')
         importlib.import_module('kvmagent.plugins.tensorfusion.tracker')
         importlib.import_module('kvmagent.plugins.tensorfusion.process_executor')
+        importlib.import_module('kvmagent.plugins.tensorfusion.container_executor')
         importlib.import_module('kvmagent.plugins.tensorfusion.monitor')
         importlib.import_module('kvmagent.plugins.tensorfusion.utils')
         importlib.import_module('kvmagent.plugins.tensorfusion.service')
@@ -172,6 +188,17 @@ def _make_gpu_details():
             'driver_version': '535.129.03',
         },
     }
+
+
+def _new_real_gpu_operation_gate():
+    module_path = os.path.abspath(os.path.join(
+        os.path.dirname(__file__), '..', '..', '..',
+        'zstacklib', 'zstacklib', 'gpu', 'operation_gate.py'))
+    spec = importlib.util.spec_from_file_location(
+        '_tensorfusion_test_operation_gate', module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.GPUOperationGate()
 
 
 # =============================================================================
@@ -1044,6 +1071,730 @@ class TestTensorFusionService(unittest.TestCase):
         mock_executor.start.assert_not_called()
 
 
+class TestTensorFusionGPUOperationGate(unittest.TestCase):
+
+    def _assert_monitoring_blocked(self, gate):
+        with gate.monitoring() as acquired:
+            self.assertFalse(acquired)
+
+    @contextmanager
+    def _service_with_gate(self, executor, gate):
+        from kvmagent.plugins.tensorfusion import service as service_module
+
+        with mock.patch.object(service_module, 'gpu_operation_gate', gate), \
+                mock.patch.object(service_module.NVIDIA, 'query_gpu_details',
+                                  return_value=_make_gpu_details()):
+            yield service_module.TensorFusionService(executor=executor)
+
+    def test_destroy_serializes_stop_and_reap(self):
+        gate = _new_real_gpu_operation_gate()
+        executor = mock.MagicMock()
+        worker = _make_worker()
+        events = []
+
+        def _record_teardown(name):
+            self._assert_monitoring_blocked(gate)
+            events.append(name)
+
+        executor.stop.side_effect = lambda _worker: _record_teardown('stop')
+        executor.reap_dead.side_effect = lambda _worker: _record_teardown('reap')
+
+        with self._service_with_gate(executor, gate) as service:
+            service._store.add(worker)
+            service._tracker.allocate(
+                worker.pci_address, worker.device_uuid, worker.allocated_memory_mb)
+            service._tracker.release = mock.MagicMock(
+                side_effect=lambda _pci, _device: _record_teardown('release'))
+            self.assertTrue(service.destroy_worker(worker.device_uuid))
+
+        self.assertEqual(['stop', 'reap', 'release'], events)
+
+    def test_remove_state_preserves_worker_when_reap_reports_running(self):
+        gate = _new_real_gpu_operation_gate()
+        executor = mock.MagicMock()
+        executor.reap_dead.return_value = False
+        worker = _make_worker()
+
+        with self._service_with_gate(executor, gate) as service:
+            service._store.add(worker)
+            service._tracker.allocate(
+                worker.pci_address, worker.device_uuid, worker.allocated_memory_mb)
+            self.assertIsNone(service._remove_worker_state(worker))
+
+            self.assertIs(worker, service._store.get(worker.device_uuid))
+            self.assertEqual(
+                worker.allocated_memory_mb,
+                service.get_gpu_usage(worker.pci_address).allocated_memory_mb)
+
+    def test_destroy_restores_monitoring_when_reap_reports_running(self):
+        gate = _new_real_gpu_operation_gate()
+        executor = mock.MagicMock()
+        executor.reap_dead.return_value = False
+        worker = _make_worker()
+
+        with self._service_with_gate(executor, gate) as service:
+            service._store.add(worker)
+            service._tracker.allocate(
+                worker.pci_address, worker.device_uuid, worker.allocated_memory_mb)
+            self.assertFalse(service.destroy_worker(worker.device_uuid))
+
+            self.assertIs(worker, service._store.get(worker.device_uuid))
+            self.assertFalse(worker.restarting)
+
+    def test_initialize_and_periodic_orphan_stop_are_serialized(self):
+        gate = _new_real_gpu_operation_gate()
+        executor = mock.MagicMock()
+        initialized_orphan = _make_worker(device_uuid='init-orphan')
+        periodic_orphan = _make_worker(device_uuid='periodic-orphan')
+        executor.scan_running.side_effect = [[initialized_orphan], [periodic_orphan]]
+        stopped = []
+
+        def _stop(worker):
+            self._assert_monitoring_blocked(gate)
+            stopped.append(worker.device_uuid)
+
+        executor.stop.side_effect = _stop
+
+        with self._service_with_gate(executor, gate) as service, \
+                mock.patch('kvmagent.plugins.tensorfusion.service._is_vm_running',
+                           return_value=False), \
+                mock.patch.object(service._monitor, 'start'), \
+                mock.patch.object(service, '_start_orphan_scan_timer'):
+            service.initialize()
+            service._scan_and_cleanup_orphans()
+
+        self.assertEqual(['init-orphan', 'periodic-orphan'], stopped)
+
+    def test_orphan_scan_does_not_remove_replaced_runtime(self):
+        gate = _new_real_gpu_operation_gate()
+        executor = mock.MagicMock()
+        scanned = _make_worker(device_uuid='dev-orphan')
+        scanned.container_id = 'old-container-id'
+        replacement = _make_worker(device_uuid='dev-orphan', pid=4321)
+        replacement.container_id = 'new-container-id'
+        executor.scan_running.return_value = [scanned]
+
+        with self._service_with_gate(executor, gate) as service:
+            service._store.add(scanned)
+
+            def _replace_during_stop(_worker):
+                self._assert_monitoring_blocked(gate)
+                service._store.remove(scanned.device_uuid,
+                                      expected_worker=scanned)
+                service._store.add(replacement)
+
+            executor.stop.side_effect = _replace_during_stop
+            with mock.patch(
+                    'kvmagent.plugins.tensorfusion.service._is_vm_running',
+                    return_value=False):
+                service._scan_and_cleanup_orphans()
+
+            self.assertIs(replacement, service._store.get(scanned.device_uuid))
+            executor.reap_dead.assert_not_called()
+
+    def test_residual_cleanup_is_serialized(self):
+        gate = _new_real_gpu_operation_gate()
+        executor = mock.MagicMock()
+
+        def _cleanup(_vm_uuid, known_workers=None):
+            self._assert_monitoring_blocked(gate)
+            self.assertEqual([], known_workers)
+            return 1
+
+        executor.cleanup_residual_workers_by_vm.side_effect = _cleanup
+
+        with self._service_with_gate(executor, gate) as service:
+            self.assertEqual(1, service.destroy_workers_by_vm('vm-001'))
+
+    def test_docker_timeout_releases_gate_after_bounded_reap(self):
+        import subprocess
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        gate = _new_real_gpu_operation_gate()
+        executor = ContainerExecutor(_make_gpu_details())
+        proc = mock.MagicMock()
+        proc.communicate.side_effect = subprocess.TimeoutExpired(
+            ['docker', 'run'], 30)
+        proc.kill.side_effect = RuntimeError('kill failed')
+        wait_started = threading.Event()
+        release_wait = threading.Event()
+        wait_timeouts = []
+        errors = []
+
+        def _wait(timeout=None):
+            wait_timeouts.append(timeout)
+            wait_started.set()
+            release_wait.wait(1)
+            raise subprocess.TimeoutExpired(['docker', 'run'], timeout)
+
+        def _run():
+            try:
+                with gate.critical():
+                    executor._docker(['run'], timeout=30)
+            except Exception as e:
+                errors.append(e)
+
+        proc.wait.side_effect = _wait
+        with mock.patch(
+                'kvmagent.plugins.tensorfusion.container_executor.subprocess.Popen',
+                return_value=proc):
+            thread = threading.Thread(target=_run)
+            thread.start()
+            self.assertTrue(wait_started.wait(1))
+            self._assert_monitoring_blocked(gate)
+            release_wait.set()
+            thread.join(1)
+
+        self.assertFalse(thread.is_alive())
+        self.assertEqual([5], wait_timeouts)
+        self.assertEqual(1, len(errors))
+        with gate.monitoring() as acquired:
+            self.assertTrue(acquired)
+
+    def test_monitor_serializes_reap_and_releases_gate_before_restart(self):
+        from kvmagent.plugins.tensorfusion import monitor as monitor_module
+
+        gate = _new_real_gpu_operation_gate()
+        executor = mock.MagicMock()
+        store = StateStore()
+        tracker = mock.MagicMock()
+        worker = _make_worker()
+        restarted = _make_worker(pid=4321)
+        events = []
+        store.add(worker)
+
+        def _reap(_worker):
+            self._assert_monitoring_blocked(gate)
+            events.append('reap')
+
+        def _restart(_worker):
+            with gate.monitoring() as acquired:
+                self.assertTrue(acquired)
+            events.append('restart')
+            return restarted
+
+        executor.reap_dead.side_effect = _reap
+        monitor = monitor_module.WorkerRestartMonitor(
+            store, executor, tracker, restart_worker=_restart)
+        store.set_restarting(worker.device_uuid, True, expected_worker=worker)
+
+        with mock.patch.object(monitor_module, 'gpu_operation_gate', gate), \
+                mock.patch('kvmagent.plugins.tensorfusion.utils.is_vm_running',
+                           return_value=True):
+            monitor._do_restart(worker, 0)
+            monitor._give_up(worker)
+
+        self.assertEqual(['reap', 'restart', 'reap'], events)
+        tracker.release.assert_called_once_with(worker.pci_address, worker.device_uuid)
+
+    def test_monitor_preserves_worker_when_reap_reports_running(self):
+        from kvmagent.plugins.tensorfusion import monitor as monitor_module
+
+        gate = _new_real_gpu_operation_gate()
+        executor = mock.MagicMock()
+        executor.reap_dead.return_value = False
+        restart = mock.MagicMock()
+        store = StateStore()
+        tracker = mock.MagicMock()
+        worker = _make_worker()
+        store.add(worker)
+        monitor = monitor_module.WorkerRestartMonitor(
+            store, executor, tracker, restart_worker=restart)
+        store.set_restarting(worker.device_uuid, True, expected_worker=worker)
+
+        with mock.patch.object(monitor_module, 'gpu_operation_gate', gate), \
+                mock.patch('kvmagent.plugins.tensorfusion.utils.is_vm_running',
+                           return_value=True):
+            monitor._do_restart(worker, 0)
+            self.assertIs(worker, store.get(worker.device_uuid))
+            self.assertFalse(worker.restarting)
+            restart.assert_not_called()
+
+            store.set_restarting(worker.device_uuid, True, expected_worker=worker)
+            self.assertFalse(monitor._give_up(worker))
+
+        self.assertIs(worker, store.get(worker.device_uuid))
+        self.assertFalse(worker.restarting)
+        tracker.release.assert_not_called()
+
+
+class TestContainerExecutor(unittest.TestCase):
+
+    @staticmethod
+    def _make_request(protocol='shmem'):
+        request = WorkerCreateRequest()
+        request.vm_uuid = 'vm-001'
+        request.pci_address = '0000:3b:00.0'
+        request.memory_mb = 8192
+        request.shmem_size = 268435456
+        request.license = TEST_LICENSE
+        request.license_sign = TEST_LICENSE_SIGN
+        request.device_uuid = 'dev-001'
+        request.sm_percent_limit = 33
+        request.protocol = protocol
+        return request
+
+    def test_start_uses_extended_docker_run_timeout(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        executor = ContainerExecutor(_make_gpu_details())
+        with mock.patch.object(executor, '_image_exists', return_value=True), \
+                mock.patch.object(executor, '_docker_quiet'), \
+                mock.patch.object(executor, '_inspect_container', return_value={'State': {'Running': True}}), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove'), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.path.getsize',
+                           return_value=268435456), \
+                mock.patch.object(executor, '_docker', return_value='container-id') as mock_docker:
+            worker = executor.start(self._make_request())
+
+        self.assertEqual('container-id', worker.container_id)
+        self.assertEqual(90, mock_docker.call_args[1]['timeout'])
+        run_cmd = mock_docker.call_args[0][0]
+        docker_env = mock_docker.call_args[1]['env']
+        self.assertIn('TF_LICENSE', run_cmd)
+        self.assertIn('TF_LICENSE_SIGN', run_cmd)
+        self.assertNotIn(TEST_LICENSE, ' '.join(run_cmd))
+        self.assertNotIn(TEST_LICENSE_SIGN, ' '.join(run_cmd))
+        self.assertEqual(TEST_LICENSE, docker_env['TF_LICENSE'])
+        self.assertEqual(TEST_LICENSE_SIGN, docker_env['TF_LICENSE_SIGN'])
+
+    def test_start_waits_for_shared_memory_readiness(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        executor = ContainerExecutor(_make_gpu_details())
+        with mock.patch.object(executor, '_image_exists', return_value=True), \
+                mock.patch.object(executor, '_docker_quiet'), \
+                mock.patch.object(executor, '_inspect_container', return_value={'State': {'Running': True}}), \
+                mock.patch.object(executor, '_docker', return_value='container-id'), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove'), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.path.getsize',
+                           side_effect=[OSError(), 0, 268435456, 268435456]), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.time.sleep') as mock_sleep:
+            worker = executor.start(self._make_request())
+
+        self.assertEqual('/dev/shm/tf_dev-001', worker.shared_memory_path)
+        self.assertEqual(2, mock_sleep.call_count)
+
+    def test_start_removes_stale_shared_memory_before_docker_run(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        events = []
+        executor = ContainerExecutor(_make_gpu_details())
+
+        def remove_shm(path):
+            events.append(('remove_shm', path))
+
+        def docker_run(args, timeout=None, env=None):
+            events.append(('docker_run', args[0], timeout, env))
+            return 'container-id'
+
+        with mock.patch.object(executor, '_image_exists', return_value=True), \
+                mock.patch.object(executor, '_docker_quiet'), \
+                mock.patch.object(executor, '_inspect_container', return_value={'State': {'Running': True}}), \
+                mock.patch.object(executor, '_docker', side_effect=docker_run), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove', side_effect=remove_shm), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.path.getsize',
+                           return_value=268435456):
+            executor.start(self._make_request())
+
+        self.assertEqual(('docker_run', 'rm', None, None), events[0])
+        self.assertEqual(('remove_shm', '/dev/shm/tf_dev-001'), events[1])
+        self.assertEqual('docker_run', events[2][0])
+        self.assertEqual('run', events[2][1])
+        self.assertEqual(90, events[2][2])
+        self.assertEqual(TEST_LICENSE, events[2][3]['TF_LICENSE'])
+
+    def test_native_start_does_not_wait_for_shared_memory(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        executor = ContainerExecutor(_make_gpu_details())
+        with mock.patch.object(executor, '_image_exists', return_value=True), \
+                mock.patch.object(executor, '_docker_quiet'), \
+                mock.patch.object(executor, '_inspect_container', return_value={'State': {'Running': True}}), \
+                mock.patch.object(executor, '_docker', return_value='container-id'), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove'), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.path.getsize') as mock_getsize:
+            worker = executor.start(self._make_request(protocol='native'))
+
+        self.assertEqual('native', worker.protocol)
+        mock_getsize.assert_not_called()
+
+    def test_shared_memory_timeout_cleans_container_and_file(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        executor = ContainerExecutor(_make_gpu_details())
+        executor.STARTUP_WAIT_SEC = 0
+        missing = OSError(2, 'No such file')
+        with mock.patch.object(executor, '_image_exists', return_value=True), \
+                mock.patch.object(executor, '_docker_quiet', return_value='') as mock_quiet, \
+                mock.patch.object(executor, '_inspect_container', return_value={'State': {'Running': True}}), \
+                mock.patch.object(executor, '_docker', return_value='container-id') as mock_docker, \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.path.getsize',
+                           side_effect=missing), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove',
+                           side_effect=[missing, None]) as mock_remove:
+            with self.assertRaises(Exception) as ctx:
+                executor.start(self._make_request())
+
+        self.assertIn('did not create shared memory', str(ctx.exception))
+        self.assertEqual(2, sum(
+            1 for call in mock_docker.call_args_list
+            if call[0][0] == ['rm', '-f', 'tf-worker-vm-001']))
+        mock_quiet.assert_called_once_with(['logs', '--tail', '20', 'tf-worker-vm-001'])
+        mock_remove.assert_has_calls([
+            mock.call('/dev/shm/tf_dev-001'),
+            mock.call('/dev/shm/tf_dev-001'),
+        ])
+
+    def test_first_inspect_failure_cleans_container_and_shared_memory(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        executor = ContainerExecutor(_make_gpu_details())
+
+        def docker_command(args, timeout=None, env=None):
+            if args[0] == 'run':
+                return 'container-id'
+            if args[:2] == ['rm', '-f']:
+                return args[2]
+            raise AssertionError('unexpected docker command: %s' % args)
+
+        with mock.patch.object(executor, '_image_exists', return_value=True), \
+                mock.patch.object(executor, '_docker_quiet'), \
+                mock.patch.object(executor, '_inspect_container', return_value=None), \
+                mock.patch.object(executor, '_docker', side_effect=docker_command), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove') as mock_remove:
+            with self.assertRaises(Exception) as ctx:
+                executor.start(self._make_request())
+
+        self.assertIn('inspect failed', str(ctx.exception))
+        self.assertEqual([
+            mock.call('/dev/shm/tf_dev-001'),
+            mock.call('/dev/shm/tf_dev-001'),
+        ], mock_remove.call_args_list)
+
+    def test_immediate_exit_cleans_container_and_shared_memory(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        executor = ContainerExecutor(_make_gpu_details())
+
+        def docker_command(args, timeout=None, env=None):
+            if args[0] == 'run':
+                return 'container-id'
+            if args[:2] == ['rm', '-f']:
+                return args[2]
+            raise AssertionError('unexpected docker command: %s' % args)
+
+        with mock.patch.object(executor, '_image_exists', return_value=True), \
+                mock.patch.object(executor, '_docker_quiet', return_value='worker failed'), \
+                mock.patch.object(executor, '_inspect_container', return_value={
+                    'State': {'Running': False, 'ExitCode': 1},
+                }), \
+                mock.patch.object(executor, '_docker', side_effect=docker_command), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.path.isfile',
+                           return_value=False), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove') as mock_remove:
+            with self.assertRaises(Exception) as ctx:
+                executor.start(self._make_request())
+
+        self.assertIn('exited immediately', str(ctx.exception))
+        self.assertEqual([
+            mock.call('/dev/shm/tf_dev-001'),
+            mock.call('/dev/shm/tf_dev-001'),
+        ], mock_remove.call_args_list)
+
+    def test_docker_run_failure_cleans_container_and_shared_memory(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        executor = ContainerExecutor(_make_gpu_details())
+        remove_attempts = []
+
+        def docker_command(args, timeout=None, env=None):
+            if args[0] == 'run':
+                raise Exception('launch rejected %s' % TEST_LICENSE)
+            remove_attempts.append(args)
+            return args[2]
+
+        with mock.patch.object(executor, '_image_exists', return_value=True), \
+                mock.patch.object(executor, '_docker', side_effect=docker_command), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove') as mock_remove:
+            with self.assertRaises(Exception) as ctx:
+                executor.start(self._make_request())
+
+        self.assertNotIn(TEST_LICENSE, str(ctx.exception))
+        self.assertIsNone(ctx.exception.__context__)
+        self.assertEqual(2, len(remove_attempts))
+        self.assertEqual([
+            mock.call('/dev/shm/tf_dev-001'),
+            mock.call('/dev/shm/tf_dev-001'),
+        ], mock_remove.call_args_list)
+
+    def test_stale_container_removal_failure_blocks_start_and_retains_shared_memory(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        executor = ContainerExecutor(_make_gpu_details())
+        with mock.patch.object(executor, '_image_exists', return_value=True), \
+                mock.patch.object(executor, '_docker', side_effect=Exception('docker unavailable')) as mock_docker, \
+                mock.patch.object(executor, '_inspect_container',
+                                  return_value={'State': {'Running': True}}), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove') as mock_remove:
+            with self.assertRaises(Exception) as ctx:
+                executor.start(self._make_request())
+
+        self.assertIn('failed to remove existing worker container', str(ctx.exception))
+        mock_docker.assert_called_once_with(['rm', '-f', 'tf-worker-vm-001'])
+        mock_remove.assert_not_called()
+
+    def test_failed_start_retains_shared_memory_when_container_may_be_running(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        executor = ContainerExecutor(_make_gpu_details())
+        remove_attempts = []
+
+        def docker_command(args, timeout=None, env=None):
+            if args[0] == 'run':
+                return 'container-id'
+            remove_attempts.append(args)
+            if len(remove_attempts) == 1:
+                return args[2]
+            raise Exception('docker daemon unavailable')
+
+        with mock.patch.object(executor, '_image_exists', return_value=True), \
+                mock.patch.object(executor, '_docker_quiet'), \
+                mock.patch.object(executor, '_inspect_container',
+                                  side_effect=[None, {'State': {'Running': True}}]), \
+                mock.patch.object(executor, '_docker', side_effect=docker_command), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove') as mock_remove:
+            with self.assertRaises(Exception):
+                executor.start(self._make_request())
+
+        mock_remove.assert_called_once_with('/dev/shm/tf_dev-001')
+
+    def test_reap_dead_removes_shared_memory(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        worker = _make_worker()
+        worker.container_id = 'container-id'
+        worker.container_name = 'tf-worker-vm-001'
+        worker.shared_memory_path = '/dev/shm/tf_dev-001'
+        executor = ContainerExecutor(_make_gpu_details())
+
+        with mock.patch.object(executor, '_docker') as mock_docker, \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove') as mock_remove:
+            executor.reap_dead(worker)
+
+        mock_docker.assert_called_once_with(['rm', '-f', 'container-id'])
+        mock_remove.assert_called_once_with('/dev/shm/tf_dev-001')
+
+    def test_stop_raises_and_retains_shared_memory_when_removal_is_unconfirmed(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        worker = _make_worker()
+        worker.container_id = 'container-id'
+        worker.container_name = 'tf-worker-vm-001'
+        worker.shared_memory_path = '/dev/shm/tf_dev-001'
+        executor = ContainerExecutor(_make_gpu_details())
+
+        with mock.patch.object(executor, '_docker', side_effect=Exception('docker unavailable')), \
+                mock.patch.object(executor, '_inspect_container',
+                                  return_value={'State': {'Running': True}}), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove') as mock_remove:
+            with self.assertRaises(Exception) as ctx:
+                executor.stop(worker)
+
+        self.assertIn('failed to remove worker container', str(ctx.exception))
+        mock_remove.assert_not_called()
+
+    def test_stop_targets_container_id_before_reusable_name(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        worker = _make_worker()
+        worker.container_id = 'old-container-id'
+        worker.container_name = 'tf-worker-vm-001'
+        worker.shared_memory_path = '/dev/shm/tf_dev-001'
+        executor = ContainerExecutor(_make_gpu_details())
+
+        with mock.patch.object(executor, '_docker', return_value='') as mock_docker, \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove'):
+            executor.stop(worker)
+
+        self.assertEqual([
+            mock.call(['stop', '-t', '5', 'old-container-id']),
+            mock.call(['rm', '-f', 'old-container-id']),
+        ], mock_docker.call_args_list)
+
+    def test_stopped_container_retains_shared_memory_when_removal_is_unconfirmed(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        executor = ContainerExecutor(_make_gpu_details())
+        with mock.patch.object(executor, '_docker',
+                               side_effect=Exception('permission denied')), \
+                mock.patch.object(executor, '_inspect_container') as mock_inspect, \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove') as mock_remove:
+            removed = executor._remove_container_and_shared_memory(
+                'container-id', '/dev/shm/tf_dev-001')
+
+        self.assertFalse(removed)
+        mock_inspect.assert_not_called()
+        mock_remove.assert_not_called()
+
+    def test_command_for_log_masks_license_values(self):
+        from kvmagent.plugins.tensorfusion.container_executor import _command_for_log, _redact_sensitive_values
+
+        args = [
+            'docker', 'run',
+            '-e', 'TF_LICENSE=secret-license',
+            '-e', 'TF_LICENSE_SIGN=secret-signature',
+            '-e', 'TF_GPU_MEMORY_LIMIT=8192',
+            'tf-worker:latest',
+        ]
+        command = _command_for_log(args)
+        stderr = _redact_sensitive_values(
+            'invalid secret-license and secret-signature', args)
+        overlapping = _redact_sensitive_values(
+            'prefix-and-prefix-suffix',
+            ['TF_LICENSE=prefix', 'TF_LICENSE_SIGN=prefix-suffix'])
+
+        self.assertNotIn('secret-license', command)
+        self.assertNotIn('secret-signature', command)
+        self.assertNotIn('secret-license', stderr)
+        self.assertNotIn('secret-signature', stderr)
+        self.assertEqual('*****-and-*****', overlapping)
+        self.assertIn('TF_LICENSE=*****', command)
+        self.assertIn('TF_LICENSE_SIGN=*****', command)
+        self.assertIn('TF_GPU_MEMORY_LIMIT=8192', command)
+
+    @mock.patch('kvmagent.plugins.tensorfusion.container_executor.subprocess.Popen')
+    def test_timeout_error_has_no_sensitive_context(self, mock_popen):
+        import subprocess
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        proc = mock_popen.return_value
+        proc.communicate.side_effect = subprocess.TimeoutExpired(
+            ['docker', 'run', '-e', 'TF_LICENSE'], 30)
+        proc.kill.side_effect = RuntimeError('kill failed')
+        proc.wait.side_effect = RuntimeError('wait failed')
+
+        executor = ContainerExecutor(_make_gpu_details())
+        with self.assertRaises(Exception) as ctx:
+            executor._docker(
+                ['run', '-e', 'TF_LICENSE'], timeout=30,
+                env={'TF_LICENSE': 'secret-license'})
+
+        self.assertNotIn('secret-license', str(ctx.exception))
+        self.assertIsNone(ctx.exception.__context__)
+        proc.kill.assert_called_once_with()
+        proc.wait.assert_called_once_with(timeout=5)
+        self.assertNotIn('secret-license', ' '.join(mock_popen.call_args[0][0]))
+        self.assertEqual(
+            'secret-license', mock_popen.call_args[1]['env']['TF_LICENSE'])
+
+    @mock.patch('kvmagent.plugins.tensorfusion.container_executor.subprocess.Popen')
+    def test_nonzero_error_redacts_command_and_stderr(self, mock_popen):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        proc = mock_popen.return_value
+        proc.communicate.return_value = (b'', b'invalid secret-license')
+        proc.returncode = 1
+
+        executor = ContainerExecutor(_make_gpu_details())
+        with self.assertRaises(Exception) as ctx:
+            executor._docker(
+                ['run', '-e', 'TF_LICENSE'],
+                env={'TF_LICENSE': 'secret-license'})
+
+        self.assertNotIn('secret-license', str(ctx.exception))
+        self.assertNotIn('secret-license', ' '.join(mock_popen.call_args[0][0]))
+        self.assertEqual(
+            'secret-license', mock_popen.call_args[1]['env']['TF_LICENSE'])
+
+    @mock.patch('kvmagent.plugins.tensorfusion.container_executor.subprocess.Popen')
+    def test_docker_env_does_not_mutate_process_environment(self, mock_popen):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        proc = mock_popen.return_value
+        proc.communicate.return_value = (b'container-id', b'')
+        proc.returncode = 0
+        executor = ContainerExecutor(_make_gpu_details())
+
+        with mock.patch.dict(os.environ, {'EXISTING': 'unchanged'}, clear=True):
+            result = executor._docker(
+                ['run', '-e', 'TF_LICENSE', '-e', 'TF_LICENSE_SIGN'],
+                env={
+                    'TF_LICENSE': 'secret-license',
+                    'TF_LICENSE_SIGN': 'secret-signature',
+                })
+            self.assertEqual({'EXISTING': 'unchanged'}, dict(os.environ))
+
+        self.assertEqual('container-id', result)
+        popen_cmd = mock_popen.call_args[0][0]
+        popen_env = mock_popen.call_args[1]['env']
+        self.assertNotIn('secret-license', ' '.join(popen_cmd))
+        self.assertNotIn('secret-signature', ' '.join(popen_cmd))
+        self.assertEqual('unchanged', popen_env['EXISTING'])
+        self.assertEqual('secret-license', popen_env['TF_LICENSE'])
+        self.assertEqual('secret-signature', popen_env['TF_LICENSE_SIGN'])
+
+    @mock.patch('kvmagent.plugins.tensorfusion.container_executor.subprocess.Popen')
+    def test_class_timeout_error_has_no_sensitive_context(self, mock_popen):
+        import subprocess
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        proc = mock_popen.return_value
+        proc.communicate.side_effect = subprocess.TimeoutExpired(
+            ['docker', 'run', '-e', 'TF_LICENSE'], 30)
+        proc.kill.side_effect = RuntimeError('kill failed')
+        proc.wait.side_effect = RuntimeError('wait failed')
+
+        with self.assertRaises(Exception) as ctx:
+            ContainerExecutor._docker_class(
+                ['run', '-e', 'TF_LICENSE'], timeout=30,
+                env={'TF_LICENSE': 'secret-license'})
+
+        self.assertNotIn('secret-license', str(ctx.exception))
+        self.assertIsNone(ctx.exception.__context__)
+        proc.kill.assert_called_once_with()
+        proc.wait.assert_called_once_with(timeout=5)
+
+
+class TestTensorFusionPluginSensitiveLogging(unittest.TestCase):
+
+    def test_create_worker_masks_request_and_error_credentials(self):
+        from zstacklib.utils import http, log
+        from kvmagent.plugins.tensorfusion import plugin as plugin_module
+
+        body = json.dumps({
+            'vmUuid': 'vm-test',
+            'pciAddress': '0000:3b:00.0',
+            'memoryMb': 8192,
+            'shmemSize': 268435456,
+            'license': 'secret-license',
+            'licenseSign': 'secret-signature',
+            'enableLog': False,
+            'logLevel': 'error',
+            'deviceUuid': 'dev-test',
+            'protocol': 'shmem',
+            'smPercentLimit': 33,
+        })
+        masked_request = log.mask_sensitive_field(plugin_module.CreateWorkerCmd(), body)
+
+        tensorfusion_plugin = plugin_module.TensorFusionPlugin()
+        tensorfusion_plugin._service = mock.MagicMock()
+        tensorfusion_plugin._service.create_worker.side_effect = Exception(
+            'failed secret-license / secret-signature')
+
+        with mock.patch.object(plugin_module, 'logger') as mock_logger:
+            response = tensorfusion_plugin.create_worker({http.REQUEST_BODY: body})
+
+        warning = mock_logger.warn.call_args[0][0]
+        self.assertNotIn('secret-license', masked_request)
+        self.assertNotIn('secret-signature', masked_request)
+        self.assertNotIn('secret-license', response)
+        self.assertNotIn('secret-signature', response)
+        self.assertNotIn('secret-license', warning)
+        self.assertNotIn('secret-signature', warning)
+        self.assertFalse(json.loads(response)['success'])
+
+
 class TestProcessExecutor(unittest.TestCase):
 
     def _import_without_psutil(self, name, *args, **kwargs):
@@ -1086,6 +1837,44 @@ class TestProcessExecutor(unittest.TestCase):
         proc.wait.assert_called_once_with()
         self.assertIsNone(executor._get_proc(5678))
         mock_killpg.assert_called_once_with(1234, mock.ANY)
+
+    def test_reap_dead_keeps_running_tracked_process(self):
+        from kvmagent.plugins.tensorfusion.process_executor import ProcessExecutor
+
+        proc = mock.MagicMock()
+        proc.pid = 5678
+        proc.poll.return_value = None
+        executor = ProcessExecutor(_make_gpu_details())
+        executor._track_proc(proc)
+
+        self.assertFalse(executor.reap_dead(_make_worker(pid=5678)))
+        proc.wait.assert_not_called()
+        self.assertIs(proc, executor._get_proc(5678))
+
+    @mock.patch('kvmagent.plugins.tensorfusion.process_executor.os.waitpid',
+                return_value=(0, 0))
+    def test_reap_dead_keeps_running_untracked_child(self, mock_waitpid):
+        from kvmagent.plugins.tensorfusion.process_executor import ProcessExecutor
+
+        executor = ProcessExecutor(_make_gpu_details())
+
+        self.assertFalse(executor.reap_dead(_make_worker(pid=5678)))
+        mock_waitpid.assert_called_once_with(5678, os.WNOHANG)
+
+    @mock.patch('kvmagent.plugins.tensorfusion.process_executor.os.waitpid',
+                side_effect=OSError(errno.ECHILD, 'not a child'))
+    @mock.patch('kvmagent.plugins.tensorfusion.process_executor.os.kill')
+    def test_reap_dead_accepts_untracked_zombie(self, mock_kill, mock_waitpid):
+        from kvmagent.plugins.tensorfusion.process_executor import ProcessExecutor
+
+        executor = ProcessExecutor(_make_gpu_details())
+        with mock.patch.object(executor, '_is_linux_zombie', return_value=True), \
+                mock.patch.object(executor, '_verify_worker_pid') as mock_verify:
+            self.assertTrue(executor.reap_dead(_make_worker(pid=5678)))
+
+        mock_waitpid.assert_called_once_with(5678, os.WNOHANG)
+        mock_kill.assert_called_once_with(5678, 0)
+        mock_verify.assert_not_called()
 
     @mock.patch('kvmagent.plugins.tensorfusion.process_executor.time.sleep')
     @mock.patch('kvmagent.plugins.tensorfusion.process_executor.time.time')

--- a/kvmagent/kvmagent/test/test_tensorfusion.py
+++ b/kvmagent/kvmagent/test/test_tensorfusion.py
@@ -132,6 +132,7 @@ def _build_mock_modules():
 
 
 def _preload_tensorfusion_modules():
+    loaded_modules = {}
     with mock.patch.dict(sys.modules, _build_mock_modules()):
         importlib.import_module('kvmagent.plugins.tensorfusion.models')
         importlib.import_module('kvmagent.plugins.tensorfusion.store')
@@ -141,6 +142,12 @@ def _preload_tensorfusion_modules():
         importlib.import_module('kvmagent.plugins.tensorfusion.monitor')
         importlib.import_module('kvmagent.plugins.tensorfusion.utils')
         importlib.import_module('kvmagent.plugins.tensorfusion.service')
+        loaded_modules.update({
+            name: module for name, module in sys.modules.items()
+            if name == 'kvmagent.plugins.tensorfusion' or
+            name.startswith('kvmagent.plugins.tensorfusion.')
+        })
+    sys.modules.update(loaded_modules)
 
 
 _preload_tensorfusion_modules()
@@ -764,7 +771,8 @@ class TestTensorFusionService(unittest.TestCase):
         count = svc.destroy_workers_by_vm('vm-001')
         self.assertEqual(count, 2)
         self.assertEqual(len(svc.list_workers()), 0)
-        mock_executor.cleanup_residual_workers_by_vm.assert_called_once_with('vm-001', known_pids=[1001, 1002])
+        mock_executor.cleanup_residual_workers_by_vm.assert_called_once_with(
+            'vm-001', known_workers=[])
 
     @mock.patch('kvmagent.plugins.tensorfusion.service.NVIDIA')
     @mock.patch('kvmagent.plugins.tensorfusion.service.ProcessExecutor')
@@ -818,7 +826,8 @@ class TestTensorFusionService(unittest.TestCase):
         count = svc.destroy_workers_by_vm('vm-001')
 
         self.assertEqual(1, count)
-        mock_executor.cleanup_residual_workers_by_vm.assert_called_once_with('vm-001', known_pids=[])
+        mock_executor.cleanup_residual_workers_by_vm.assert_called_once_with(
+            'vm-001', known_workers=[])
 
     @mock.patch('kvmagent.plugins.tensorfusion.service.NVIDIA')
     @mock.patch('kvmagent.plugins.tensorfusion.service.ProcessExecutor')
@@ -1086,7 +1095,7 @@ class TestTensorFusionGPUOperationGate(unittest.TestCase):
                                   return_value=_make_gpu_details()):
             yield service_module.TensorFusionService(executor=executor)
 
-    def test_destroy_serializes_stop_and_reap(self):
+    def test_destroy_serializes_stop_and_state_finalize(self):
         gate = _new_real_gpu_operation_gate()
         executor = mock.MagicMock()
         worker = _make_worker()
@@ -1097,7 +1106,6 @@ class TestTensorFusionGPUOperationGate(unittest.TestCase):
             events.append(name)
 
         executor.stop.side_effect = lambda _worker: _record_teardown('stop')
-        executor.reap_dead.side_effect = lambda _worker: _record_teardown('reap')
 
         with self._service_with_gate(executor, gate) as service:
             service._store.add(worker)
@@ -1107,7 +1115,8 @@ class TestTensorFusionGPUOperationGate(unittest.TestCase):
                 side_effect=lambda _pci, _device: _record_teardown('release'))
             self.assertTrue(service.destroy_worker(worker.device_uuid))
 
-        self.assertEqual(['stop', 'reap', 'release'], events)
+        self.assertEqual(['stop', 'release'], events)
+        executor.reap_dead.assert_not_called()
 
     def test_remove_state_preserves_worker_when_reap_reports_running(self):
         gate = _new_real_gpu_operation_gate()
@@ -1126,9 +1135,11 @@ class TestTensorFusionGPUOperationGate(unittest.TestCase):
                 worker.allocated_memory_mb,
                 service.get_gpu_usage(worker.pci_address).allocated_memory_mb)
 
-    def test_destroy_restores_monitoring_when_reap_reports_running(self):
+    def test_destroy_restores_monitoring_when_reap_rechecks_running(self):
         gate = _new_real_gpu_operation_gate()
         executor = mock.MagicMock()
+        executor.stop.side_effect = Exception('stop failed')
+        executor.is_alive.return_value = False
         executor.reap_dead.return_value = False
         worker = _make_worker()
 
@@ -1136,10 +1147,32 @@ class TestTensorFusionGPUOperationGate(unittest.TestCase):
             service._store.add(worker)
             service._tracker.allocate(
                 worker.pci_address, worker.device_uuid, worker.allocated_memory_mb)
-            self.assertFalse(service.destroy_worker(worker.device_uuid))
+            with self.assertRaises(Exception):
+                service.destroy_worker(worker.device_uuid)
 
             self.assertIs(worker, service._store.get(worker.device_uuid))
             self.assertFalse(worker.restarting)
+
+    def test_start_failure_reconciles_labeled_residual_under_gate(self):
+        gate = _new_real_gpu_operation_gate()
+        executor = mock.MagicMock()
+        executor.start.side_effect = Exception('start failed')
+        request = WorkerCreateRequest()
+        request.vm_uuid = 'vm-001'
+
+        def _cleanup(vm_uuid, known_workers=None):
+            self._assert_monitoring_blocked(gate)
+            self.assertEqual('vm-001', vm_uuid)
+            self.assertEqual([], known_workers)
+
+        executor.cleanup_residual_workers_by_vm.side_effect = _cleanup
+
+        with self._service_with_gate(executor, gate) as service:
+            with self.assertRaises(Exception):
+                service._start_worker_runtime(request)
+
+        executor.cleanup_residual_workers_by_vm.assert_called_once_with(
+            'vm-001', known_workers=[])
 
     def test_initialize_and_periodic_orphan_stop_are_serialized(self):
         gate = _new_real_gpu_operation_gate()
@@ -1287,8 +1320,9 @@ class TestTensorFusionGPUOperationGate(unittest.TestCase):
         self.assertEqual(['reap', 'restart', 'reap'], events)
         tracker.release.assert_called_once_with(worker.pci_address, worker.device_uuid)
 
-    def test_monitor_preserves_worker_when_reap_reports_running(self):
+    def test_monitor_clears_false_crash_episode_when_reap_reports_running(self):
         from kvmagent.plugins.tensorfusion import monitor as monitor_module
+        from kvmagent.plugins.tensorfusion.monitor import CrashState
 
         gate = _new_real_gpu_operation_gate()
         executor = mock.MagicMock()
@@ -1301,6 +1335,8 @@ class TestTensorFusionGPUOperationGate(unittest.TestCase):
         monitor = monitor_module.WorkerRestartMonitor(
             store, executor, tracker, restart_worker=restart)
         store.set_restarting(worker.device_uuid, True, expected_worker=worker)
+        monitor._states[worker.device_uuid] = CrashState()
+        monitor._notified_events.add(worker.device_uuid)
 
         with mock.patch.object(monitor_module, 'gpu_operation_gate', gate), \
                 mock.patch('kvmagent.plugins.tensorfusion.utils.is_vm_running',
@@ -1309,12 +1345,18 @@ class TestTensorFusionGPUOperationGate(unittest.TestCase):
             self.assertIs(worker, store.get(worker.device_uuid))
             self.assertFalse(worker.restarting)
             restart.assert_not_called()
+            self.assertNotIn(worker.device_uuid, monitor._states)
+            self.assertNotIn(worker.device_uuid, monitor._notified_events)
 
             store.set_restarting(worker.device_uuid, True, expected_worker=worker)
+            monitor._states[worker.device_uuid] = CrashState()
+            monitor._notified_events.add(worker.device_uuid)
             self.assertFalse(monitor._give_up(worker))
 
         self.assertIs(worker, store.get(worker.device_uuid))
         self.assertFalse(worker.restarting)
+        self.assertNotIn(worker.device_uuid, monitor._states)
+        self.assertNotIn(worker.device_uuid, monitor._notified_events)
         tracker.release.assert_not_called()
 
 
@@ -1424,6 +1466,7 @@ class TestContainerExecutor(unittest.TestCase):
 
         executor = ContainerExecutor(_make_gpu_details())
         executor.STARTUP_WAIT_SEC = 0
+        executor.ROLLBACK_RETRY_WINDOW_SEC = 0
         missing = OSError(2, 'No such file')
         with mock.patch.object(executor, '_image_exists', return_value=True), \
                 mock.patch.object(executor, '_docker_quiet', return_value='') as mock_quiet, \
@@ -1450,6 +1493,7 @@ class TestContainerExecutor(unittest.TestCase):
         from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
 
         executor = ContainerExecutor(_make_gpu_details())
+        executor.ROLLBACK_RETRY_WINDOW_SEC = 0
 
         def docker_command(args, timeout=None, env=None):
             if args[0] == 'run':
@@ -1476,6 +1520,7 @@ class TestContainerExecutor(unittest.TestCase):
         from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
 
         executor = ContainerExecutor(_make_gpu_details())
+        executor.ROLLBACK_RETRY_WINDOW_SEC = 0
 
         def docker_command(args, timeout=None, env=None):
             if args[0] == 'run':
@@ -1506,6 +1551,7 @@ class TestContainerExecutor(unittest.TestCase):
         from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
 
         executor = ContainerExecutor(_make_gpu_details())
+        executor.ROLLBACK_RETRY_WINDOW_SEC = 0
         remove_attempts = []
 
         def docker_command(args, timeout=None, env=None):
@@ -1548,6 +1594,7 @@ class TestContainerExecutor(unittest.TestCase):
         from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
 
         executor = ContainerExecutor(_make_gpu_details())
+        executor.ROLLBACK_RETRY_WINDOW_SEC = 0
         remove_attempts = []
 
         def docker_command(args, timeout=None, env=None):
@@ -1578,7 +1625,8 @@ class TestContainerExecutor(unittest.TestCase):
         worker.shared_memory_path = '/dev/shm/tf_dev-001'
         executor = ContainerExecutor(_make_gpu_details())
 
-        with mock.patch.object(executor, '_docker') as mock_docker, \
+        with mock.patch.object(executor, 'is_alive', return_value=False), \
+                mock.patch.object(executor, '_docker') as mock_docker, \
                 mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove') as mock_remove:
             executor.reap_dead(worker)
 
@@ -1622,20 +1670,163 @@ class TestContainerExecutor(unittest.TestCase):
             mock.call(['rm', '-f', 'old-container-id']),
         ], mock_docker.call_args_list)
 
-    def test_stopped_container_retains_shared_memory_when_removal_is_unconfirmed(self):
+    def test_failed_start_retains_shared_memory_when_removal_is_unconfirmed(self):
         from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
 
         executor = ContainerExecutor(_make_gpu_details())
+        executor.ROLLBACK_RETRY_WINDOW_SEC = 1
+        now = [10.0]
+
+        def _time():
+            return now[0]
+
+        def _sleep(seconds):
+            now[0] += seconds
+
         with mock.patch.object(executor, '_docker',
-                               side_effect=Exception('permission denied')), \
-                mock.patch.object(executor, '_inspect_container') as mock_inspect, \
+                               side_effect=Exception('permission denied')) as mock_docker, \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.time.time',
+                           side_effect=_time), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.time.sleep',
+                           side_effect=_sleep) as mock_sleep, \
                 mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove') as mock_remove:
-            removed = executor._remove_container_and_shared_memory(
+            removed = executor._rollback_failed_start(
                 'container-id', '/dev/shm/tf_dev-001')
 
         self.assertFalse(removed)
-        mock_inspect.assert_not_called()
+        self.assertEqual([
+            mock.call(['rm', '-f', 'container-id'], timeout=1),
+            mock.call(['rm', '-f', 'container-id'], timeout=1),
+            mock.call(['rm', '-f', 'container-id'], timeout=1),
+        ], mock_docker.call_args_list)
+        self.assertEqual([
+            mock.call(0.5),
+            mock.call(0.5),
+        ], mock_sleep.call_args_list)
         mock_remove.assert_not_called()
+
+    def test_failed_start_rollback_retries_for_delayed_container_creation(self):
+        from kvmagent.plugins.tensorfusion.container_executor import (
+            ContainerExecutor, DockerCommandError)
+
+        executor = ContainerExecutor(_make_gpu_details())
+        executor.ROLLBACK_RETRY_WINDOW_SEC = 1
+        now = [10.0]
+
+        def _time():
+            return now[0]
+
+        def _sleep(seconds):
+            now[0] += seconds
+
+        not_found = DockerCommandError(
+            1, 'docker rm -f tf-worker-vm-001',
+            'Error: No such container: tf-worker-vm-001')
+
+        with mock.patch.object(
+                executor, '_docker',
+                side_effect=[not_found, 'tf-worker-vm-001', not_found]) as mock_docker, \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.time.time',
+                           side_effect=_time), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.time.sleep',
+                           side_effect=_sleep) as mock_sleep, \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove') as mock_remove:
+            removed = executor._rollback_failed_start(
+                'tf-worker-vm-001', '/dev/shm/tf_dev-001')
+
+        self.assertTrue(removed)
+        self.assertEqual([
+            mock.call(['rm', '-f', 'tf-worker-vm-001'], timeout=1),
+            mock.call(['rm', '-f', 'tf-worker-vm-001'], timeout=1),
+            mock.call(['rm', '-f', 'tf-worker-vm-001'], timeout=1),
+        ], mock_docker.call_args_list)
+        self.assertEqual([
+            mock.call(0.5),
+            mock.call(0.5),
+        ], mock_sleep.call_args_list)
+        mock_remove.assert_called_once_with('/dev/shm/tf_dev-001')
+
+    def test_stop_succeeds_when_shared_memory_cleanup_fails(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        worker = _make_worker()
+        worker.container_id = 'container-id'
+        worker.container_name = 'tf-worker-vm-001'
+        worker.shared_memory_path = '/dev/shm/tf_dev-001'
+        executor = ContainerExecutor(_make_gpu_details())
+
+        with mock.patch.object(executor, '_docker', return_value='') as mock_docker, \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove',
+                           side_effect=OSError(errno.EPERM, 'permission denied')) as mock_remove:
+            executor.stop(worker)
+
+        self.assertEqual([
+            mock.call(['stop', '-t', '5', 'container-id']),
+            mock.call(['rm', '-f', 'container-id']),
+        ], mock_docker.call_args_list)
+        mock_remove.assert_called_once_with('/dev/shm/tf_dev-001')
+
+    def test_reap_dead_preserves_container_that_is_running_again(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        worker = _make_worker()
+        worker.container_id = 'container-id'
+        worker.container_name = 'tf-worker-vm-001'
+        worker.shared_memory_path = '/dev/shm/tf_dev-001'
+        executor = ContainerExecutor(_make_gpu_details())
+
+        with mock.patch.object(executor, 'is_alive', return_value=True), \
+                mock.patch.object(executor, '_docker') as mock_docker, \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove') as mock_remove:
+            self.assertFalse(executor.reap_dead(worker))
+
+        mock_docker.assert_not_called()
+        mock_remove.assert_not_called()
+
+    def test_reap_dead_uses_deterministic_shared_memory_fallback(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        worker = _make_worker(device_uuid='dev-fallback')
+        worker.container_id = 'container-id'
+        worker.container_name = 'tf-worker-vm-001'
+        worker.shared_memory_path = None
+        executor = ContainerExecutor(_make_gpu_details())
+
+        with mock.patch.object(executor, 'is_alive', return_value=False), \
+                mock.patch.object(executor, '_docker'), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove') as mock_remove:
+            self.assertTrue(executor.reap_dead(worker))
+
+        mock_remove.assert_called_once_with('/dev/shm/tf_dev-fallback')
+
+    def test_residual_cleanup_does_not_trust_reused_container_name(self):
+        from kvmagent.plugins.tensorfusion.container_executor import ContainerExecutor
+
+        known = _make_worker()
+        known.container_id = 'old-container-id'
+        known.container_name = 'tf-worker-vm-001'
+        executor = ContainerExecutor(_make_gpu_details())
+
+        info = {
+            'Id': 'new-container-id',
+            'Name': '/tf-worker-vm-001',
+            'Config': {'Env': ['TF_DEVICE_UUID=dev-residual']},
+        }
+
+        def _docker(args, timeout=None, env=None):
+            if args[0:2] == ['ps', '-aq']:
+                return 'new-container-id'
+            return ''
+
+        with mock.patch.object(executor, '_docker', side_effect=_docker) as mock_docker, \
+                mock.patch.object(executor, '_inspect_container', return_value=info), \
+                mock.patch('kvmagent.plugins.tensorfusion.container_executor.os.remove') as mock_remove:
+            self.assertEqual(
+                1, executor.cleanup_residual_workers_by_vm('vm-001', known_workers=[known]))
+
+        self.assertIn(
+            mock.call(['rm', '-f', 'new-container-id']), mock_docker.call_args_list)
+        mock_remove.assert_called_once_with('/dev/shm/tf_dev-residual')
 
     def test_command_for_log_masks_license_values(self):
         from kvmagent.plugins.tensorfusion.container_executor import _command_for_log, _redact_sensitive_values
@@ -2136,7 +2327,8 @@ class TestProcessExecutor(unittest.TestCase):
 
         with mock.patch.dict(sys.modules, {'psutil': fake_psutil}):
             executor = ProcessExecutor(_make_gpu_details())
-            cleaned = executor.cleanup_residual_workers_by_vm('vm-001', known_pids=[1234])
+            cleaned = executor.cleanup_residual_workers_by_vm(
+                'vm-001', known_workers=[_make_worker(pid=1234)])
 
         self.assertEqual(1, cleaned)
         mock_killpg.assert_called_once_with(9001, mock.ANY)
@@ -2330,28 +2522,19 @@ class TestOrphanScan(unittest.TestCase):
 
         mock_executor.stop.assert_called_with(orphan_worker)
 
-    @mock.patch('kvmagent.plugins.tensorfusion.service.NVIDIA')
-    @mock.patch('kvmagent.plugins.tensorfusion.service.ProcessExecutor')
-    def test_orphan_scan_keeps_untracked_worker_when_vm_check_fails(self, MockExecutor, MockNVIDIA):
-        """When libvirt query fails (returns None), untracked worker should be kept alive."""
-        MockNVIDIA.query_gpu_details.return_value = _make_gpu_details()
-
-        mock_executor = MockExecutor.return_value
-        mock_executor.cleanup_residual_workers_by_vm.return_value = 0
-        mock_executor.is_alive.return_value = True
-
-        from kvmagent.plugins.tensorfusion.service import TensorFusionService
-        svc = TensorFusionService()
-
-        mock_executor.scan_running.return_value = []
-        with mock.patch('kvmagent.plugins.tensorfusion.service._is_vm_running', return_value=True):
-            svc.initialize()
-
+    def test_orphan_scan_keeps_untracked_worker_when_vm_running_or_unknown(self):
+        """Untracked runtimes are not killed without a definitive absent VM."""
+        mock_executor = mock.MagicMock()
         orphan_worker = _make_worker(device_uuid='orphan-002', vm_uuid='vm-unknown', pid=8888)
         mock_executor.scan_running.return_value = [orphan_worker]
 
-        # is_vm_running returns None (libvirt query failed)
-        with mock.patch('kvmagent.plugins.tensorfusion.service._is_vm_running', return_value=None):
+        from kvmagent.plugins.tensorfusion.service import TensorFusionService
+        svc = TensorFusionService(executor=mock_executor)
+
+        with mock.patch(
+                'kvmagent.plugins.tensorfusion.service._is_vm_running',
+                side_effect=[True, None]):
+            svc._scan_and_cleanup_orphans()
             svc._scan_and_cleanup_orphans()
 
         mock_executor.stop.assert_not_called()

--- a/tests/unit/kvmagent/test_prometheus_gpu_metrics.py
+++ b/tests/unit/kvmagent/test_prometheus_gpu_metrics.py
@@ -1,3 +1,5 @@
+import sys
+import types
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -79,3 +81,27 @@ def test_collector_exports_cached_pcie_values_under_existing_metric_contract():
     ]
     vendor.collect_metrics.assert_called_once_with()
     vendor.collect_vgpu_metrics.assert_called_once_with()
+
+
+def test_dgpu_collector_omits_samples_when_vendor_metrics_are_unavailable():
+    service = MagicMock()
+    workers = [SimpleNamespace(device_uuid="device-uuid")]
+    service.list_workers.return_value = workers
+    nvidia = MagicMock()
+    nvidia.is_available.return_value = True
+    nvidia.collect_dgpu_worker_metrics.return_value = []
+    nvidia_module = types.ModuleType("zstacklib.gpu.vendors.nvidia")
+    nvidia_module.NVIDIA = nvidia
+
+    with patch.object(prometheus.kvmagent, "get_tf_service",
+                      return_value=service), \
+            patch.dict(sys.modules, {
+                "zstacklib.gpu.vendors.nvidia": nvidia_module,
+            }), \
+            patch.object(prometheus, "GaugeMetricFamily",
+                         side_effect=lambda *args, **kwargs: RecordingMetric()):
+        metrics = list(prometheus.collect_dgpu_worker_metrics())
+
+    assert len(metrics) == 2
+    assert all(metric.samples == [] for metric in metrics)
+    nvidia.collect_dgpu_worker_metrics.assert_called_once_with(workers)

--- a/tests/unit/kvmagent/test_prometheus_gpu_metrics.py
+++ b/tests/unit/kvmagent/test_prometheus_gpu_metrics.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from kvmagent.plugins import prometheus
+
+
+class RecordingMetric(object):
+    def __init__(self):
+        self.samples = []
+
+    def add_metric(self, labels, value):
+        self.samples.append((labels, value))
+
+
+def _metric_families():
+    return {name: RecordingMetric() for name in (
+        "host_gpu_power_draw",
+        "host_gpu_temperature",
+        "host_gpu_fan_speed",
+        "host_gpu_utilization",
+        "host_gpu_memory_utilization",
+        "host_gpu_rxpci_in_bytes",
+        "host_gpu_txpci_in_bytes",
+        "host_gpu_status",
+        "vgpu_utilization",
+        "vgpu_memory_utilization",
+    )}
+
+
+def test_gpu_metric_names_and_pcie_labels_remain_compatible():
+    definitions = []
+
+    def metric_family(name, help_text, _value=None, labels=None):
+        definitions.append((name, tuple(labels or ())))
+        return RecordingMetric()
+
+    with patch.object(prometheus, "GaugeMetricFamily", side_effect=metric_family):
+        metrics = prometheus.get_gpu_metrics()
+
+    assert "host_gpu_rxpci_in_bytes" in metrics
+    assert "host_gpu_txpci_in_bytes" in metrics
+    assert ("host_gpu_rxpci_in_bytes", ("pci_device_address", "gpu_serial")) in definitions
+    assert ("host_gpu_txpci_in_bytes", ("pci_device_address", "gpu_serial")) in definitions
+
+
+def test_collector_exports_cached_pcie_values_under_existing_metric_contract():
+    metrics = _metric_families()
+    gpu_metric = SimpleNamespace(
+        pci_address="0000:1a:00.0",
+        serial_number="SN00",
+        power_draw=65.0,
+        temperature=58.0,
+        fan_speed=None,
+        utilization=45.0,
+        memory_utilization=62.0,
+        pcie_rx_bytes=2048.0,
+        pcie_tx_bytes=1024.0,
+        extra={},
+    )
+    vendor = MagicMock()
+    vendor.VENDOR_NAME = "NVIDIA"
+    vendor.is_available.return_value = True
+    vendor.collect_metrics.return_value = [gpu_metric]
+    vendor.collect_vgpu_metrics.return_value = []
+
+    gpu_module = __import__("zstacklib.gpu", fromlist=["get_all_gpu_vendors"])
+    with patch.object(gpu_module, "get_all_gpu_vendors", return_value=[vendor], create=True), \
+            patch.object(prometheus, "get_gpu_metrics", return_value=metrics), \
+            patch.object(prometheus, "add_gpu_pci_device_address"), \
+            patch.object(prometheus, "check_gpu_status_and_save_gpu_status"), \
+            patch.object(prometheus, "collect_gpu_xid_errors", return_value=[]):
+        prometheus.collect_gpu_metrics_via_plugin()
+
+    assert metrics["host_gpu_rxpci_in_bytes"].samples == [
+        (["0000:1a:00.0", "SN00"], 2048.0)
+    ]
+    assert metrics["host_gpu_txpci_in_bytes"].samples == [
+        (["0000:1a:00.0", "SN00"], 1024.0)
+    ]
+    vendor.collect_metrics.assert_called_once_with()
+    vendor.collect_vgpu_metrics.assert_called_once_with()

--- a/zstacklib/zstacklib/gpu/__init__.py
+++ b/zstacklib/zstacklib/gpu/__init__.py
@@ -120,18 +120,23 @@ def enrich_gpu_info_map(gpu_info_map):
     _log = log.get_logger(__name__)
 
     pci_to_vendor = {}
-    for vendor_class in get_all_gpu_vendors():
-        if not vendor_class.is_available():
-            continue
-        try:
-            for gpu_info in vendor_class.get_basic_info():
-                if gpu_info.pci_address:
-                    norm = normalize_pci_address(gpu_info.pci_address)
-                    if norm and norm in gpu_info_map:
-                        pci_to_vendor[norm] = vendor_class.VENDOR_NAME
-        except Exception as e:
-            _log.debug("enrich_gpu_info_map: get_basic_info from %s: %s" %
-                       (vendor_class.VENDOR_NAME, str(e)))
+    for pci, info in gpu_info_map.items():
+        if isinstance(info, dict) and info.get('_vendor'):
+            pci_to_vendor[pci] = info['_vendor']
+
+    if len(pci_to_vendor) < len(gpu_info_map):
+        for vendor_class in get_all_gpu_vendors():
+            if not vendor_class.is_available():
+                continue
+            try:
+                for gpu_info in vendor_class.get_basic_info():
+                    if gpu_info.pci_address:
+                        norm = normalize_pci_address(gpu_info.pci_address)
+                        if norm and norm in gpu_info_map and norm not in pci_to_vendor:
+                            pci_to_vendor[norm] = vendor_class.VENDOR_NAME
+            except Exception as e:
+                _log.debug("enrich_gpu_info_map: get_basic_info from %s: %s" %
+                           (vendor_class.VENDOR_NAME, str(e)))
 
     vendor_to_pcis = {}
     for pci, vendor in pci_to_vendor.items():

--- a/zstacklib/zstacklib/gpu/__init__.py
+++ b/zstacklib/zstacklib/gpu/__init__.py
@@ -142,12 +142,6 @@ def enrich_gpu_info_map(gpu_info_map):
     for pci, vendor in pci_to_vendor.items():
         vendor_to_pcis.setdefault(vendor, []).append(pci)
 
-    # Include PCI-only candidates (passthrough'd devices tagged with _vendor
-    # by _supplement_gpu_info_map_from_pci) so they participate in enrich_addon_info
-    for pci, info in gpu_info_map.items():
-        if pci not in pci_to_vendor and isinstance(info, dict) and '_vendor' in info:
-            vendor_to_pcis.setdefault(info['_vendor'], []).append(pci)
-
     for vendor_name, pcis in vendor_to_pcis.items():
         vendor_class = get_gpu_vendor(vendor_name)
         if vendor_class and hasattr(vendor_class, 'enrich_addon_info'):

--- a/zstacklib/zstacklib/gpu/base.py
+++ b/zstacklib/zstacklib/gpu/base.py
@@ -452,7 +452,7 @@ class GPUBase(object):
         capability_info['virtCapabilities'] = list(virt_capabilities or [])
 
     @classmethod
-    def detect_vfio_mdev_capability(cls, pci_device_to):
+    def detect_vfio_mdev_capability(cls, pci_device_to, prepared_context=None):
         """
         Detect if the GPU device supports VFIO mdev (mediated device) virtualization.
 
@@ -489,7 +489,7 @@ class GPUBase(object):
         return False, {}
 
     @classmethod
-    def detect_tensorfusion_capability(cls, pci_device_to):
+    def detect_tensorfusion_capability(cls, pci_device_to, prepared_context=None):
         """
         Detect if the GPU device supports TensorFusion virtualization.
 

--- a/zstacklib/zstacklib/gpu/operation_gate.py
+++ b/zstacklib/zstacklib/gpu/operation_gate.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+
+import threading
+from contextlib import contextmanager
+
+try:
+    import _thread as thread
+except ImportError:
+    import thread
+
+
+class GPUOperationGate(object):
+    def __init__(self):
+        self._condition = threading.Condition(threading.Lock())
+        self._owner = None
+        self._critical_depth = 0
+        self._critical_waiters = 0
+
+    def acquire_critical(self):
+        owner = thread.get_ident()
+        with self._condition:
+            if self._owner == owner:
+                if self._critical_depth == 0:
+                    raise RuntimeError('cannot upgrade a monitoring GPU operation')
+                self._critical_depth += 1
+                return
+
+            self._critical_waiters += 1
+            try:
+                while self._owner is not None:
+                    self._condition.wait()
+                self._owner = owner
+                self._critical_depth = 1
+            finally:
+                self._critical_waiters -= 1
+
+    def try_acquire_monitoring(self):
+        owner = thread.get_ident()
+        with self._condition:
+            if self._owner is not None or self._critical_waiters:
+                return False
+            self._owner = owner
+            self._critical_depth = 0
+            return True
+
+    def release(self):
+        owner = thread.get_ident()
+        with self._condition:
+            if self._owner != owner:
+                raise RuntimeError('GPU operation gate released by non-owner')
+
+            if self._critical_depth > 1:
+                self._critical_depth -= 1
+                return
+
+            self._owner = None
+            self._critical_depth = 0
+            self._condition.notify_all()
+
+    @contextmanager
+    def critical(self):
+        self.acquire_critical()
+        try:
+            yield
+        finally:
+            self.release()
+
+    @contextmanager
+    def monitoring(self):
+        acquired = self.try_acquire_monitoring()
+        try:
+            yield acquired
+        finally:
+            if acquired:
+                self.release()
+
+
+gpu_operation_gate = GPUOperationGate()

--- a/zstacklib/zstacklib/gpu/tests/test_gpu_vendors.py
+++ b/zstacklib/zstacklib/gpu/tests/test_gpu_vendors.py
@@ -261,7 +261,8 @@ class TestNVIDIA(unittest.TestCase):
             return 1, '', 'error'
 
         with patch('zstacklib.gpu.vendors.nvidia.bash_roe', side_effect=fake_bash_roe), \
-             patch('os.path.isdir', return_value=False):
+             patch('os.path.isdir', return_value=False), \
+             patch('os.path.exists', return_value=True):
             supported, info = NVIDIA.detect_vfio_mdev_capability(pci_to)
 
         self.assertFalse(supported)
@@ -284,7 +285,8 @@ class TestNVIDIA(unittest.TestCase):
             return 0, '', ''
 
         with patch('zstacklib.gpu.vendors.nvidia.bash_roe', side_effect=fake_bash_roe), \
-             patch('os.path.isdir', return_value=False):
+             patch('os.path.isdir', return_value=False), \
+             patch('os.path.exists', return_value=True):
             supported, info = NVIDIA.detect_vfio_mdev_capability(pci_to)
 
         self.assertTrue(supported)
@@ -304,7 +306,8 @@ class TestNVIDIA(unittest.TestCase):
             return 0, '', ''
 
         with patch('zstacklib.gpu.vendors.nvidia.bash_roe', side_effect=fake_bash_roe), \
-             patch('os.path.isdir', return_value=False):
+             patch('os.path.isdir', return_value=False), \
+             patch('os.path.exists', return_value=True):
             supported, info = NVIDIA.detect_vfio_mdev_capability(pci_to)
 
         self.assertTrue(supported)
@@ -320,9 +323,17 @@ class TestNVIDIA(unittest.TestCase):
 
         pci_device = type('PciDeviceTO', (), {'pciDeviceAddress': '0000:3b:00.0'})()
 
-        with patch("zstacklib.gpu.vendors.nvidia.bash_roe",
-                   return_value=(0, "00000000:3B:00.0, 570.124.06\n", "")), \
-             patch("zstacklib.gpu.vendors.nvidia.os.path.exists", return_value=True):
+        def run_command(command):
+            if '--query-gpu=pci.bus_id,driver_version' in command:
+                return 0, "00000000:3B:00.0, 570.124.06\n", ""
+            if command in ('which docker', 'which nvidia-ctk',
+                           'docker image inspect tf-worker:latest'):
+                return 0, '', ''
+            return 1, '', 'unexpected command'
+
+        with patch("zstacklib.gpu.vendors.nvidia.bash_roe", side_effect=run_command), \
+             patch.object(NVIDIA, "_is_bound_to_vfio", return_value=False), \
+             patch("zstacklib.gpu.vendors.nvidia.os.path.exists", return_value=False):
             supported, info = NVIDIA.detect_tensorfusion_capability(pci_device)
 
         self.assertTrue(supported)
@@ -341,15 +352,16 @@ class TestNVIDIA(unittest.TestCase):
 
         with patch("zstacklib.gpu.vendors.nvidia.bash_roe",
                    return_value=(0, "00000000:3B:00.0, 565.43.01\n", "")), \
-             patch("zstacklib.gpu.vendors.nvidia.os.path.exists", return_value=True):
+             patch.object(NVIDIA, "_is_bound_to_vfio", return_value=False), \
+             patch("zstacklib.gpu.vendors.nvidia.os.path.exists", return_value=False):
             supported, info = NVIDIA.detect_tensorfusion_capability(pci_device)
 
         self.assertFalse(supported)
         self.assertEqual(info.get("virtStatus"), "TENSORFUSION_NOT_SUPPORTED")
         self.assertIn("570.x", info.get("reason", ""))
 
-    def test_detect_tensorfusion_capability_rejects_missing_worker_binary(self):
-        """TensorFusion capability should reject hosts without tensor-fusion-worker installed."""
+    def test_detect_tensorfusion_capability_rejects_missing_worker_image(self):
+        """TensorFusion capability should reject hosts without the worker image."""
         from zstacklib.gpu.vendors.nvidia import NVIDIA
         try:
             from unittest.mock import patch
@@ -358,14 +370,23 @@ class TestNVIDIA(unittest.TestCase):
 
         pci_device = type('PciDeviceTO', (), {'pciDeviceAddress': '0000:3b:00.0'})()
 
-        with patch("zstacklib.gpu.vendors.nvidia.bash_roe",
-                   return_value=(0, "00000000:3B:00.0, 570.124.06\n", "")), \
+        def run_command(command):
+            if '--query-gpu=pci.bus_id,driver_version' in command:
+                return 0, "00000000:3B:00.0, 570.124.06\n", ""
+            if command in ('which docker', 'which nvidia-ctk'):
+                return 0, '', ''
+            if command == 'docker image inspect tf-worker:latest':
+                return 1, '', 'image not found'
+            return 1, '', 'unexpected command'
+
+        with patch("zstacklib.gpu.vendors.nvidia.bash_roe", side_effect=run_command), \
+             patch.object(NVIDIA, "_is_bound_to_vfio", return_value=False), \
              patch("zstacklib.gpu.vendors.nvidia.os.path.exists", return_value=False):
             supported, info = NVIDIA.detect_tensorfusion_capability(pci_device)
 
         self.assertFalse(supported)
         self.assertEqual(info.get("virtStatus"), "TENSORFUSION_NOT_SUPPORTED")
-        self.assertIn("tensor-fusion-worker", info.get("reason", ""))
+        self.assertIn("tf-worker:latest", info.get("reason", ""))
 
 class TestAMD(unittest.TestCase):
     """Test AMD vendor implementation"""

--- a/zstacklib/zstacklib/gpu/tests/test_nvidia_contention.py
+++ b/zstacklib/zstacklib/gpu/tests/test_nvidia_contention.py
@@ -55,6 +55,18 @@ def _lspci_outputs(count=8):
     return id_output, name_output
 
 
+def _worker(pid=123):
+    return type('Worker', (), {
+        'device_uuid': 'device-uuid',
+        'vm_uuid': 'vm-uuid',
+        'pci_address': '0000:1a:00.0',
+        'pid': pid,
+        'container_id': None,
+        'restarting': False,
+        'allocated_memory_mb': 1024,
+    })()
+
+
 class TestNVIDIAContention(unittest.TestCase):
 
     def setUp(self):
@@ -242,6 +254,30 @@ class TestNVIDIAContention(unittest.TestCase):
         self.assertEqual(len(second), 1)
         self.assertEqual(second[0].pci_address, "0000:1a:00.0")
 
+    def test_metrics_cache_accepts_inventory_shrink_after_driver_unbind(self):
+        now = [1000]
+        outputs = [(0, _metric_output(), ""),
+                   (0, _metric_output(7), "")]
+
+        with patch.object(NVIDIA, "is_available", return_value=True), \
+                patch.object(NVIDIA, "_is_nvidia_driver_bound",
+                             return_value=False), \
+                patch.object(NVIDIA, "_collect_pcie_metrics"), \
+                patch("zstacklib.gpu.vendors.nvidia.time.time",
+                      side_effect=lambda: now[0]), \
+                patch("zstacklib.gpu.vendors.nvidia.bash_roe",
+                      side_effect=outputs) as bash_roe:
+            first = NVIDIA.collect_metrics()
+            now[0] = 1031
+            second = NVIDIA.collect_metrics()
+
+        self.assertEqual(len(first), 8)
+        self.assertEqual(len(second), 7)
+        self.assertNotIn("0000:21:00.0",
+                         [metric.pci_address for metric in second])
+        self.assertEqual(NVIDIA._metrics_cache_time, 1031)
+        self.assertEqual(bash_roe.call_count, 2)
+
     def test_pcie_failure_opens_per_device_circuit_breaker(self):
         commands = []
         now = [1000]
@@ -275,6 +311,40 @@ class TestNVIDIAContention(unittest.TestCase):
 
         self.assertEqual(len(metrics), 1)
         bash_roe.assert_not_called()
+
+    def test_pcie_skip_does_not_delay_next_attempt(self):
+        metrics = NVIDIA.parse_metrics(_metric_output(1))
+
+        with patch("zstacklib.gpu.vendors.nvidia.bash_roe") as bash_roe, \
+                gpu_operation_gate.critical():
+            NVIDIA._collect_pcie_metrics(metrics, 1000)
+
+        self.assertNotIn("_all", NVIDIA._pcie_last_attempt)
+        bash_roe.assert_not_called()
+
+    def test_dgpu_metrics_are_unavailable_while_critical_is_active(self):
+        with patch("zstacklib.gpu.vendors.nvidia.bash_roe") as bash_roe, \
+                gpu_operation_gate.critical():
+            metrics = NVIDIA.collect_dgpu_worker_metrics([_worker()])
+
+        self.assertEqual(metrics, [])
+        bash_roe.assert_not_called()
+
+    def test_dgpu_metrics_are_unavailable_after_pmon_failure(self):
+        with patch.object(
+                NVIDIA, "_run_monitoring_command",
+                return_value=(1, "", "NVML busy")):
+            metrics = NVIDIA.collect_dgpu_worker_metrics([_worker()])
+
+        self.assertEqual(metrics, [])
+
+    def test_dgpu_metrics_keep_zero_for_pid_missing_from_successful_pmon(self):
+        with patch.object(NVIDIA, "_parse_pmon_output", return_value={}):
+            metrics = NVIDIA.collect_dgpu_worker_metrics([_worker()])
+
+        self.assertEqual(len(metrics), 1)
+        self.assertEqual(metrics[0].utilization, 0.0)
+        self.assertEqual(metrics[0].memory_utilization, 0.0)
 
     def test_query_gpu_details_has_hard_timeout(self):
         output = "0, 00000000:1A:00.0, NVIDIA GeForce RTX 3090, 24576, 580.142"

--- a/zstacklib/zstacklib/gpu/tests/test_nvidia_contention.py
+++ b/zstacklib/zstacklib/gpu/tests/test_nvidia_contention.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+from zstacklib.gpu.vendors.nvidia import NVIDIA
+from zstacklib.gpu.operation_gate import gpu_operation_gate
+
+
+def _metric_output(count=8):
+    return "\n".join(
+        "00000000:%02X:00.0, %d, %d, %d, %.2f, %d, SN%02d" % (
+            0x1a + index, 10 + index, 20 + index, 40 + index,
+            60.0 + index, index, index)
+        for index in range(count)
+    )
+
+
+def _basic_output(count=8):
+    return "\n".join(
+        "00000000:%02X:00.0, 24576 MiB, 350.00 W, SN%02d, 580.142" % (
+            0x1a + index, index)
+        for index in range(count)
+    )
+
+
+def _pcie_output(count=8):
+    return "\n".join(
+        "GPU %d: NVIDIA GeForce RTX 3090\n    TX_BYTES: %d\n    RX_BYTES: %d" % (
+            index, 1024 + index, 2048 + index)
+        for index in range(count)
+    )
+
+
+def _lspci_outputs(count=8):
+    id_output = "\n\n".join(
+        "Slot:\t0000:%02x:00.0\n"
+        "Class:\t030200\n"
+        "Vendor:\t10de\n"
+        "Device:\t2204" % (0x1a + index)
+        for index in range(count)
+    )
+    name_output = "\n\n".join(
+        "Slot:\t0000:%02x:00.0\n"
+        "Class:\t3D controller\n"
+        "Vendor:\tNVIDIA Corporation\n"
+        "Device:\tNVIDIA GPU" % (0x1a + index)
+        for index in range(count)
+    )
+    return id_output, name_output
+
+
+class TestNVIDIAContention(unittest.TestCase):
+
+    def setUp(self):
+        self._reset_metrics_cache()
+
+    def tearDown(self):
+        self._reset_metrics_cache()
+
+    @staticmethod
+    def _reset_metrics_cache():
+        NVIDIA._metrics_cache = []
+        NVIDIA._metrics_cache_time = 0
+        NVIDIA._pcie_metrics_cache = {}
+        NVIDIA._pcie_last_attempt = {}
+        NVIDIA._pcie_blocked_until = {}
+        NVIDIA._basic_info_cache = []
+        NVIDIA._basic_info_cache_time = 0
+
+    def test_parse_metrics_is_pure_for_eight_gpus(self):
+        with patch("zstacklib.gpu.vendors.nvidia.bash_roe") as bash_roe:
+            metrics = NVIDIA.parse_metrics(_metric_output())
+
+        self.assertEqual(len(metrics), 8)
+        self.assertEqual(metrics[0].pci_address, "0000:1a:00.0")
+        self.assertEqual(metrics[-1].pci_address, "0000:21:00.0")
+        self.assertIsNone(metrics[0].pcie_tx_bytes)
+        self.assertIsNone(metrics[0].pcie_rx_bytes)
+        self.assertEqual(metrics[0]._nvidia_index, "0")
+        bash_roe.assert_not_called()
+
+    def test_collect_vgpu_metrics_skips_nvidia_smi_without_active_mdev(self):
+        with patch.object(NVIDIA, "_has_active_mdev_devices", return_value=False), \
+                patch("zstacklib.gpu.vendors.nvidia.bash_roe") as bash_roe:
+            metrics = NVIDIA.collect_vgpu_metrics()
+
+        self.assertEqual(metrics, [])
+        bash_roe.assert_not_called()
+
+    def test_basic_info_carries_driver_version_for_all_gpus(self):
+        infos = NVIDIA.parse_basic_info(_basic_output())
+
+        self.assertEqual(len(infos), 8)
+        self.assertTrue(all(info.extra.get("driverVersion") == "580.142"
+                            for info in infos))
+
+    def test_basic_info_accepts_inventory_shrink_after_driver_rebind(self):
+        now = [1000]
+        outputs = [(0, _basic_output(), ""),
+                   (0, _basic_output(7), "")]
+
+        with patch.object(NVIDIA, "is_available", return_value=True), \
+                patch("zstacklib.gpu.vendors.nvidia.os.path.exists",
+                      return_value=True), \
+                patch("zstacklib.gpu.vendors.nvidia.os.path.islink",
+                      return_value=True), \
+                patch("zstacklib.gpu.vendors.nvidia.os.path.realpath",
+                      return_value="/sys/bus/pci/drivers/vfio-pci"), \
+                patch("zstacklib.gpu.vendors.nvidia.time.time",
+                      side_effect=lambda: now[0]), \
+                patch("zstacklib.gpu.vendors.nvidia.bash_roe",
+                      side_effect=outputs) as bash_roe:
+            first = NVIDIA.get_basic_info()
+            now[0] = 1031
+            second = NVIDIA.get_basic_info()
+
+        self.assertEqual(len(first), 8)
+        self.assertEqual(len(second), 7)
+        self.assertNotIn("0000:21:00.0",
+                         [info.pci_address for info in second])
+        self.assertEqual(bash_roe.call_count, 2)
+        self.assertTrue(all(call[0][0].startswith("timeout 12 nvidia-smi")
+                            for call in bash_roe.call_args_list))
+
+    def test_basic_info_retries_single_partial_inventory(self):
+        now = [1000]
+        outputs = [(0, _basic_output(), ""),
+                   (0, _basic_output(7), ""),
+                   (0, _basic_output(), "")]
+
+        with patch.object(NVIDIA, "is_available", return_value=True), \
+                patch.object(NVIDIA, "_is_nvidia_driver_bound",
+                             return_value=True), \
+                patch("zstacklib.gpu.vendors.nvidia.time.time",
+                      side_effect=lambda: now[0]), \
+                patch("zstacklib.gpu.vendors.nvidia.bash_roe",
+                      side_effect=outputs) as bash_roe:
+            NVIDIA.get_basic_info()
+            now[0] = 1031
+            refreshed = NVIDIA.get_basic_info()
+
+        self.assertEqual(len(refreshed), 8)
+        self.assertIn("0000:21:00.0",
+                      [info.pci_address for info in refreshed])
+        self.assertEqual(bash_roe.call_count, 3)
+
+    def test_basic_info_keeps_repeated_partial_when_gpu_still_uses_nvidia(self):
+        now = [1000]
+        outputs = [(0, _basic_output(), ""),
+                   (0, _basic_output(7), ""),
+                   (0, _basic_output(7), "")]
+
+        with patch.object(NVIDIA, "is_available", return_value=True), \
+                patch("zstacklib.gpu.vendors.nvidia.os.path.exists",
+                      return_value=True), \
+                patch("zstacklib.gpu.vendors.nvidia.os.path.islink",
+                      return_value=True), \
+                patch("zstacklib.gpu.vendors.nvidia.os.path.realpath",
+                      return_value="/sys/bus/pci/drivers/nvidia"), \
+                patch("zstacklib.gpu.vendors.nvidia.time.time",
+                      side_effect=lambda: now[0]), \
+                patch("zstacklib.gpu.vendors.nvidia.bash_roe",
+                      side_effect=outputs) as bash_roe:
+            NVIDIA.get_basic_info()
+            now[0] = 1031
+            refreshed = NVIDIA.get_basic_info()
+
+        self.assertEqual(len(refreshed), 8)
+        self.assertIn("0000:21:00.0",
+                      [info.pci_address for info in refreshed])
+        self.assertEqual(bash_roe.call_count, 3)
+
+    def test_pci_fallback_marks_gpu_missing_from_stable_inventory_unloaded(self):
+        from zstacklib.utils.gpu import get_all_gpu_infos_by_pci
+
+        id_output, name_output = _lspci_outputs()
+        NVIDIA._basic_info_cache = NVIDIA.parse_basic_info(_basic_output(7))
+        NVIDIA._basic_info_cache_time = 1000
+
+        with patch.object(NVIDIA, "is_available", return_value=True), \
+                patch("zstacklib.gpu.vendors.nvidia.time.time",
+                      return_value=1000), \
+                patch("zstacklib.gpu.get_all_gpu_vendors",
+                      return_value=[NVIDIA]), \
+                patch("zstacklib.utils.pci.get_pci_device_ids",
+                      return_value=(0, id_output, "")), \
+                patch("zstacklib.utils.pci.get_pci_device_names",
+                      return_value=(0, name_output, "")):
+            gpu_info_map = get_all_gpu_infos_by_pci()
+
+        self.assertEqual(len(gpu_info_map), 8)
+        self.assertFalse(gpu_info_map["0000:21:00.0"]["isDriverLoaded"])
+        self.assertNotIn("driverVersion", gpu_info_map["0000:21:00.0"])
+
+    def test_metrics_cache_batches_all_pcie_values_in_one_query(self):
+        commands = []
+
+        def run_command(command):
+            commands.append(command)
+            if "--query-gpu" in command:
+                return 0, _metric_output(), ""
+            return 0, _pcie_output(), ""
+
+        with patch.object(NVIDIA, "is_available", return_value=True), \
+                patch("zstacklib.gpu.vendors.nvidia.time.time", return_value=1000), \
+                patch("zstacklib.gpu.vendors.nvidia.bash_roe", side_effect=run_command):
+            results = [NVIDIA.collect_metrics() for _ in range(9)]
+
+        base_queries = [command for command in commands if "--query-gpu" in command]
+        pcie_queries = [command for command in commands if " pci " in command]
+        self.assertEqual(len(base_queries), 1)
+        self.assertEqual(len(pcie_queries), 1)
+        self.assertTrue(all(len(metrics) == 8 for metrics in results))
+        self.assertEqual(pcie_queries[0], "timeout 10 nvidia-smi pci -gCnt")
+        self.assertEqual(results[-1][0].pcie_tx_bytes, 1024.0)
+        self.assertEqual(results[-1][-1].pcie_rx_bytes, 2055.0)
+
+    def test_metrics_cache_keeps_last_good_data_after_refresh_failure(self):
+        now = [1000]
+
+        def run_command(command):
+            if " pci " in command:
+                return 1, "", "PCI query failed"
+            if now[0] == 1000:
+                return 0, _metric_output(1), ""
+            return 1, "", "NVML busy"
+
+        with patch.object(NVIDIA, "is_available", return_value=True), \
+                patch("zstacklib.gpu.vendors.nvidia.time.time", side_effect=lambda: now[0]), \
+                patch("zstacklib.gpu.vendors.nvidia.bash_roe", side_effect=run_command):
+            first = NVIDIA.collect_metrics()
+            now[0] = 1031
+            second = NVIDIA.collect_metrics()
+
+        self.assertEqual(len(first), 1)
+        self.assertEqual(len(second), 1)
+        self.assertEqual(second[0].pci_address, "0000:1a:00.0")
+
+    def test_pcie_failure_opens_per_device_circuit_breaker(self):
+        commands = []
+        now = [1000]
+
+        def run_command(command):
+            commands.append(command)
+            if "--query-gpu" in command:
+                return 0, _metric_output(1), ""
+            return 1, "", "NVML busy"
+
+        with patch.object(NVIDIA, "is_available", return_value=True), \
+                patch("zstacklib.gpu.vendors.nvidia.time.time", side_effect=lambda: now[0]), \
+                patch("zstacklib.gpu.vendors.nvidia.bash_roe", side_effect=run_command):
+            NVIDIA.collect_metrics()
+            now[0] = 1061
+            NVIDIA.collect_metrics()
+
+        pcie_queries = [command for command in commands if " pci " in command]
+        self.assertEqual(len(pcie_queries), 1)
+        self.assertGreater(NVIDIA._pcie_blocked_until["_all"], now[0])
+
+    def test_monitoring_returns_cache_without_shell_when_critical_is_active(self):
+        NVIDIA._metrics_cache = NVIDIA.parse_metrics(_metric_output(1))
+        NVIDIA._metrics_cache_time = 1000
+
+        with patch.object(NVIDIA, "is_available", return_value=True), \
+                patch("zstacklib.gpu.vendors.nvidia.time.time", return_value=1031), \
+                patch("zstacklib.gpu.vendors.nvidia.bash_roe") as bash_roe, \
+                gpu_operation_gate.critical():
+            metrics = NVIDIA.collect_metrics()
+
+        self.assertEqual(len(metrics), 1)
+        bash_roe.assert_not_called()
+
+    def test_query_gpu_details_has_hard_timeout(self):
+        output = "0, 00000000:1A:00.0, NVIDIA GeForce RTX 3090, 24576, 580.142"
+        with patch.object(NVIDIA, "is_available", return_value=True), \
+                patch("zstacklib.gpu.vendors.nvidia.bash_roe",
+                      return_value=(0, output, "")) as bash_roe:
+            details = NVIDIA.query_gpu_details()
+
+        self.assertIn("0000:1a:00.0", details)
+        self.assertTrue(bash_roe.call_args[0][0].startswith(
+            "timeout 12 nvidia-smi --query-gpu=index"))
+
+    def test_prepared_context_reuses_tensorfusion_prerequisites_for_eight_gpus(self):
+        gpu_info_map = {}
+        for index in range(8):
+            address = "0000:%02x:00.0" % (0x1a + index)
+            gpu_info_map[address] = {
+                '_vendor': 'NVIDIA',
+                '_deviceId': '2204',
+                'driverVersion': '580.142',
+            }
+        prepared = NVIDIA.prepare_capability_context(gpu_info_map)
+        commands = []
+
+        def run_command(command):
+            commands.append(command)
+            return 0, '', ''
+
+        with patch("zstacklib.gpu.vendors.nvidia.bash_roe", side_effect=run_command), \
+                patch.object(NVIDIA, "_is_bound_to_vfio", return_value=False), \
+                patch("zstacklib.gpu.vendors.nvidia.os.path.exists", return_value=False):
+            for address in gpu_info_map:
+                pci_device = type('PciDeviceTO', (), {
+                    'pciDeviceAddress': address,
+                })()
+                supported, info = NVIDIA.detect_tensorfusion_capability(
+                    pci_device, prepared)
+                self.assertTrue(supported)
+                self.assertEqual(info.get('driverVersion'), '580.142')
+
+        self.assertEqual(commands, [
+            'which docker',
+            'which nvidia-ctk',
+            'docker image inspect tf-worker:latest',
+        ])
+        self.assertFalse(any('nvidia-smi' in command for command in commands))
+
+    def test_vgpu_probe_reuses_static_result_without_sysfs_capability_signal(self):
+        gpu_info_map = {}
+        for index in range(8):
+            address = "0000:%02x:00.0" % (0x1a + index)
+            gpu_info_map[address] = {
+                '_vendor': 'NVIDIA',
+                '_deviceId': '2204',
+                'driverVersion': '580.142',
+            }
+        prepared = NVIDIA.prepare_capability_context(gpu_info_map)
+
+        with patch("zstacklib.gpu.vendors.nvidia.bash_roe",
+                   return_value=(0, "No supported devices", "")) as bash_roe, \
+                patch.object(NVIDIA, "_is_bound_to_vfio", return_value=False), \
+                patch("zstacklib.gpu.vendors.nvidia.os.path.isdir", return_value=False), \
+                patch("zstacklib.gpu.vendors.nvidia.os.path.exists", return_value=False):
+            for address in gpu_info_map:
+                pci_device = type('PciDeviceTO', (), {
+                    'pciDeviceAddress': address,
+                })()
+                supported, info = NVIDIA.detect_vfio_mdev_capability(
+                    pci_device, prepared)
+                self.assertFalse(supported)
+                self.assertEqual(info, {})
+
+        bash_roe.assert_called_once_with(
+            "timeout 10 nvidia-smi vgpu -i 0000:1a:00.0 -s")
+
+    def test_vgpu_probe_bounds_transient_family_failures(self):
+        gpu_info_map = {}
+        for index in range(8):
+            address = "0000:%02x:00.0" % (0x1a + index)
+            gpu_info_map[address] = {
+                '_deviceId': '2204',
+                'driverVersion': '580.142',
+            }
+        prepared = NVIDIA.prepare_capability_context(gpu_info_map)
+
+        with patch("zstacklib.gpu.vendors.nvidia.bash_roe",
+                   return_value=(124, "", "timed out")) as bash_roe, \
+                patch.object(NVIDIA, "_is_bound_to_vfio", return_value=False), \
+                patch("zstacklib.gpu.vendors.nvidia.os.path.isdir", return_value=False), \
+                patch("zstacklib.gpu.vendors.nvidia.os.path.exists", return_value=False):
+            for address in gpu_info_map:
+                pci_device = type('PciDeviceTO', (), {
+                    'pciDeviceAddress': address,
+                })()
+                self.assertFalse(NVIDIA.detect_vfio_mdev_capability(
+                    pci_device, prepared)[0])
+
+        self.assertEqual(bash_roe.call_count, 3)
+        self.assertEqual(prepared['vgpu_families'], {})
+
+    def test_vgpu_probe_recovers_after_two_transient_family_failures(self):
+        addresses = ["0000:%02x:00.0" % (0x1a + index)
+                     for index in range(4)]
+        gpu_info_map = dict((address, {
+            '_deviceId': '26b9',
+            'driverVersion': '580.142',
+        }) for address in addresses)
+        prepared = NVIDIA.prepare_capability_context(gpu_info_map)
+        output = ("GPU 00000000:1C:00.0\n"
+                  "vGPU Type ID : 239\n"
+                  "Name : GRID L20-4Q\n")
+        probe_results = [(124, "", "timed out"),
+                         (124, "", "timed out"),
+                         (0, output, "")]
+
+        with patch("zstacklib.gpu.vendors.nvidia.bash_roe",
+                   side_effect=probe_results) as bash_roe, \
+                patch.object(NVIDIA, "_is_bound_to_vfio", return_value=False), \
+                patch.object(NVIDIA, "_has_mdev_for_pci_address",
+                             return_value=False), \
+                patch("zstacklib.gpu.vendors.nvidia.os.path.isdir",
+                      return_value=True):
+            results = []
+            for address in addresses:
+                pci_device = type('PciDeviceTO', (), {
+                    'pciDeviceAddress': address,
+                })()
+                results.append(NVIDIA.detect_vfio_mdev_capability(
+                    pci_device, prepared))
+
+        self.assertEqual([supported for supported, _ in results],
+                         [False, False, True, True])
+        self.assertEqual(bash_roe.call_count, 3)
+        self.assertTrue(list(prepared['vgpu_families'].values())[0]
+                        ['supported'])
+
+    def test_vgpu_probe_caches_only_static_supported_types_per_family(self):
+        addresses = ["0000:1a:00.0", "0000:1b:00.0"]
+        gpu_info_map = dict((address, {
+            '_deviceId': '26b9',
+            'driverVersion': '580.142',
+        }) for address in addresses)
+        prepared = NVIDIA.prepare_capability_context(gpu_info_map)
+        output = ("GPU 00000000:1A:00.0\n"
+                  "vGPU Type ID : 239\n"
+                  "Name : GRID L20-4Q\n")
+
+        with patch("zstacklib.gpu.vendors.nvidia.bash_roe",
+                   return_value=(0, output, "")) as bash_roe, \
+                patch.object(NVIDIA, "_is_bound_to_vfio", return_value=False), \
+                patch.object(NVIDIA, "_has_mdev_for_pci_address", return_value=False), \
+                patch("zstacklib.gpu.vendors.nvidia.os.path.isdir", return_value=True):
+            results = []
+            for address in addresses:
+                pci_device = type('PciDeviceTO', (), {
+                    'pciDeviceAddress': address,
+                })()
+                results.append(NVIDIA.detect_vfio_mdev_capability(
+                    pci_device, prepared))
+
+        self.assertTrue(all(supported for supported, _ in results))
+        self.assertTrue(all(info['mdevSpecifications'][0]['TypeId'] == '239'
+                            for _, info in results))
+        bash_roe.assert_called_once_with(
+            "timeout 10 nvidia-smi vgpu -i 0000:1a:00.0 -s")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zstacklib/zstacklib/gpu/tests/test_operation_gate.py
+++ b/zstacklib/zstacklib/gpu/tests/test_operation_gate.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+
+import threading
+import time
+import unittest
+
+from zstacklib.gpu.operation_gate import GPUOperationGate
+
+
+class TestGPUOperationGate(unittest.TestCase):
+    def test_monitoring_is_rejected_while_critical_operation_is_active(self):
+        gate = GPUOperationGate()
+        critical_entered = threading.Event()
+        release_critical = threading.Event()
+
+        def run_critical():
+            with gate.critical():
+                critical_entered.set()
+                release_critical.wait(1)
+
+        thread = threading.Thread(target=run_critical)
+        thread.start()
+        self.assertTrue(critical_entered.wait(1))
+
+        with gate.monitoring() as acquired:
+            self.assertFalse(acquired)
+
+        release_critical.set()
+        thread.join(1)
+        self.assertFalse(thread.is_alive())
+
+    def test_waiting_critical_operation_prevents_new_monitoring(self):
+        gate = GPUOperationGate()
+        critical_entered = threading.Event()
+
+        with gate.monitoring() as first_monitoring:
+            self.assertTrue(first_monitoring)
+
+            def run_critical():
+                with gate.critical():
+                    critical_entered.set()
+
+            thread = threading.Thread(target=run_critical)
+            thread.start()
+            self._wait_for_critical_waiter(gate)
+
+            with gate.monitoring() as second_monitoring:
+                self.assertFalse(second_monitoring)
+
+        self.assertTrue(critical_entered.wait(1))
+        thread.join(1)
+        self.assertFalse(thread.is_alive())
+
+    def test_context_releases_gate_after_exception(self):
+        gate = GPUOperationGate()
+
+        with self.assertRaises(RuntimeError):
+            with gate.critical():
+                raise RuntimeError('failed GPU operation')
+
+        with gate.monitoring() as acquired:
+            self.assertTrue(acquired)
+
+    def test_critical_operation_is_reentrant(self):
+        gate = GPUOperationGate()
+
+        with gate.critical():
+            with gate.critical():
+                with gate.monitoring() as acquired:
+                    self.assertFalse(acquired)
+
+        with gate.monitoring() as acquired:
+            self.assertTrue(acquired)
+
+    @staticmethod
+    def _wait_for_critical_waiter(gate):
+        deadline = time.time() + 1
+        while time.time() < deadline:
+            with gate._condition:
+                if gate._critical_waiters:
+                    return
+            time.sleep(0.001)
+        raise AssertionError('critical operation did not start waiting')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zstacklib/zstacklib/gpu/vendors/nvidia.py
+++ b/zstacklib/zstacklib/gpu/vendors/nvidia.py
@@ -6,6 +6,7 @@ NVIDIA GPU Vendor Implementation (Python 2/3 Compatible)
 import os
 import re
 import threading
+import time
 
 from zstacklib.utils import log, linux
 from zstacklib.utils.bash import bash_roe
@@ -16,6 +17,7 @@ from zstacklib.gpu.base import (
     VGPUMetrics,
     register_gpu_vendor
 )
+from zstacklib.gpu.operation_gate import gpu_operation_gate
 
 logger = log.get_logger(__name__)
 
@@ -40,6 +42,23 @@ class NVIDIA(GPUBase):
     # Device types recognized as GPU
     DEVICE_TYPES = {"3D controller", "VGA compatible controller"}
     IS_GPU_VENDOR = True
+
+    _metrics_lock = threading.Lock()
+    _metrics_cache = []
+    _metrics_cache_time = 0
+    _pcie_metrics_cache = {}
+    _pcie_last_attempt = {}
+    _pcie_blocked_until = {}
+    _basic_info_lock = threading.Lock()
+    _basic_info_cache = []
+    _basic_info_cache_time = 0
+
+    METRICS_CACHE_SECONDS = 30
+    METRICS_LAST_GOOD_SECONDS = 300
+    QUERY_TIMEOUT_SECONDS = 12
+    PCIE_CACHE_SECONDS = 60
+    PCIE_CIRCUIT_BREAKER_SECONDS = 300
+    VGPU_FAMILY_MAX_PROBE_ATTEMPTS = 3
 
     # ==========================================================================
     # PCI-only fallback (no nvidia-smi): match by vendor_id + class
@@ -104,11 +123,69 @@ class NVIDIA(GPUBase):
         2. memory.total   - Total GPU memory
         3. power.limit    - Power limit
         4. gpu_serial     - Serial number
+        5. driver_version - NVIDIA driver version
         """
-        cmd = "nvidia-smi --query-gpu=gpu_bus_id,memory.total,power.limit,gpu_serial --format=csv,noheader"
+        cmd = "nvidia-smi --query-gpu=gpu_bus_id,memory.total,power.limit,gpu_serial,driver_version --format=csv,noheader"
         if is_windows:
             cmd = cmd.replace(" ", "|")
         return cmd
+
+    @classmethod
+    def get_basic_info(cls):
+        if not cls.is_available():
+            return []
+
+        now = time.time()
+        with cls._basic_info_lock:
+            cache_age = now - cls._basic_info_cache_time
+            if cls._basic_info_cache_time and cache_age < cls.METRICS_CACHE_SECONDS:
+                return list(cls._basic_info_cache)
+
+            error = ''
+            cached_inventory = cls._basic_info_inventory(
+                cls._basic_info_cache)
+            for _ in range(2):
+                r, output, error = cls._run_critical_command(
+                    "timeout %s %s" %
+                    (cls.QUERY_TIMEOUT_SECONDS, cls.get_basic_info_cmd()))
+                parsed = cls.parse_basic_info(output) if r == 0 else []
+                has_usable_cache = (cls._basic_info_cache and
+                                    cache_age < cls.METRICS_LAST_GOOD_SECONDS)
+                if not parsed:
+                    continue
+
+                inventory = cls._basic_info_inventory(parsed)
+                missing_inventory = cached_inventory - inventory
+                inventory_is_current = (
+                    not has_usable_cache or
+                    not missing_inventory or
+                    not any(cls._is_nvidia_driver_bound(pci_address)
+                            for pci_address in missing_inventory))
+                if inventory_is_current:
+                    cls._basic_info_cache = parsed
+                    cls._basic_info_cache_time = now
+                    return list(parsed)
+
+            if cls._basic_info_cache and cache_age < cls.METRICS_LAST_GOOD_SECONDS:
+                logger.warn("NVIDIA basic info query returned incomplete data, using last-good cache")
+                return list(cls._basic_info_cache)
+            logger.warn("Failed to get basic info for NVIDIA: %s" % error)
+            return []
+
+    @staticmethod
+    def _basic_info_inventory(gpu_infos):
+        return frozenset(info.pci_address for info in gpu_infos
+                         if info.pci_address)
+
+    @staticmethod
+    def _is_nvidia_driver_bound(pci_address):
+        device_path = os.path.join('/sys/bus/pci/devices', pci_address)
+        if not os.path.exists(device_path):
+            return False
+        driver_link = os.path.join(device_path, 'driver')
+        if not os.path.islink(driver_link):
+            return False
+        return os.path.basename(os.path.realpath(driver_link)) == 'nvidia'
 
     @classmethod
     def parse_basic_info(cls, output):
@@ -135,12 +212,16 @@ class NVIDIA(GPUBase):
             memory = parts[1].strip()
             power = parts[2].strip()
             serial = parts[3].strip()
+            extra = {}
+            if len(parts) >= 5:
+                extra['driverVersion'] = parts[4].strip()
 
             results.append(GPUInfo(
                 pci_address=pci_address,
                 memory=memory,
                 power=power,
-                serial_number=serial
+                serial_number=serial,
+                extra=extra
             ))
         return results
 
@@ -194,39 +275,139 @@ class NVIDIA(GPUBase):
             gpu_index = parts[5].strip()
             serial = parts[6]
 
-            # Get PCIe metrics
-            pcie_tx_bytes = None
-            pcie_rx_bytes = None
-            if gpu_index:
-                try:
-                    r, pci_output, _ = bash_roe(
-                        "nvidia-smi pci -gCnt -i %s" % gpu_index)
-                    if r == 0 and pci_output:
-                        for pci_line in pci_output.splitlines():
-                            pci_line = pci_line.strip()
-                            if pci_line.startswith("TX_BYTES:"):
-                                tx_value = pci_line.split()[-1]
-                                pcie_tx_bytes = cls.parse_unit_value(tx_value)
-                            elif pci_line.startswith("RX_BYTES:"):
-                                rx_value = pci_line.split()[-1]
-                                pcie_rx_bytes = cls.parse_unit_value(rx_value)
-                except Exception as e:
-                    logger.debug(
-                        "Failed to get PCIe metrics for GPU %s: %s" % (gpu_index, str(e)))
-
             metrics = GPUMetrics(
                 pci_address=pci_address,
                 serial_number=serial,
                 utilization=util,
                 memory_utilization=mem_util,
                 temperature=temp,
-                power_draw=power,
-                pcie_tx_bytes=pcie_tx_bytes,
-                pcie_rx_bytes=pcie_rx_bytes
+                power_draw=power
             )
+            metrics._nvidia_index = gpu_index
 
             results.append(metrics)
         return results
+
+    @classmethod
+    def collect_metrics(cls):
+        if not cls.is_available():
+            return []
+
+        now = time.time()
+        with cls._metrics_lock:
+            cache_age = now - cls._metrics_cache_time
+            if not cls._metrics_cache_time or cache_age >= cls.METRICS_CACHE_SECONDS:
+                result = cls._run_monitoring_command(
+                    "timeout %s %s" %
+                    (cls.QUERY_TIMEOUT_SECONDS, cls.get_metric_cmd()))
+                if result is None:
+                    if cache_age >= cls.METRICS_LAST_GOOD_SECONDS:
+                        cls._metrics_cache = []
+                    cls._apply_cached_pcie_metrics(cls._metrics_cache, now)
+                    return list(cls._metrics_cache)
+                r, output, error = result
+                if r == 0:
+                    try:
+                        parsed = cls.parse_metrics(output)
+                        has_usable_cache = (cls._metrics_cache and
+                                            cache_age < cls.METRICS_LAST_GOOD_SECONDS)
+                        if parsed and (not has_usable_cache or
+                                       len(parsed) >= len(cls._metrics_cache)):
+                            cls._metrics_cache = parsed
+                            cls._metrics_cache_time = now
+                        elif not parsed and cache_age >= cls.METRICS_LAST_GOOD_SECONDS:
+                            cls._metrics_cache = []
+                    except Exception as ex:
+                        logger.warn("Failed to parse NVIDIA metrics: %s" % str(ex))
+                elif cache_age >= cls.METRICS_LAST_GOOD_SECONDS:
+                    logger.warn("Failed to collect NVIDIA metrics: %s" % error)
+                    cls._metrics_cache = []
+
+            metrics = cls._metrics_cache
+            cls._collect_pcie_metrics(metrics, now)
+            cls._apply_cached_pcie_metrics(metrics, now)
+            return list(metrics)
+
+    @classmethod
+    def _collect_pcie_metrics(cls, metrics, now):
+        if not metrics:
+            return
+
+        cache_key = '_all'
+        if now < cls._pcie_blocked_until.get(cache_key, 0):
+            return
+        if now - cls._pcie_last_attempt.get(cache_key, 0) < cls.PCIE_CACHE_SECONDS:
+            return
+
+        cls._pcie_last_attempt[cache_key] = now
+        result = cls._run_monitoring_command("timeout 10 nvidia-smi pci -gCnt")
+        if result is None:
+            return
+        r, output, error = result
+        if r != 0:
+            cls._pcie_blocked_until[cache_key] = now + cls.PCIE_CIRCUIT_BREAKER_SECONDS
+            logger.debug("Failed to collect NVIDIA PCIe metrics: %s" % error)
+            return
+
+        values_by_index = cls._parse_pcie_metrics(output)
+        if not values_by_index:
+            cls._pcie_blocked_until[cache_key] = now + cls.PCIE_CIRCUIT_BREAKER_SECONDS
+            return
+
+        for metric in metrics:
+            gpu_index = getattr(metric, '_nvidia_index', None)
+            if gpu_index not in values_by_index:
+                continue
+            tx_bytes, rx_bytes = values_by_index[gpu_index]
+            cls._pcie_metrics_cache[metric.pci_address] = (
+                tx_bytes, rx_bytes, now)
+        cls._pcie_blocked_until.pop(cache_key, None)
+
+    @classmethod
+    def _apply_cached_pcie_metrics(cls, metrics, now):
+        for metric in metrics:
+            cached = cls._pcie_metrics_cache.get(metric.pci_address)
+            if not cached or now - cached[2] >= cls.METRICS_LAST_GOOD_SECONDS:
+                metric.pcie_tx_bytes = None
+                metric.pcie_rx_bytes = None
+                continue
+            metric.pcie_tx_bytes = cached[0]
+            metric.pcie_rx_bytes = cached[1]
+
+    @classmethod
+    def _parse_pcie_metrics(cls, output):
+        result = {}
+        gpu_index = None
+        tx_bytes = None
+        rx_bytes = None
+        for line in (output or '').splitlines():
+            line = line.strip()
+            match = re.match(r'^GPU\s+(\d+):', line)
+            if match:
+                if gpu_index is not None and (tx_bytes is not None or rx_bytes is not None):
+                    result[gpu_index] = (tx_bytes, rx_bytes)
+                gpu_index = match.group(1)
+                tx_bytes = None
+                rx_bytes = None
+            elif line.startswith("TX_BYTES:"):
+                tx_bytes = cls.parse_unit_value(line.split()[-1])
+            elif line.startswith("RX_BYTES:"):
+                rx_bytes = cls.parse_unit_value(line.split()[-1])
+        if gpu_index is not None and (tx_bytes is not None or rx_bytes is not None):
+            result[gpu_index] = (tx_bytes, rx_bytes)
+        return result
+
+    @classmethod
+    def _run_critical_command(cls, command):
+        with gpu_operation_gate.critical():
+            return bash_roe(command)
+
+    @classmethod
+    def _run_monitoring_command(cls, command):
+        with gpu_operation_gate.monitoring() as acquired:
+            if not acquired:
+                return None
+            return bash_roe(command)
 
     @classmethod
     def collect_vgpu_metrics(cls):
@@ -235,7 +416,13 @@ class NVIDIA(GPUBase):
 
         Returns list of VGPUMetrics for each active vGPU.
         """
-        r, output, _ = bash_roe("nvidia-smi vgpu -q")
+        if not cls._has_active_mdev_devices():
+            return []
+
+        result = cls._run_monitoring_command("timeout 5 nvidia-smi vgpu -q")
+        if result is None:
+            return []
+        r, output, _ = result
         if r != 0 or "VM Name" not in output:
             return []
 
@@ -269,6 +456,14 @@ class NVIDIA(GPUBase):
             vgpu_metrics.append(metrics)
 
         return vgpu_metrics
+
+    @classmethod
+    def _has_active_mdev_devices(cls):
+        mdev_dir = "/sys/bus/mdev/devices"
+        try:
+            return os.path.isdir(mdev_dir) and bool(os.listdir(mdev_dir))
+        except OSError:
+            return False
 
     @staticmethod
     def _parse_vgpu_output(output):
@@ -369,7 +564,10 @@ class NVIDIA(GPUBase):
         sm_util: GPU SM utilization percentage from pmon.
         fb_mib: framebuffer usage in MiB (absolute value, converted to % later using worker.allocatedMemoryMb).
         """
-        r, o, _ = bash_roe("timeout 10 nvidia-smi pmon -c 1 -s mu")
+        result = cls._run_monitoring_command("timeout 10 nvidia-smi pmon -c 1 -s mu")
+        if result is None:
+            return {}
+        r, o, _ = result
         if r != 0:
             return {}
 
@@ -671,7 +869,7 @@ class NVIDIA(GPUBase):
         return False
 
     @classmethod
-    def detect_vfio_mdev_capability(cls, pci_device_to):
+    def detect_vfio_mdev_capability(cls, pci_device_to, prepared_context=None):
         """
         Detect NVIDIA vGPU (VFIO mdev) capability.
 
@@ -688,17 +886,20 @@ class NVIDIA(GPUBase):
         legacy_mdev_dir_exists = os.path.isdir(check_mdev_folder)
         check_virtfn_folder = '/sys/bus/pci/devices/%s/virtfn0/mdev_supported_types' % addr
         virt_function_dir_exits = os.path.isdir(check_virtfn_folder)
-
-        # Check if nvidia vgpu is supported by current device
-        r, o, e = bash_roe("timeout 10 nvidia-smi vgpu -i %s -v -c" % addr)
-        if r != 0 or not o or "No supported devices" in o:
-            # SR-IOV backed vGPU cards (e.g. L20, RTX8000) may not report
-            # creatable types on the PF before VFs are created. Fall back to
-            # supported-types query which still reflects device capability.
-            rs, support, _ = bash_roe("timeout 10 nvidia-smi vgpu -i %s -s" % addr)
-            if rs != 0 or not support or "No supported devices" in support:
+        if prepared_context is not None:
+            probe = cls._get_cached_vgpu_probe(pci_device_to, prepared_context)
+            if not probe['supported']:
                 return False, {}
-            o = support
+            o = probe['output']
+        else:
+            r, o, e = cls._run_critical_command(
+                "timeout 10 nvidia-smi vgpu -i %s -v -c" % addr)
+            if r != 0 or not o or "No supported devices" in o:
+                rs, support, _ = cls._run_critical_command(
+                    "timeout 10 nvidia-smi vgpu -i %s -s" % addr)
+                if rs != 0 or not support or "No supported devices" in support:
+                    return False, {}
+                o = support
 
         mdev_specs = []
         for line in o.splitlines()[1:]:
@@ -720,10 +921,21 @@ class NVIDIA(GPUBase):
 
         # Determine virtStatus based on mdev directory structure
         if legacy_mdev_dir_exists:
+            if prepared_context is not None:
+                if cls._has_mdev_for_pci_address(addr):
+                    cls.set_capability_virt_metadata(
+                        capability_info, "VFIO_MDEV_VIRTUALIZED",
+                        "VIRTUALIZED", "VFIO_MDEV", ["VFIO_MDEV"])
+                else:
+                    cls.set_capability_virt_metadata(
+                        capability_info, "VFIO_MDEV_VIRTUALIZABLE",
+                        "VIRTUALIZABLE", None, ["VFIO_MDEV"])
+                return True, capability_info
+
             # Legacy mdev: check if supported specs != creatable specs
-            rs, support, _ = bash_roe("timeout 10 nvidia-smi vgpu -i %s -s | grep -v %s" %
-                                      (addr, addr))
-            rc, creatable, _ = bash_roe(
+            rs, support, _ = cls._run_critical_command(
+                "timeout 10 nvidia-smi vgpu -i %s -s | grep -v %s" % (addr, addr))
+            rc, creatable, _ = cls._run_critical_command(
                 "timeout 10 nvidia-smi vgpu -i %s -c | grep -v %s" % (addr, addr))
             if rs != 0:
                 return False, {}
@@ -782,6 +994,47 @@ class NVIDIA(GPUBase):
                 "VIRTUALIZABLE", None, ["VFIO_MDEV"])
 
         return True, capability_info
+
+    @classmethod
+    def _get_cached_vgpu_probe(cls, pci_device_to, prepared_context):
+        addr = cls.normalize_pci_address(pci_device_to.pciDeviceAddress)
+        gpu_info = prepared_context.get('gpu_info_map', {}).get(addr, {})
+        family = (gpu_info.get('_deviceId') or getattr(pci_device_to, 'deviceId', None) or addr,
+                  gpu_info.get('driverVersion') or '')
+        cache = prepared_context.setdefault('vgpu_families', {})
+        if family in cache:
+            return cache[family]
+
+        attempts = prepared_context.setdefault('vgpu_family_attempts', {})
+        if attempts.get(family, 0) >= cls.VGPU_FAMILY_MAX_PROBE_ATTEMPTS:
+            return {'supported': False, 'output': '', 'unknown': True}
+        attempts[family] = attempts.get(family, 0) + 1
+
+        r, output, error = cls._run_critical_command(
+            "timeout 10 nvidia-smi vgpu -i %s -s" % addr)
+        supported = r == 0 and "vGPU Type ID" in (output or '')
+        explicit_unsupported = "No supported devices" in (
+            "%s\n%s" % (output or '', error or ''))
+        result = {
+            'supported': supported,
+            'output': output if supported else '',
+            'unknown': not supported and not explicit_unsupported,
+        }
+        if supported or explicit_unsupported:
+            cache[family] = result
+        return result
+
+    @classmethod
+    def _has_mdev_for_pci_address(cls, pci_address):
+        mdev_dir = "/sys/bus/mdev/devices"
+        try:
+            for mdev_uuid in os.listdir(mdev_dir):
+                path = os.path.realpath(os.path.join(mdev_dir, mdev_uuid))
+                if pci_address in path:
+                    return True
+        except OSError:
+            pass
+        return False
 
     @classmethod
     def detect_sriov_capability(cls, pci_device_to, gpu_info_map=None):
@@ -864,7 +1117,7 @@ class NVIDIA(GPUBase):
             return False, {}
 
     @classmethod
-    def detect_tensorfusion_capability(cls, pci_device_to):
+    def detect_tensorfusion_capability(cls, pci_device_to, prepared_context=None):
         """
         Detect NVIDIA TensorFusion (GPU virtualization) capability.
 
@@ -885,17 +1138,25 @@ class NVIDIA(GPUBase):
             logger.debug('TensorFusion capability check skipped for %s: device bound to vfio-pci (passthrough)' % addr)
             return False, {}
 
-        r, o, e = bash_roe('timeout 10 nvidia-smi --query-gpu=pci.bus_id,driver_version --format=csv,noheader -i %s' % addr)
-        if r != 0:
-            logger.debug('TensorFusion capability check failed for %s: nvidia-smi query failed' % addr)
-            return False, {}
+        if prepared_context is not None:
+            normalized = cls.normalize_pci_address(addr)
+            gpu_info = prepared_context.get('gpu_info_map', {}).get(normalized, {})
+            driver_version = gpu_info.get('driverVersion')
+            if not driver_version:
+                logger.debug('TensorFusion capability check failed for %s: driver version missing from batch query' % addr)
+                return False, {}
+        else:
+            r, o, e = cls._run_critical_command(
+                'timeout 10 nvidia-smi --query-gpu=pci.bus_id,driver_version --format=csv,noheader -i %s' % addr)
+            if r != 0:
+                logger.debug('TensorFusion capability check failed for %s: nvidia-smi query failed' % addr)
+                return False, {}
 
-        parts = [p.strip() for p in o.strip().split(',')]
-        if len(parts) < 2:
-            logger.debug('TensorFusion capability check failed for %s: unexpected nvidia-smi output' % addr)
-            return False, {}
-
-        driver_version = parts[1]
+            parts = [p.strip() for p in o.strip().split(',')]
+            if len(parts) < 2:
+                logger.debug('TensorFusion capability check failed for %s: unexpected nvidia-smi output' % addr)
+                return False, {}
+            driver_version = parts[1]
 
         capability_info = {
             'driverVersion': driver_version
@@ -910,26 +1171,11 @@ class NVIDIA(GPUBase):
                 capability_info['reason'] = "Driver version %s < 570.x" % driver_version
                 return False, capability_info
 
-            # Container runtime checks for dGPU virtualization.
-            r_docker, _, _ = bash_roe('which docker')
-            if r_docker != 0:
+            supported, reason = cls._get_tensorfusion_prerequisites(prepared_context)
+            if not supported:
                 cls.set_capability_virt_metadata(
                     capability_info, "TENSORFUSION_NOT_SUPPORTED", "", None, [])
-                capability_info['reason'] = "docker is not installed or not in PATH"
-                return False, capability_info
-
-            r_ctk, _, _ = bash_roe('which nvidia-ctk')
-            if r_ctk != 0:
-                cls.set_capability_virt_metadata(
-                    capability_info, "TENSORFUSION_NOT_SUPPORTED", "", None, [])
-                capability_info['reason'] = "nvidia-container-toolkit (nvidia-ctk) is not installed"
-                return False, capability_info
-
-            r_img, _, _ = bash_roe('docker image inspect tf-worker:latest')
-            if r_img != 0:
-                cls.set_capability_virt_metadata(
-                    capability_info, "TENSORFUSION_NOT_SUPPORTED", "", None, [])
-                capability_info['reason'] = "tf-worker:latest image not found, install via zstack-dgpu-toolkit.bin or docker load"
+                capability_info['reason'] = reason
                 return False, capability_info
 
             # Check if TensorFusion worker can be created (virtualizable)
@@ -946,6 +1192,40 @@ class NVIDIA(GPUBase):
                 capability_info, "TENSORFUSION_NOT_SUPPORTED", "", None, [])
             capability_info['reason'] = "Failed to parse version info"
             return False, capability_info
+
+    @classmethod
+    def prepare_capability_context(cls, gpu_info_map):
+        return {
+            'gpu_info_map': gpu_info_map,
+            'vgpu_families': {},
+            'vgpu_family_attempts': {},
+            'tensorfusion_prerequisites': None,
+        }
+
+    @classmethod
+    def _get_tensorfusion_prerequisites(cls, prepared_context=None):
+        if prepared_context is not None:
+            cached = prepared_context.get('tensorfusion_prerequisites')
+            if cached is not None:
+                return cached
+
+        r_docker, _, _ = bash_roe('which docker')
+        if r_docker != 0:
+            result = (False, "docker is not installed or not in PATH")
+        else:
+            r_ctk, _, _ = bash_roe('which nvidia-ctk')
+            if r_ctk != 0:
+                result = (False, "nvidia-container-toolkit (nvidia-ctk) is not installed")
+            else:
+                r_img, _, _ = bash_roe('docker image inspect tf-worker:latest')
+                if r_img != 0:
+                    result = (False, "tf-worker:latest image not found, install via zstack-dgpu-toolkit.bin or docker load")
+                else:
+                    result = (True, '')
+
+        if prepared_context is not None:
+            prepared_context['tensorfusion_prerequisites'] = result
+        return result
 
     # ==========================================================================
     # GPU Detail Query
@@ -967,8 +1247,9 @@ class NVIDIA(GPUBase):
             logger.warn('nvidia-smi not available')
             return {}
 
-        _DETAIL_QUERY_CMD = ('nvidia-smi --query-gpu=index,pci.bus_id,name,memory.total,driver_version '
-                             '--format=csv,noheader,nounits')
+        _DETAIL_QUERY_CMD = (
+            'timeout %s nvidia-smi --query-gpu=index,pci.bus_id,name,memory.total,driver_version '
+            '--format=csv,noheader,nounits' % cls.QUERY_TIMEOUT_SECONDS)
 
         r, o, e = bash_roe(_DETAIL_QUERY_CMD)
         if r != 0:

--- a/zstacklib/zstacklib/gpu/vendors/nvidia.py
+++ b/zstacklib/zstacklib/gpu/vendors/nvidia.py
@@ -142,7 +142,7 @@ class NVIDIA(GPUBase):
                 return list(cls._basic_info_cache)
 
             error = ''
-            cached_inventory = cls._basic_info_inventory(
+            cached_inventory = cls._inventory(
                 cls._basic_info_cache)
             for _ in range(2):
                 r, output, error = cls._run_critical_command(
@@ -154,7 +154,7 @@ class NVIDIA(GPUBase):
                 if not parsed:
                     continue
 
-                inventory = cls._basic_info_inventory(parsed)
+                inventory = cls._inventory(parsed)
                 missing_inventory = cached_inventory - inventory
                 inventory_is_current = (
                     not has_usable_cache or
@@ -173,7 +173,7 @@ class NVIDIA(GPUBase):
             return []
 
     @staticmethod
-    def _basic_info_inventory(gpu_infos):
+    def _inventory(gpu_infos):
         return frozenset(info.pci_address for info in gpu_infos
                          if info.pci_address)
 
@@ -296,6 +296,7 @@ class NVIDIA(GPUBase):
         now = time.time()
         with cls._metrics_lock:
             cache_age = now - cls._metrics_cache_time
+            cached_inventory = cls._inventory(cls._metrics_cache)
             if not cls._metrics_cache_time or cache_age >= cls.METRICS_CACHE_SECONDS:
                 result = cls._run_monitoring_command(
                     "timeout %s %s" %
@@ -311,8 +312,13 @@ class NVIDIA(GPUBase):
                         parsed = cls.parse_metrics(output)
                         has_usable_cache = (cls._metrics_cache and
                                             cache_age < cls.METRICS_LAST_GOOD_SECONDS)
-                        if parsed and (not has_usable_cache or
-                                       len(parsed) >= len(cls._metrics_cache)):
+                        missing_inventory = cached_inventory - cls._inventory(parsed)
+                        inventory_is_current = (
+                            not has_usable_cache or
+                            not missing_inventory or
+                            not any(cls._is_nvidia_driver_bound(pci_address)
+                                    for pci_address in missing_inventory))
+                        if parsed and inventory_is_current:
                             cls._metrics_cache = parsed
                             cls._metrics_cache_time = now
                         elif not parsed and cache_age >= cls.METRICS_LAST_GOOD_SECONDS:
@@ -339,10 +345,10 @@ class NVIDIA(GPUBase):
         if now - cls._pcie_last_attempt.get(cache_key, 0) < cls.PCIE_CACHE_SECONDS:
             return
 
-        cls._pcie_last_attempt[cache_key] = now
         result = cls._run_monitoring_command("timeout 10 nvidia-smi pci -gCnt")
         if result is None:
             return
+        cls._pcie_last_attempt[cache_key] = now
         r, output, error = result
         if r != 0:
             cls._pcie_blocked_until[cache_key] = now + cls.PCIE_CIRCUIT_BREAKER_SECONDS
@@ -541,6 +547,8 @@ class NVIDIA(GPUBase):
 
         # Get per-PID GPU metrics from nvidia-smi pmon
         pmon = cls._parse_pmon_output()
+        if pmon is None:
+            return []
 
         # Iterate all workers; default to 0 if not found in pmon
         result = []
@@ -566,10 +574,10 @@ class NVIDIA(GPUBase):
         """
         result = cls._run_monitoring_command("timeout 10 nvidia-smi pmon -c 1 -s mu")
         if result is None:
-            return {}
+            return None
         r, o, _ = result
         if r != 0:
-            return {}
+            return None
 
         # nvidia-smi pmon -c 1 -s mu output columns:
         # gpu  pid  type  fb  ccpm  sm  mem  enc  dec  jpg  ofa  command

--- a/zstacklib/zstacklib/utils/gpu.py
+++ b/zstacklib/zstacklib/utils/gpu.py
@@ -925,12 +925,23 @@ def _gpu_device_processor(pci_device_to, context):
                         return False, {}
 
                 # Detect all capabilities independently (no short-circuit)
-                vfio_mdev_supported, vfio_mdev_info = _safe_detect(
-                    "vfio_mdev", vendor_class.detect_vfio_mdev_capability, pci_device_to)
+                vendor_context = (getattr(context, 'gpu_vendor_context', None) or {}).get(vendor_name)
+                if vendor_context is not None:
+                    vfio_mdev_supported, vfio_mdev_info = _safe_detect(
+                        "vfio_mdev", vendor_class.detect_vfio_mdev_capability,
+                        pci_device_to, vendor_context)
+                else:
+                    vfio_mdev_supported, vfio_mdev_info = _safe_detect(
+                        "vfio_mdev", vendor_class.detect_vfio_mdev_capability, pci_device_to)
                 sriov_supported, sriov_info = _safe_detect(
                     "sriov", vendor_class.detect_sriov_capability, pci_device_to, gpu_info_map)
-                tensorfusion_supported, tensorfusion_info = _safe_detect(
-                    "tensorfusion", vendor_class.detect_tensorfusion_capability, pci_device_to)
+                if vendor_context is not None:
+                    tensorfusion_supported, tensorfusion_info = _safe_detect(
+                        "tensorfusion", vendor_class.detect_tensorfusion_capability,
+                        pci_device_to, vendor_context)
+                else:
+                    tensorfusion_supported, tensorfusion_info = _safe_detect(
+                        "tensorfusion", vendor_class.detect_tensorfusion_capability, pci_device_to)
 
                 # Apply non-virtStatus attributes
                 if vfio_mdev_supported and 'mdevSpecifications' in vfio_mdev_info:
@@ -980,7 +991,8 @@ def _gpu_device_processor(pci_device_to, context):
     vendor_name = pci_device_to.vendor if hasattr(
         pci_device_to, 'vendor') else None
     if vendor_name and normalized_pci and normalized_pci in gpu_info_map:
-        info = gpu_info_map[normalized_pci].copy()
+        info = dict((key, value) for key, value in gpu_info_map[normalized_pci].items()
+                    if not key.startswith('_'))
         pci_device_to.addonInfo = info
 
         # Set ramSize from gpu_info_map when present (e.g. Alibaba ppu-smi memory)
@@ -2014,6 +2026,7 @@ def get_all_gpu_infos_by_pci():
                             if normalized_pci.endswith('.0'):
                                 result = gpu_info.to_addon_dict()
                                 result.update(gpu_info.extra)
+                                result['_vendor'] = vendor_class.VENDOR_NAME
                                 gpu_info_map[normalized_pci] = result
                             else:
                                 logger.debug("Skipping non-function-0 GPU device: %s (vendor: %s)" %
@@ -2216,6 +2229,17 @@ def _gpu_device_prepare(context):
 
     # Store in context for use by device ops and other components (e.g., sriov detection)
     context.gpu_info_map = gpu_info_map
+    context.gpu_vendor_context = {}
+
+    from zstacklib.gpu import get_all_gpu_vendors
+    for vendor_class in get_all_gpu_vendors():
+        prepare = getattr(vendor_class, 'prepare_capability_context', None)
+        if not prepare:
+            continue
+        if not any(info.get('_vendor') == vendor_class.VENDOR_NAME
+                   for info in gpu_info_map.values()):
+            continue
+        context.gpu_vendor_context[vendor_class.VENDOR_NAME] = prepare(gpu_info_map)
 
     # No post-prepare hook needed anymore
     # SR-IOV detection is now handled by vendor methods in GPU device ops

--- a/zstacklib/zstacklib/utils/gpu.py
+++ b/zstacklib/zstacklib/utils/gpu.py
@@ -1431,7 +1431,7 @@ def get_info(pci_address=None, pci_device=None, vendor_name=None):
     Automatically handles:
     - Auto-identify vendor (if not provided)
     - Prioritize plugin (no environment variable check, try directly)
-    - Auto fallback to legacy when plugin fails
+    - Use legacy fallback when it is safe to retry
     - Handle all vendor-specific fields (Huawei npuId, product name, etc.)
 
     Args:
@@ -1477,6 +1477,7 @@ def get_info(pci_address=None, pci_device=None, vendor_name=None):
     pci_address = normalized_pci
 
     # 2. Try using plugin (no environment variable check, try directly)
+    nvidia_plugin_attempted = False
     try:
         from zstacklib.gpu import (
             get_gpu_vendor,
@@ -1491,6 +1492,7 @@ def get_info(pci_address=None, pci_device=None, vendor_name=None):
         if plugin_vendor_name:
             plugin = get_gpu_vendor(plugin_vendor_name)
             if plugin and plugin.is_available():
+                nvidia_plugin_attempted = vendor_name == VendorEnum.NVIDIA
                 # Use plugin to collect information
                 gpu_infos = plugin.get_basic_info()
                 for gpu_info in gpu_infos:
@@ -1562,11 +1564,12 @@ def get_info(pci_address=None, pci_device=None, vendor_name=None):
                                     "Failed to get Alibaba product name: %s" % str(e))
 
                         return result
-                # Plugin ran but no matching GPU found (e.g. hy-smi "No device available" in VM)
-                # Fall through to legacy so vendor can return minimal addon and device still recognized as GPU
     except Exception as e:
-        logger.debug("Plugin failed for %s, fallback to legacy: %s" %
+        logger.debug("Plugin failed for %s: %s" %
                      (pci_address, str(e)))
+
+    if nvidia_plugin_attempted:
+        return None
 
     # 3. Fallback to legacy (error tolerance mechanism)
     return _get_info_legacy(pci_address, vendor_name)
@@ -1612,7 +1615,10 @@ def _collect_nvidia_legacy(pci_address):
     if r != 0:
         return None
 
-    r, o, e = bash_roe(get_nvidia_gpu_basic_info_cmd())
+    from zstacklib.gpu.vendors.nvidia import NVIDIA
+    r, o, e = NVIDIA._run_critical_command(
+        "timeout %s %s" %
+        (NVIDIA.QUERY_TIMEOUT_SECONDS, get_nvidia_gpu_basic_info_cmd()))
     if r != 0:
         return None
 

--- a/zstacklib/zstacklib/utils/test_gpu_get_info.py
+++ b/zstacklib/zstacklib/utils/test_gpu_get_info.py
@@ -15,6 +15,7 @@ from zstacklib.gpu.base import (
     PCI_CLASS_VGA,
     PCI_CLASS_PROCESSING_ACCEL,
 )
+from zstacklib.gpu.vendors.nvidia import NVIDIA
 from zstacklib.utils import gpu
 import unittest
 import sys
@@ -108,18 +109,19 @@ class TestGetInfo(unittest.TestCase):
             # Product name should be collected
             # Note: This requires actual implementation of get_huawei_product_type
 
+    @patch.object(NVIDIA, '_run_critical_command')
     @patch('zstacklib.utils.gpu.bash_roe')
-    def test_get_info_legacy_nvidia(self, mock_bash):
+    def test_get_info_legacy_nvidia(self, mock_bash, mock_run_critical):
         """Test get_info legacy fallback for NVIDIA"""
-        mock_bash.side_effect = [
-            (0, "/usr/bin/nvidia-smi", ""),  # which nvidia-smi
-            # nvidia-smi query
-            (0, "00000000:3B:00.0, 15360 MiB, 70.00 W, 1322519087621", ""),
-        ]
+        mock_bash.return_value = (0, "/usr/bin/nvidia-smi", "")
+        mock_run_critical.return_value = (
+            0, "00000000:3B:00.0, 15360 MiB, 70.00 W, 1322519087621", "")
 
         result = gpu._get_info_legacy("0000:3b:00.0", VendorEnum.NVIDIA)
         self.assertIsNotNone(result)
         self.assertTrue(result.get("isDriverLoaded", False))
+        mock_run_critical.assert_called_once_with(
+            "timeout 12 nvidia-smi --query-gpu=gpu_bus_id,memory.total,power.limit,gpu_serial --format=csv,noheader")
 
     @patch('zstacklib.utils.gpu.bash_roe')
     def test_get_info_legacy_amd(self, mock_bash):
@@ -236,22 +238,42 @@ class TestGetInfo(unittest.TestCase):
 
             result = gpu.get_info("0000:3b:00.0", vendor_name=VendorEnum.NVIDIA)
             self.assertIsNone(result)
+            mock_bash.assert_not_called()
+
+    @patch('zstacklib.utils.gpu.bash_roe')
+    def test_get_info_does_not_retry_nvidia_legacy_after_plugin_failure(
+            self, mock_bash):
+        with patch('zstacklib.gpu.get_gpu_vendor') as mock_get_vendor, \
+                patch('zstacklib.gpu.get_vendor_enum_mapping') as mock_mapping:
+            mock_plugin = MagicMock()
+            mock_plugin.is_available.return_value = True
+            mock_plugin.get_basic_info.side_effect = RuntimeError("NVML busy")
+            mock_get_vendor.return_value = mock_plugin
+            mock_mapping.return_value = {"NVIDIA": "NVIDIA"}
+
+            result = gpu.get_info(
+                "0000:3b:00.0", vendor_name=VendorEnum.NVIDIA)
+
+        self.assertIsNone(result)
+        mock_bash.assert_not_called()
 
 
 class TestLegacyCollectors(unittest.TestCase):
     """Test legacy collection functions for each vendor"""
 
+    @patch.object(NVIDIA, '_run_critical_command')
     @patch('zstacklib.utils.gpu.bash_roe')
-    def test_collect_nvidia_legacy(self, mock_bash):
+    def test_collect_nvidia_legacy(self, mock_bash, mock_run_critical):
         """Test _collect_nvidia_legacy"""
-        mock_bash.side_effect = [
-            (0, "/usr/bin/nvidia-smi", ""),  # which
-            (0, "00000000:3B:00.0, 15360 MiB, 70.00 W, SN001", ""),  # nvidia-smi
-        ]
+        mock_bash.return_value = (0, "/usr/bin/nvidia-smi", "")
+        mock_run_critical.return_value = (
+            0, "00000000:3B:00.0, 15360 MiB, 70.00 W, SN001", "")
 
         result = gpu._collect_nvidia_legacy("0000:3b:00.0")
         self.assertIsNotNone(result)
         self.assertTrue(result.get("isDriverLoaded", False))
+        mock_run_critical.assert_called_once_with(
+            "timeout 12 nvidia-smi --query-gpu=gpu_bus_id,memory.total,power.limit,gpu_serial --format=csv,noheader")
 
     @patch('zstacklib.utils.gpu.bash_roe')
     def test_collect_nvidia_legacy_no_tool(self, mock_bash):
@@ -261,13 +283,14 @@ class TestLegacyCollectors(unittest.TestCase):
         result = gpu._collect_nvidia_legacy("0000:3b:00.0")
         self.assertIsNone(result)
 
+    @patch.object(NVIDIA, '_run_critical_command')
     @patch('zstacklib.utils.gpu.bash_roe')
-    def test_collect_nvidia_legacy_returns_none_when_no_matching_pci(self, mock_bash):
+    def test_collect_nvidia_legacy_returns_none_when_no_matching_pci(
+            self, mock_bash, mock_run_critical):
         """Test _collect_nvidia_legacy returns None when no GPU in output matches PCI (ZSTAC-81489)"""
-        mock_bash.side_effect = [
-            (0, "/usr/bin/nvidia-smi", ""),
-            (0, "00000000:86:00.0, 16384 MiB, 75.00 W, SN_OTHER", ""),
-        ]
+        mock_bash.return_value = (0, "/usr/bin/nvidia-smi", "")
+        mock_run_critical.return_value = (
+            0, "00000000:86:00.0, 16384 MiB, 75.00 W, SN_OTHER", "")
         result = gpu._collect_nvidia_legacy("0000:3b:00.0")
         self.assertIsNone(result)
 


### PR DESCRIPTION
## 问题

8 卡 NVIDIA 主机上，Prometheus 每轮执行全局查询、逐卡 PCIe 查询和 vGPU 查询；物理机重连又逐卡执行能力探测。多路 `nvidia-smi` 竞争 NVIDIA RM/NVML 锁，造成能力识别漂移，并可能让 TensorFusion `docker run --runtime=nvidia` 在 30 秒内无法完成。

## 修改

- NVIDIA 基础信息和指标查询增加硬超时、30 秒缓存及 300 秒 last-good。
- PCIe 累计计数改为每 60 秒一次全卡批量查询，失败熔断 300 秒；保留原指标名和标签。
- 无活动 mdev 时跳过 vGPU 监控；vGPU 静态 supported types 按设备族在单次扫描中复用。
- 重连批量复用 driverVersion、Docker/CTK/Worker image 检查，消除逐卡 TensorFusion 驱动查询。
- 新增 GPU operation gate：Worker 创建/重启为关键操作，监控非阻塞让行。
- 不启用或依赖 `nvidia-persistenced`。

## 本地验证

- GPU vendor / contention / operation gate / PCI processor：143 passed（Python 3.6）。
- Prometheus 指标契约：2 passed（Python 3.9）。
- operation gate Python 2.7 兼容验证通过。
- `git diff --check`、`py_compile`、zstacklib/kvmagent sdist 构建通过。
- `test_gpu_get_info.py` 仅保留 upstream/5.5.30 已存在的 2 个无关失败，无新增失败。

## 环境验证

172.20.1.165 灰度、重连稳定性和 TensorFusion Worker 验证进行中，完成后补充结果。

Resolves: ZSTAC-86867

sync from gitlab !7559