### PR TITLE
<fix>[kvmagent]: ZSTAC-86849 pause VM during CDP recovery

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -7566,6 +7566,7 @@ class Vm(object):
                 logger.info("vm[%s] is recovering with disks: %s" % (cmd.vmInstanceUuid, list(rvols.keys())))
                 global VM_RECOVER_DICT
                 VM_RECOVER_DICT[cmd.vmInstanceUuid] = rvols
+                cmd.createPaused = True
 
         def make_nics():
             if not cmd.nics:
@@ -9985,7 +9986,7 @@ class VmPlugin(kvmagent.KvmAgent):
         else:
             vm = get_vm_by_uuid(cmd.vmUuid)
             disks = vm.domain_xmlobject.devices.get_child_node_as_list('disk')
-            rsp.status = 'interrupted' if any(is_nbd_disk(d) for d in disks) else 'done'
+            rsp.status = 'interrupted' if vm.state != Vm.VM_STATE_RUNNING or any(is_nbd_disk(d) for d in disks) else 'done'
 
         return jsonobject.dumps(rsp)
 
@@ -10032,8 +10033,11 @@ class VmPlugin(kvmagent.KvmAgent):
             try:
                 with t:
                     VM_RECOVER_TASKS[cmd.vmUuid] = t
+                    vm = get_vm_by_uuid(cmd.vmUuid)
+                    vm.pause()
                     t.recover_vm_volumes()
                     check_volume_recover_results()
+                    vm.resume()
 
                 logger.info("recovery completed. VM: " + cmd.vmUuid)
             finally:

--- a/tests/unit/kvmagent/test_vm_plugin_handlers.py
+++ b/tests/unit/kvmagent/test_vm_plugin_handlers.py
@@ -1043,10 +1043,15 @@ class TestBlockPullHandler:
 
 @pytest.mark.kvmagent
 class TestCheckRecoverHandler:
-    def test_check_recover(self):
+    @pytest.mark.parametrize(('state', 'expected'), [
+        (vm_plugin.Vm.VM_STATE_RUNNING, 'done'),
+        (vm_plugin.Vm.VM_STATE_PAUSED, 'interrupted'),
+    ])
+    def test_check_recover(self, state, expected):
         plugin = _make_vm_plugin()
-        mock_vm = MagicMock()
+        mock_vm = MagicMock(state=state)
         mock_vm.domain_xmlobject.devices.get_child_node_as_list = MagicMock(return_value=[])
+        vm_plugin.VM_RECOVER_TASKS = {}
         vm_plugin.get_vm_by_uuid = MagicMock(return_value=mock_vm)
         vm_plugin.is_nbd_disk = MagicMock(return_value=False)
 
@@ -1055,7 +1060,7 @@ class TestCheckRecoverHandler:
         rsp = json.loads(result)
 
         assert rsp['success'] is True
-        assert rsp['status'] == 'done'
+        assert rsp['status'] == expected
 
 
 @pytest.mark.kvmagent
@@ -2012,23 +2017,28 @@ class TestQueryVolumeMirrorHandler:
 class TestRecoverVolumesHandler:
     def test_recover_volumes(self):
         plugin = _make_vm_plugin()
+        events = []
         vm_plugin.VM_RECOVER_DICT = {'vm-uuid': MagicMock()}
         vm_plugin.VM_RECOVER_TASKS = {}
         vm_plugin.parse_url = MagicMock(return_value=MagicMock(scheme=None))
         task = MagicMock()
         task.__enter__.return_value = task
         task.__exit__.return_value = None
-        task.recover_vm_volumes = MagicMock()
+        task.recover_vm_volumes = MagicMock(side_effect=lambda: events.append('recover'))
         vm_plugin.VmVolumesRecoveryTask = MagicMock(return_value=task)
-        vm_plugin.linux.wait_callback_success = MagicMock(return_value=True)
-        vm_plugin.get_vm_by_uuid = MagicMock(return_value=MagicMock())
+        mock_vm = MagicMock()
+        mock_vm.pause.side_effect = lambda: events.append('pause')
+        mock_vm.resume.side_effect = lambda: events.append('resume')
+        vm_plugin.linux.wait_callback_success = MagicMock(
+            side_effect=lambda *_args, **_kwargs: events.append('check') or True)
+        vm_plugin.get_vm_by_uuid = MagicMock(return_value=mock_vm)
 
         req = _make_req({'vmUuid': 'vm-uuid', 'volumes': [{'installPath': '/path/vol'}]})
         result = plugin.recover_volumes(req)
         rsp = json.loads(result)
 
         assert rsp['success'] is True
-        task.recover_vm_volumes.assert_called_once()
+        assert events == ['pause', 'recover', 'check', 'resume']
 
 
 @pytest.mark.kvmagent
@@ -3306,6 +3316,7 @@ class TestVmStartCmdXmlBuild:
                 patch.object(vm_plugin.etree, 'tostring', side_effect=orig_tostring):
             vm = vm_plugin.Vm.from_StartVmCmd(cmd)
 
+        assert cmd.createPaused is True
         xml_str = vm.domain_xml.decode() if isinstance(vm.domain_xml, bytes) else vm.domain_xml
         root = vm_plugin.etree.fromstring(xml_str)
         root_driver = self._driver_by_target(root, 'vda')


### PR DESCRIPTION
## Summary
Disable CDP fast bring-up while temporary NBD volumes are copied: start the domain paused and resume only after every volume is pivoted and validated.

## Changes
- Detect recovery from the current `/vm/start` XML build while preserving normal `createPaused` behavior.
- Execute `/vm/recover/volumes` as `pause -> blockCopy/pivot -> XML check -> resume`.
- Serialize concurrent recovery requests for the same VM and propagate the owner task result.
- Clean stale recovery markers and keep incomplete recovery status retryable.

## Testing
- [x] `tests/unit/kvmagent/test_vm_plugin_handlers.py`
- [ ] kvmagent package (run after MR creation)
- [ ] CI pipeline
- [ ] Repeated CDP runtime recovery with multi-queue NBD

Resolves: ZSTAC-86849

sync from gitlab !7564