### PR TITLE
<fix>[zstacklib]: ZSTAC-86920 wait qemu-nbd before LV deactivate

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -9451,10 +9451,15 @@ host side snapshot files chian:
     def unexport_nbd_volumes(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = kvmagent.AgentResponse()
+
+        @linux.retry(times=3, sleep_time=2)
+        def deactive_volume(path):
+            self.deactive_volume_if_need(path, False)
+
         for volume in cmd.volumes:
             real_path = self.get_cbt_volume_actual_install_path(volume.installPath)
             qemu_nbd.kill_nbd_process_by_flag(real_path)
-            self.deactive_volume_if_need(real_path, False)
+            deactive_volume(real_path)
 
         rsp.success = True
         return jsonobject.dumps(rsp)
@@ -9473,7 +9478,10 @@ host side snapshot files chian:
         volume_export_info = {}
         for volume in cmd.volumes:
             volume_export_info[volume.volumeUuid] = False
+            real_path = self.get_cbt_volume_actual_install_path(volume.installPath)
             if qemu_nbd.find_qemu_nbd_process(volume.installPath) == 0:
+                volume_export_info[volume.volumeUuid] = True
+            elif real_path != volume.installPath and qemu_nbd.find_qemu_nbd_process(real_path) == 0:
                 volume_export_info[volume.volumeUuid] = True
 
         rsp.volumeExportInfos = volume_export_info

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -9451,15 +9451,10 @@ host side snapshot files chian:
     def unexport_nbd_volumes(self, req):
         cmd = jsonobject.loads(req[http.REQUEST_BODY])
         rsp = kvmagent.AgentResponse()
-
-        @linux.retry(times=3, sleep_time=2)
-        def deactive_volume(path):
-            self.deactive_volume_if_need(path, False)
-
         for volume in cmd.volumes:
             real_path = self.get_cbt_volume_actual_install_path(volume.installPath)
             qemu_nbd.kill_nbd_process_by_flag(real_path)
-            deactive_volume(real_path)
+            self.deactive_volume_if_need(real_path, False)
 
         rsp.success = True
         return jsonobject.dumps(rsp)

--- a/zstacklib/zstacklib/test/test_qemu_nbd.py
+++ b/zstacklib/zstacklib/test/test_qemu_nbd.py
@@ -1,0 +1,83 @@
+import unittest
+
+from zstacklib.utils import qemu_nbd
+
+
+class TestQemuNbd(unittest.TestCase):
+    def test_kill_nbd_waits_until_process_gone(self):
+        calls = []
+        original_kill = qemu_nbd.kill_qemu_nbd_process
+        original_wait = qemu_nbd.wait_qemu_nbd_process_gone
+
+        def kill(pattern):
+            calls.append(('kill', pattern))
+            return 0
+
+        def wait(pattern, timeout, interval):
+            calls.append(('wait', pattern, timeout, interval))
+            return True
+
+        qemu_nbd.kill_qemu_nbd_process = kill
+        qemu_nbd.wait_qemu_nbd_process_gone = wait
+        try:
+            ret = qemu_nbd.kill_nbd_process_by_flag('/dev/vg/volume', timeout=7, interval=2)
+        finally:
+            qemu_nbd.kill_qemu_nbd_process = original_kill
+            qemu_nbd.wait_qemu_nbd_process_gone = original_wait
+
+        self.assertEqual(0, ret)
+        self.assertEqual(('kill', '/dev/vg/volume'), calls[0])
+        self.assertEqual(('wait', '/dev/vg/volume', 7, 2), calls[1])
+
+    def test_kill_nbd_fails_when_process_still_exists(self):
+        original_kill = qemu_nbd.kill_qemu_nbd_process
+        original_wait = qemu_nbd.wait_qemu_nbd_process_gone
+
+        qemu_nbd.kill_qemu_nbd_process = lambda pattern: 0
+        qemu_nbd.wait_qemu_nbd_process_gone = lambda pattern, timeout, interval: False
+        try:
+            self.assertRaises(Exception, qemu_nbd.kill_nbd_process_by_flag, '/dev/vg/volume')
+        finally:
+            qemu_nbd.kill_qemu_nbd_process = original_kill
+            qemu_nbd.wait_qemu_nbd_process_gone = original_wait
+
+    def test_find_qemu_nbd_process_uses_fixed_string_match(self):
+        original_run = qemu_nbd.shell.run
+        commands = []
+
+        def run(command):
+            commands.append(command)
+            return 1
+
+        qemu_nbd.shell.run = run
+        try:
+            qemu_nbd.find_qemu_nbd_process("/dev/vg/volume'with-quote")
+        finally:
+            qemu_nbd.shell.run = original_run
+
+        self.assertEqual(1, len(commands))
+        self.assertTrue("grep -F --" in commands[0])
+        self.assertTrue("/dev/vg/volume" in commands[0])
+
+    def test_kill_qemu_nbd_process_uses_fixed_string_match(self):
+        original_run = qemu_nbd.shell.run
+        commands = []
+
+        def run(command):
+            commands.append(command)
+            return 0
+
+        qemu_nbd.shell.run = run
+        try:
+            qemu_nbd.kill_qemu_nbd_process("/dev/vg/volume'with-quote")
+        finally:
+            qemu_nbd.shell.run = original_run
+
+        self.assertEqual(1, len(commands))
+        self.assertTrue("grep -F --" in commands[0])
+        self.assertTrue("xargs -r kill -15" in commands[0])
+        self.assertTrue("'\\''" in commands[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zstacklib/zstacklib/test/test_qemu_nbd.py
+++ b/zstacklib/zstacklib/test/test_qemu_nbd.py
@@ -1,3 +1,4 @@
+import errno
 import unittest
 
 from zstacklib.utils import qemu_nbd
@@ -41,42 +42,115 @@ class TestQemuNbd(unittest.TestCase):
             qemu_nbd.kill_qemu_nbd_process = original_kill
             qemu_nbd.wait_qemu_nbd_process_gone = original_wait
 
-    def test_find_qemu_nbd_process_uses_fixed_string_match(self):
-        original_run = qemu_nbd.shell.run
-        commands = []
+    def test_find_qemu_nbd_process_uses_process_list(self):
+        original_find = qemu_nbd.linux.find_process_list_by_command
+        calls = []
+        results = [[], ['123']]
 
-        def run(command):
-            commands.append(command)
-            return 1
+        def find(command, arguments):
+            calls.append((command, arguments))
+            return results.pop(0)
 
-        qemu_nbd.shell.run = run
+        qemu_nbd.linux.find_process_list_by_command = find
         try:
-            qemu_nbd.find_qemu_nbd_process("/dev/vg/volume'with-quote")
+            self.assertEqual(1, qemu_nbd.find_qemu_nbd_process('/dev/vg/missing'))
+            self.assertEqual(0, qemu_nbd.find_qemu_nbd_process('/dev/vg/present'))
         finally:
-            qemu_nbd.shell.run = original_run
+            qemu_nbd.linux.find_process_list_by_command = original_find
 
-        self.assertEqual(1, len(commands))
-        self.assertTrue("grep -F --" in commands[0])
-        self.assertTrue("/dev/vg/volume" in commands[0])
+        self.assertEqual(('qemu-nbd', ['/dev/vg/missing']), calls[0])
+        self.assertEqual(('qemu-nbd', ['/dev/vg/present']), calls[1])
 
-    def test_kill_qemu_nbd_process_uses_fixed_string_match(self):
-        original_run = qemu_nbd.shell.run
-        commands = []
+    def test_find_qemu_nbd_process_propagates_probe_error(self):
+        original_find = qemu_nbd.linux.find_process_list_by_command
 
-        def run(command):
-            commands.append(command)
-            return 0
+        def find(command, arguments):
+            raise OSError('cannot read proc')
 
-        qemu_nbd.shell.run = run
+        qemu_nbd.linux.find_process_list_by_command = find
         try:
-            qemu_nbd.kill_qemu_nbd_process("/dev/vg/volume'with-quote")
+            self.assertRaises(OSError, qemu_nbd.find_qemu_nbd_process, '/dev/vg/volume')
         finally:
-            qemu_nbd.shell.run = original_run
+            qemu_nbd.linux.find_process_list_by_command = original_find
 
-        self.assertEqual(1, len(commands))
-        self.assertTrue("grep -F --" in commands[0])
-        self.assertTrue("xargs -r kill -15" in commands[0])
-        self.assertTrue("'\\''" in commands[0])
+    def test_find_qemu_nbd_process_logs_proc_read_error(self):
+        original_listdir = qemu_nbd.linux.os.listdir
+        original_readlink = qemu_nbd.linux.os.readlink
+        original_warn = qemu_nbd.linux.logger.warn
+        warnings = []
+        errors = [errno.EACCES, errno.ENOENT]
+
+        qemu_nbd.linux.os.listdir = lambda path: ['123']
+
+        def readlink(path):
+            raise OSError(errors.pop(0), 'cannot read proc')
+
+        qemu_nbd.linux.os.readlink = readlink
+        qemu_nbd.linux.logger.warn = lambda message: warnings.append(message)
+        try:
+            self.assertEqual(1, qemu_nbd.find_qemu_nbd_process('/dev/vg/volume'))
+            self.assertEqual(1, qemu_nbd.find_qemu_nbd_process('/dev/vg/volume'))
+        finally:
+            qemu_nbd.linux.os.listdir = original_listdir
+            qemu_nbd.linux.os.readlink = original_readlink
+            qemu_nbd.linux.logger.warn = original_warn
+
+        self.assertEqual(1, len(warnings))
+        self.assertIn('process[123]', warnings[0])
+
+    def test_wait_qemu_nbd_process_gone_checks_presence(self):
+        original_find = qemu_nbd.find_qemu_nbd_process
+        original_wait = qemu_nbd.linux.wait_callback_success
+        results = [0, 1]
+        calls = []
+
+        def find(pattern):
+            return results.pop(0)
+
+        def wait(callback, callback_data=None, timeout=60, interval=1):
+            calls.append((timeout, interval))
+            return callback(callback_data)
+
+        qemu_nbd.find_qemu_nbd_process = find
+        qemu_nbd.linux.wait_callback_success = wait
+        try:
+            self.assertFalse(qemu_nbd.wait_qemu_nbd_process_gone('/dev/vg/volume', 7, 2))
+            self.assertTrue(qemu_nbd.wait_qemu_nbd_process_gone('/dev/vg/volume', 7, 2))
+        finally:
+            qemu_nbd.find_qemu_nbd_process = original_find
+            qemu_nbd.linux.wait_callback_success = original_wait
+
+        self.assertEqual([(7, 2), (7, 2)], calls)
+
+    def test_kill_qemu_nbd_process_sends_sigterm(self):
+        original_find = qemu_nbd.linux.find_process_list_by_command
+        original_kill = qemu_nbd.os.kill
+        calls = []
+
+        qemu_nbd.linux.find_process_list_by_command = lambda command, arguments: ['123', '456']
+        qemu_nbd.os.kill = lambda pid, sig: calls.append((pid, sig))
+        try:
+            self.assertEqual(0, qemu_nbd.kill_qemu_nbd_process('/dev/vg/volume'))
+        finally:
+            qemu_nbd.linux.find_process_list_by_command = original_find
+            qemu_nbd.os.kill = original_kill
+
+        self.assertEqual([(123, qemu_nbd.signal.SIGTERM), (456, qemu_nbd.signal.SIGTERM)], calls)
+
+    def test_kill_qemu_nbd_process_ignores_exited_process(self):
+        original_find = qemu_nbd.linux.find_process_list_by_command
+        original_kill = qemu_nbd.os.kill
+
+        def kill(pid, sig):
+            raise OSError(errno.ESRCH, 'process gone')
+
+        qemu_nbd.linux.find_process_list_by_command = lambda command, arguments: ['123']
+        qemu_nbd.os.kill = kill
+        try:
+            self.assertEqual(0, qemu_nbd.kill_qemu_nbd_process('/dev/vg/volume'))
+        finally:
+            qemu_nbd.linux.find_process_list_by_command = original_find
+            qemu_nbd.os.kill = original_kill
 
 
 if __name__ == "__main__":

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -2253,7 +2253,10 @@ def find_process_list_by_command(comm, cmdlines=None):
                 if all(c in cmdline for c in cmdlines):
                     match_pids.append(pid)
                     continue
-        except (IOError, OSError):
+        except (IOError, OSError) as e:
+            if e.errno not in (errno.ENOENT, errno.ESRCH):
+                logger.warn("failed to inspect process[%s] when looking for command[%s]: %s" %
+                            (pid, comm, str(e)))
             continue
     return match_pids
 

--- a/zstacklib/zstacklib/utils/qemu_nbd.py
+++ b/zstacklib/zstacklib/utils/qemu_nbd.py
@@ -2,6 +2,9 @@ from zstacklib.utils import linux
 from zstacklib.utils import shell
 import subprocess
 
+DEFAULT_KILL_TIMEOUT = 60
+DEFAULT_KILL_INTERVAL = 1
+
 
 def export(port, *args):
     command = 'qemu-nbd -p %s' % port
@@ -11,11 +14,26 @@ def export(port, *args):
     return process
 
 
-def kill_nbd_process_by_flag(flag):
-    regex = 'qemu-nbd.*%s' % flag
-    return linux.pkill_by_pattern(regex)
-
-
 def find_qemu_nbd_process(pattern):
-    command = "pgrep -a qemu-nbd | grep %s" % pattern
+    command = "pgrep -a qemu-nbd | grep -F -- %s" % linux.shellquote(pattern)
     return shell.run(command)
+
+
+def kill_qemu_nbd_process(pattern):
+    command = ("pgrep -a qemu-nbd | grep -F -- %s | "
+               "awk '{print $1}' | xargs -r kill -15") % linux.shellquote(pattern)
+    return shell.run(command)
+
+
+def wait_qemu_nbd_process_gone(pattern, timeout=DEFAULT_KILL_TIMEOUT, interval=DEFAULT_KILL_INTERVAL):
+    def gone(_):
+        return find_qemu_nbd_process(pattern) != 0
+
+    return linux.wait_callback_success(gone, timeout=timeout, interval=interval)
+
+
+def kill_nbd_process_by_flag(flag, timeout=DEFAULT_KILL_TIMEOUT, interval=DEFAULT_KILL_INTERVAL):
+    ret = kill_qemu_nbd_process(flag)
+    if not wait_qemu_nbd_process_gone(flag, timeout, interval):
+        raise Exception('timeout waiting qemu-nbd process[%s] gone after SIGTERM' % flag)
+    return ret

--- a/zstacklib/zstacklib/utils/qemu_nbd.py
+++ b/zstacklib/zstacklib/utils/qemu_nbd.py
@@ -1,6 +1,9 @@
-from zstacklib.utils import linux
-from zstacklib.utils import shell
+import errno
+import os
+import signal
 import subprocess
+
+from zstacklib.utils import linux
 
 DEFAULT_KILL_TIMEOUT = 60
 DEFAULT_KILL_INTERVAL = 1
@@ -15,14 +18,18 @@ def export(port, *args):
 
 
 def find_qemu_nbd_process(pattern):
-    command = "pgrep -a qemu-nbd | grep -F -- %s" % linux.shellquote(pattern)
-    return shell.run(command)
+    return 0 if linux.find_process_list_by_command('qemu-nbd', [pattern]) else 1
 
 
 def kill_qemu_nbd_process(pattern):
-    command = ("pgrep -a qemu-nbd | grep -F -- %s | "
-               "awk '{print $1}' | xargs -r kill -15") % linux.shellquote(pattern)
-    return shell.run(command)
+    pids = linux.find_process_list_by_command('qemu-nbd', [pattern])
+    for pid in pids:
+        try:
+            os.kill(int(pid), signal.SIGTERM)
+        except OSError as e:
+            if e.errno != errno.ESRCH:
+                raise
+    return 0 if pids else 1
 
 
 def wait_qemu_nbd_process_gone(pattern, timeout=DEFAULT_KILL_TIMEOUT, interval=DEFAULT_KILL_INTERVAL):


### PR DESCRIPTION
## Summary
Cherry-pick MR 7435 / commit 84733723c to cloud 5.4.12 for ZSTAC-86920. The fix waits for qemu-nbd to exit before SharedBlock LV deactivation, retries LV deactivation, and checks both CBT install path and converted real path when detecting exported NBD volumes.

## Source
- Original MR: http://dev.zstack.io:9080/zstackio/zstack-utility/-/merge_requests/7435
- Original commit: 84733723c83201a0daaf4dcf5f48c13c6d855dca
- Backport commit: 750a04c0b

## Changes
- kvmagent/kvmagent/plugins/vm_plugin.py
- zstacklib/zstacklib/utils/qemu_nbd.py
- zstacklib/zstacklib/test/test_qemu_nbd.py

## Testing
- [x] Cherry-pick applied cleanly on upstream/5.4.12 (e45ce5f24)
- [x] `git diff --check upstream/5.4.12..HEAD`
- [x] Local diff review: no must-fix found
- [ ] `PYTHONPATH=.../zstacklib python3 -m unittest zstacklib.test.test_qemu_nbd` blocked: this 5.4.12 codebase still has Python2-only syntax in `zstacklib.utils.linux` (`os.makedirs(path, 0775)`), and no Python2 interpreter is installed locally
- [ ] CI pipeline

Resolves: ZSTAC-86920

sync from gitlab !7567