### PR TITLE
<fix>[kvmagent]: ZSTAC-86956 prepare VirtioFS model cache on demand

### DIFF
--- a/kvmagent/kvmagent/plugins/virtiofs_plugin.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_plugin.py
@@ -206,6 +206,8 @@ def _get_cmd_attr(obj, name, default=None):
 def _classify_host_model_cache_failure(error):
     error = str(error or '')
     lowered = error.lower()
+    if 'mount model center' in lowered or 'model center mount' in lowered:
+        return 'ModelSourceMount', 'JuicefsMountFailed'
     if 'capacity' in lowered or 'available' in lowered:
         return 'CapacityCheck', 'InsufficientHostCacheStorage'
     if 'permission' in lowered or 'denied' in lowered:
@@ -712,7 +714,17 @@ class VirtiofsPlugin(kvmagent.KvmAgent):
             source_root = _get_cmd_attr(cmd, 'sourceRoot', _get_cmd_attr(cmd, 'sourceRootPath', None))
             source_path = _get_cmd_attr(cmd, 'sourcePath', None)
             required_capacity = _get_cmd_attr(cmd, 'requiredCapacityBytes', None)
-            entry = virtiofs_source.prepare_host_model_cache(source_root, source_path, required_capacity)
+            source_type = _get_cmd_attr(cmd, 'sourceType', 'preparedPath')
+            if source_type == 'juicefsModelCenter':
+                entry = virtiofs_source.prepare_model_center_cache(
+                    source_root,
+                    source_path,
+                    _get_cmd_attr(cmd, 'modelCenterUuid', None),
+                    _get_cmd_attr(cmd, 'storageUrl', None),
+                    _get_cmd_attr(cmd, 'modelRelativePath', None),
+                    required_capacity)
+            else:
+                entry = virtiofs_source.prepare_host_model_cache(source_root, source_path, required_capacity)
             rsp.cacheEntry = entry
             rsp.success = True
             logger.info("Prepared host model cache path[%s], size=%s" % (

--- a/kvmagent/kvmagent/plugins/virtiofs_source.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_source.py
@@ -1,10 +1,13 @@
 # Copyright (c) 2025, ZStack, Inc.
 
+import errno
+import fcntl
 import hashlib
 import json
 import os
 import re
 import shutil
+import subprocess
 import time
 
 
@@ -21,6 +24,22 @@ except NameError:
 HOST_SOURCE_ROOT = '/var/lib/zstack/aios/virtiofs-sources'
 VM_VIEW_ROOT = '/var/lib/zstack/aios/vm-views'
 SOURCE_REGISTRY_FILE = os.path.join(HOST_SOURCE_ROOT, '.registry')
+MODEL_CENTER_PROVIDER_ROOT = '/var/lib/zstack/aios/provider-mounts/model-centers'
+MODEL_CENTER_LOCK_ROOT = '/var/lib/zstack/aios/provider-locks/model-centers'
+JUICEFS_CACHE_DIR = '/var/cache/virtiofs/juicefs'
+JUICEFS_CANDIDATE_PATHS = (
+    '/usr/local/bin/juicefs',
+    '/usr/bin/juicefs',
+    '/opt/zstack/bin/juicefs',
+)
+
+
+def _ensure_directory(path):
+    try:
+        os.makedirs(path, 0o755)
+    except OSError as exc:
+        if exc.errno != errno.EEXIST or not os.path.isdir(path):
+            raise
 
 
 def get_attr(obj, name, default=None):
@@ -208,6 +227,123 @@ def prepare_host_model_cache(source_root, source_path, required_capacity_bytes=N
         raise Exception('sourceRoot[%s] does not exist' % root)
     check_available_capacity(root, required_capacity_bytes)
     return cache_entry(root, source_path)
+
+
+def _validate_source_id(value, field_name):
+    value = str(value or '').strip()
+    if not value or not re.match(r'^[A-Za-z0-9][A-Za-z0-9_.-]*$', value):
+        raise Exception('invalid %s[%s]' % (field_name, value))
+    return value
+
+
+def _validate_relative_path(value, field_name):
+    value = str(value or '').strip()
+    if not value or os.path.isabs(value):
+        raise Exception('%s[%s] must be a non-empty relative path' % (field_name, value))
+    normalized = os.path.normpath(value)
+    if normalized == '..' or normalized.startswith('..' + os.sep):
+        raise Exception('%s[%s] escapes its source root' % (field_name, value))
+    return normalized
+
+
+def _find_juicefs_binary():
+    for path in JUICEFS_CANDIDATE_PATHS:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+    raise Exception('juicefs binary not found')
+
+
+def _run_process(args, error_message):
+    process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = process.communicate()
+    if process.returncode != 0:
+        raise Exception('%s, exitCode[%s]' % (error_message, process.returncode))
+    return stdout, stderr
+
+
+def _mount_model_center(storage_url, mount_path):
+    if os.path.ismount(mount_path):
+        _unmount_model_center(mount_path)
+    if not os.path.exists(mount_path):
+        _ensure_directory(mount_path)
+    if not os.path.exists(JUICEFS_CACHE_DIR):
+        _ensure_directory(JUICEFS_CACHE_DIR)
+    juicefs = _find_juicefs_binary()
+    _run_process([
+        juicefs, 'mount',
+        '--read-only', '-d', '--subdir', 'models',
+        '--cache-dir', JUICEFS_CACHE_DIR,
+        storage_url, mount_path,
+    ], 'failed to mount model center')
+    for _ in range(20):
+        if os.path.ismount(mount_path):
+            return
+        time.sleep(0.5)
+    raise Exception('model center mount did not become ready')
+
+
+def _unmount_model_center(mount_path):
+    if not os.path.ismount(mount_path):
+        return
+    juicefs = _find_juicefs_binary()
+    _run_process([juicefs, 'umount', '--force', mount_path], 'failed to unmount model center')
+    if os.path.ismount(mount_path):
+        raise Exception('model center mount is still active after unmount')
+
+
+def prepare_model_center_cache(source_root, source_path, model_center_uuid, storage_url,
+                               model_relative_path, required_capacity_bytes=None):
+    root = _normalize_root(source_root or HOST_SOURCE_ROOT)
+    target = ensure_under(source_path, root, 'sourcePath', allow_root=False)
+    model_center_uuid = _validate_source_id(model_center_uuid, 'modelCenterUuid')
+    if not storage_url or not str(storage_url).strip():
+        raise Exception('storageUrl is required')
+    relative_path = _validate_relative_path(model_relative_path, 'modelRelativePath')
+
+    if not os.path.exists(root):
+        _ensure_directory(root)
+
+    if not os.path.exists(MODEL_CENTER_PROVIDER_ROOT):
+        _ensure_directory(MODEL_CENTER_PROVIDER_ROOT)
+    if not os.path.exists(MODEL_CENTER_LOCK_ROOT):
+        _ensure_directory(MODEL_CENTER_LOCK_ROOT)
+
+    mount_path = os.path.join(MODEL_CENTER_PROVIDER_ROOT, model_center_uuid)
+    lock_path = os.path.join(MODEL_CENTER_LOCK_ROOT, model_center_uuid + '.lock')
+    lock_fd = open(lock_path, 'a+')
+    try:
+        fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
+        if os.path.ismount(mount_path):
+            _unmount_model_center(mount_path)
+        if os.path.exists(target):
+            entry = cache_entry(root, target)
+            _register_model_center_cache(root, target)
+            return entry
+
+        check_available_capacity(root, required_capacity_bytes)
+        try:
+            _mount_model_center(str(storage_url).strip(), mount_path)
+            remote_source = ensure_under(
+                os.path.join(mount_path, relative_path),
+                mount_path,
+                'modelRelativePath',
+                allow_root=False)
+            prepare_copy_source(
+                target,
+                (root,),
+                remote_source,
+                (mount_path,),
+                required_capacity_bytes)
+        finally:
+            _unmount_model_center(mount_path)
+        entry = cache_entry(root, target)
+        _register_model_center_cache(root, target)
+        return entry
+    finally:
+        try:
+            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
+        finally:
+            lock_fd.close()
 
 
 def cleanup_host_model_cache(source_root, source_path):
@@ -447,6 +583,30 @@ class SourceRegistry(object):
             return True
         except (IOError, OSError):
             return False
+
+
+def _register_model_center_cache(source_root, source_path):
+    source = HostSource(
+        _path_id(source_path),
+        'juicefsModelCenter',
+        source_path,
+        SourceCapability(
+            migratable=False,
+            snapshotable=False,
+            persistent=True,
+            shared_across_hosts=False,
+        ))
+    registry = SourceRegistry(os.path.join(source_root, '.registry'))
+    lock_fd = open(registry.path + '.lock', 'a+')
+    try:
+        fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
+        if not registry.save_host_source(source):
+            raise Exception('failed to register prepared model center cache[%s]' % source_path)
+    finally:
+        try:
+            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
+        finally:
+            lock_fd.close()
 
 
 class SourceManager(object):

--- a/tests/unit/kvmagent/test_virtiofs_handlers.py
+++ b/tests/unit/kvmagent/test_virtiofs_handlers.py
@@ -291,6 +291,43 @@ class TestVerifySourcePath:
 
 
 @pytest.mark.kvmagent
+class TestHostModelCachePrepareHandler:
+
+    def test_dispatches_juicefs_model_center_source(self, monkeypatch):
+        captured = {}
+
+        def prepare(source_root, source_path, model_center_uuid, storage_url,
+                    model_relative_path, required_capacity):
+            captured.update({
+                'sourceRoot': source_root,
+                'sourcePath': source_path,
+                'modelCenterUuid': model_center_uuid,
+                'storageUrl': storage_url,
+                'modelRelativePath': model_relative_path,
+                'requiredCapacityBytes': required_capacity,
+            })
+            return {'sourcePath': source_path, 'sizeBytes': 1024}
+
+        monkeypatch.setattr(virtiofs_plugin.virtiofs_source, 'prepare_model_center_cache', prepare)
+        plugin = virtiofs_plugin.VirtiofsPlugin()
+        response = json.loads(plugin.prepare_host_model_cache({
+            http.REQUEST_BODY: json.dumps({
+                'sourceType': 'juicefsModelCenter',
+                'sourceRoot': '/cache',
+                'sourcePath': '/cache/models/model/v1',
+                'modelCenterUuid': 'mc',
+                'storageUrl': 'redis://model-center',
+                'modelRelativePath': 'qwen/v1',
+                'requiredCapacityBytes': 1024,
+            })
+        }))
+
+        assert response['success'] is True
+        assert response['cacheEntry']['sourcePath'] == '/cache/models/model/v1'
+        assert captured['modelRelativePath'] == 'qwen/v1'
+        assert captured['storageUrl'] == 'redis://model-center'
+
+
 class TestVirtiofsAttachHandler:
     """Test virtiofs attach handler."""
 

--- a/tests/unit/kvmagent/test_virtiofs_source.py
+++ b/tests/unit/kvmagent/test_virtiofs_source.py
@@ -118,6 +118,151 @@ def test_prepare_path_source_copies_remote_source_to_target_root(tmp_path):
     assert (target_dir / 'config.json').read_text() == '{}'
 
 
+def test_prepare_model_center_cache_mounts_copies_and_unmounts(tmp_path, monkeypatch):
+    source_root = tmp_path / 'primary-storage' / 'ai-model-cache'
+    source_root.mkdir(parents=True)
+    target = source_root / 'models' / 'model-uuid' / 'v1'
+    provider_root = tmp_path / 'provider-mounts'
+    lock_root = tmp_path / 'provider-locks'
+    events = []
+
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_PROVIDER_ROOT', str(provider_root))
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_LOCK_ROOT', str(lock_root))
+
+    def mount_model_center(storage_url, mount_path):
+        events.append(('mount', storage_url, mount_path))
+        model_dir = os.path.join(mount_path, 'qwen', 'v1')
+        os.makedirs(model_dir)
+        with open(os.path.join(model_dir, 'config.json'), 'w') as stream:
+            stream.write('{}')
+
+    def unmount_model_center(mount_path):
+        events.append(('unmount', mount_path))
+
+    monkeypatch.setattr(virtiofs_source, '_mount_model_center', mount_model_center)
+    monkeypatch.setattr(virtiofs_source, '_unmount_model_center', unmount_model_center)
+
+    entry = virtiofs_source.prepare_model_center_cache(
+        str(source_root),
+        str(target),
+        'model-center-uuid',
+        'redis://model-center',
+        'qwen/v1',
+        1024)
+
+    assert entry['sourcePath'] == os.path.realpath(str(target))
+    assert (target / 'config.json').read_text() == '{}'
+    registry = json.loads((source_root / '.registry').read_text())
+    assert list(registry.values())[0]['path'] == os.path.realpath(str(target))
+    assert events[0][0] == 'mount'
+    assert events[-1][0] == 'unmount'
+
+
+def test_mount_model_center_uses_packaged_juicefs_layout(tmp_path, monkeypatch):
+    mount_path = tmp_path / 'provider-mount'
+    cache_path = tmp_path / 'juicefs-cache'
+    commands = []
+    mount_checks = iter([False, True])
+
+    monkeypatch.setattr(virtiofs_source, 'JUICEFS_CACHE_DIR', str(cache_path))
+    monkeypatch.setattr(virtiofs_source, '_find_juicefs_binary', lambda: '/usr/local/bin/juicefs')
+    monkeypatch.setattr(
+        virtiofs_source,
+        '_run_process',
+        lambda args, error_message: commands.append(args))
+    monkeypatch.setattr(os.path, 'ismount', lambda path: next(mount_checks))
+
+    virtiofs_source._mount_model_center('redis://model-center', str(mount_path))
+
+    assert commands == [[
+        '/usr/local/bin/juicefs', 'mount',
+        '--read-only', '-d', '--subdir', 'models',
+        '--cache-dir', str(cache_path),
+        'redis://model-center', str(mount_path),
+    ]]
+    assert cache_path.is_dir()
+
+
+def test_prepare_model_center_cache_rejects_escaping_model_path(tmp_path):
+    source_root = tmp_path / 'primary-storage' / 'ai-model-cache'
+    source_root.mkdir(parents=True)
+
+    with pytest.raises(Exception) as exc_info:
+        virtiofs_source.prepare_model_center_cache(
+            str(source_root),
+            str(source_root / 'models' / 'model-uuid' / 'v1'),
+            'model-center-uuid',
+            'redis://model-center',
+            '../outside',
+            1024)
+
+    assert 'escapes its source root' in str(exc_info.value)
+
+
+def test_prepare_model_center_cache_unmounts_when_model_is_missing(tmp_path, monkeypatch):
+    source_root = tmp_path / 'primary-storage' / 'ai-model-cache'
+    source_root.mkdir(parents=True)
+    provider_root = tmp_path / 'provider-mounts'
+    lock_root = tmp_path / 'provider-locks'
+    unmounted = []
+
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_PROVIDER_ROOT', str(provider_root))
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_LOCK_ROOT', str(lock_root))
+    monkeypatch.setattr(
+        virtiofs_source,
+        '_mount_model_center',
+        lambda storage_url, mount_path: os.makedirs(mount_path))
+    monkeypatch.setattr(
+        virtiofs_source,
+        '_unmount_model_center',
+        lambda mount_path: unmounted.append(mount_path))
+
+    with pytest.raises(Exception) as exc_info:
+        virtiofs_source.prepare_model_center_cache(
+            str(source_root),
+            str(source_root / 'models' / 'model-uuid' / 'v1'),
+            'model-center-uuid',
+            'redis://model-center',
+            'missing/model',
+            1024)
+
+    assert 'does not exist' in str(exc_info.value)
+    assert unmounted == [str(provider_root / 'model-center-uuid')]
+
+
+def test_prepare_model_center_cache_reuses_existing_cache_without_mounting(tmp_path, monkeypatch):
+    source_root = tmp_path / 'primary-storage' / 'ai-model-cache'
+    target = source_root / 'models' / 'model-uuid' / 'v1'
+    target.mkdir(parents=True)
+    (target / 'config.json').write_text('{}')
+    monkeypatch.setattr(
+        virtiofs_source,
+        'MODEL_CENTER_PROVIDER_ROOT',
+        str(tmp_path / 'provider-mounts'))
+    monkeypatch.setattr(
+        virtiofs_source,
+        'MODEL_CENTER_LOCK_ROOT',
+        str(tmp_path / 'provider-locks'))
+    monkeypatch.setattr(
+        virtiofs_source,
+        '_mount_model_center',
+        lambda storage_url, mount_path: pytest.fail('existing cache must not remount model center'))
+    monkeypatch.setattr(
+        virtiofs_source,
+        'check_available_capacity',
+        lambda path, required: pytest.fail('existing cache must not reserve capacity again'))
+
+    entry = virtiofs_source.prepare_model_center_cache(
+        str(source_root),
+        str(target),
+        'model-center-uuid',
+        'redis://model-center',
+        'qwen/v1',
+        1024)
+
+    assert entry['sourcePath'] == os.path.realpath(str(target))
+
+
 def test_prepare_path_source_rejects_empty_command_source_root(tmp_path):
     source_dir = tmp_path / 'virtiofs-sources' / 'source-a'
     source_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary

Provide the Host-side source provider required by newly created VM inference services. The provider mounts the selected model center only while preparing the requested cache and removes the transient mount before VM start.

## Changes

- handle the `juicefsModelCenter` host-cache source type
- mount JuiceFS read-only under a transient provider path
- validate model center identifiers and model-relative paths
- copy model contents atomically into the prepared cache
- register prepared caches for telemetry reconciliation
- serialize concurrent preparation and registry updates with file locks
- always unmount the temporary model-center mount

## Dependency

Must be merged and released together with the companion `zstackio/premium` MR from branch `fix/ZSTAC-86956-virtiofs-model-cache-prepare@@2`.

## Testing

- [x] VirtioFS unit suites — 79/79 passed
- [x] Python bytecode compilation
- [x] `git diff --check`
- [ ] End-to-end JuiceFS copy on a real KVM Host

Resolves: ZSTAC-86956

sync from gitlab !7577