### PR TITLE
<fix>[ceph]: detect local IPv6 monitor routes

### DIFF
--- a/tests/unit/zstacklib/test_management_network_ipv6.py
+++ b/tests/unit/zstacklib/test_management_network_ipv6.py
@@ -269,7 +269,7 @@ def test_extract_ceph_mon_host_supports_ipv4_ipv6_and_addrvec_prefixes():
     assert ceph_utils.extract_mon_host(TEST_IPV6_ADDRESS) == TEST_IPV6_ADDRESS
 
 
-def test_get_ceph_mon_addr_uses_ipv6_route_table(monkeypatch):
+def test_get_ceph_mon_addr_uses_ipv6_local_route(monkeypatch):
     commands = []
     monmap = '{"mons":[{"addr":"[%s]:%s/0"}]}' % (TEST_IPV6_ADDRESS, TEST_CEPH_PORT)
 
@@ -281,7 +281,39 @@ def test_get_ceph_mon_addr_uses_ipv6_route_table(monkeypatch):
 
     assert ceph_utils.get_mon_addr(monmap, ceph_utils.ROUTE_PROTOCOL_KERNEL) == TEST_IPV6_ADDRESS
     assert commands == [
-        'ip -6 route | grep -w "proto kernel" | grep -w \'%s\' > /dev/null' % TEST_IPV6_ADDRESS
+        "ip -6 route get '%s' | grep -E '^local[[:space:]]' > /dev/null" % TEST_IPV6_ADDRESS
+    ]
+
+
+def test_get_ceph_mon_addr_rejects_nonlocal_ipv6_route(monkeypatch):
+    commands = []
+    monmap = '{"mons":[{"addr":"[%s]:%s/0"}]}' % (TEST_IPV6_ADDRESS, TEST_CEPH_PORT)
+
+    def fake_bash_r(cmd):
+        commands.append(cmd)
+        return 1
+
+    monkeypatch.setattr(ceph_utils, 'bash_r', fake_bash_r)
+
+    assert ceph_utils.get_mon_addr(monmap, ceph_utils.ROUTE_PROTOCOL_KERNEL) is None
+    assert commands == [
+        "ip -6 route get '%s' | grep -E '^local[[:space:]]' > /dev/null" % TEST_IPV6_ADDRESS
+    ]
+
+
+def test_get_ceph_mon_addr_keeps_ipv6_static_route_fallback(monkeypatch):
+    commands = []
+    monmap = '{"mons":[{"addr":"[%s]:%s/0"}]}' % (TEST_IPV6_ADDRESS, TEST_CEPH_PORT)
+
+    def fake_bash_r(cmd):
+        commands.append(cmd)
+        return 0
+
+    monkeypatch.setattr(ceph_utils, 'bash_r', fake_bash_r)
+
+    assert ceph_utils.get_mon_addr(monmap) == TEST_IPV6_ADDRESS
+    assert commands == [
+        "ip -6 route | grep -w '%s' > /dev/null" % TEST_IPV6_ADDRESS
     ]
 
 

--- a/zstacklib/zstacklib/utils/ceph.py
+++ b/zstacklib/zstacklib/utils/ceph.py
@@ -27,7 +27,7 @@ ROUTE_PROTOCOL_KERNEL = 'kernel'
 ROUTE_MATCH_CMD_FORMAT = "ip route | grep -w '%s' > /dev/null"
 ROUTE_KERNEL_MATCH_CMD_FORMAT = 'ip route | grep -w "proto kernel" | grep -w \'%s\' > /dev/null'
 IPV6_ROUTE_MATCH_CMD_FORMAT = "ip -6 route | grep -w '%s' > /dev/null"
-IPV6_ROUTE_KERNEL_MATCH_CMD_FORMAT = 'ip -6 route | grep -w "proto kernel" | grep -w \'%s\' > /dev/null'
+IPV6_ROUTE_KERNEL_MATCH_CMD_FORMAT = "ip -6 route get '%s' | grep -E '^local[[:space:]]' > /dev/null"
 
 QEMU_NBD_SOCKET_DIR = "/var/lock/"
 QEMU_NBD_SOCKET_PREFIX = "qemu-nbd-nbd"


### PR DESCRIPTION
## Summary
- detect locally assigned IPv6 monitor addresses from `ip -6 route get` when the route begins with `local`
- remove the dependency on a temporary `/128` route for directly connected `/64` addresses
- keep the existing static-route fallback for non-local addresses

## Validation
- `git diff --check`, Python compile checks, and targeted local/non-local/static-fallback regression harness passed
- on all three XSKY nodes, both `cephb` and `cephp` resolve their local IPv6 monitor address without a `/128` route and reject non-local `ff02::1`
- XSKY backup storage and primary storage reconnect as Enabled/Connected
- the local host lacks the repository pytest dependencies, so the complete unit suite is left to CI

sync from gitlab !7585