### PR TITLE
<fix>[kvm]: ZSTAC-86993 avoid libvirt dependency during startup

### DIFF
--- a/zstacklib/zstacklib/test/test_qemu_version.py
+++ b/zstacklib/zstacklib/test/test_qemu_version.py
@@ -1,0 +1,55 @@
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+class TestQemuVersion(unittest.TestCase):
+    def load_qemu(self):
+        modules = {
+            name: types.ModuleType(name)
+            for name in ['bash', 'log', 'jsonobject', 'shell', 'linux',
+                         'zstacklib', 'zstacklib.utils',
+                         'zstacklib.utils.qemu_img']
+        }
+        modules['zstacklib'].utils = modules['zstacklib.utils']
+        modules['zstacklib.utils'].qemu_img = modules['zstacklib.utils.qemu_img']
+        modules['log'].get_logger = mock.Mock(return_value=mock.Mock())
+        modules['shell'].call = mock.Mock(return_value='6.2.0')
+        modules['bash'].bash_roe = mock.Mock(
+            return_value=(0, 'QEMU emulator version 6.2.0 (qemu-kvm-6.2.0)\n', '')
+        )
+        modules['linux'].get_vm_pid = mock.Mock()
+        modules['linux'].get_process_start_time = mock.Mock()
+        modules['linux'].HOST_ARCH = 'x86_64'
+
+        qemu_path = os.path.join(
+            os.path.dirname(__file__), '..', 'utils', 'qemu.py'
+        )
+        spec = importlib.util.spec_from_file_location('qemu_under_test', qemu_path)
+        qemu = importlib.util.module_from_spec(spec)
+
+        with mock.patch.dict(sys.modules, modules), \
+                mock.patch('os.path.exists', return_value=True):
+            spec.loader.exec_module(qemu)
+
+        return qemu
+
+    def test_get_version_does_not_depend_on_libvirt(self):
+        qemu = self.load_qemu()
+        qemu.shell.call.assert_not_called()
+        qemu.shell.call.reset_mock()
+        qemu.get_path = mock.Mock(return_value='/usr/libexec/qemu-kvm')
+        qemu.get_version_from_exe_file2 = mock.Mock(return_value='6.2.0')
+
+        self.assertEqual('6.2.0', qemu.get_version())
+        qemu.get_version_from_exe_file2.assert_called_once_with(
+            '/usr/libexec/qemu-kvm'
+        )
+        qemu.shell.call.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zstacklib/zstacklib/utils/qemu.py
+++ b/zstacklib/zstacklib/utils/qemu.py
@@ -45,13 +45,7 @@ def get_bin_dir():
 
 
 def get_version():
-    version = shell.call("virsh version | awk '/hypervisor.*QEMU/{print $4}'", False).strip()
-
-    # failed to get qemu version, fallback to get its version from path
-    if version == "":
-        return get_version_from_exe_file2(get_path())
-
-    return version
+    return get_version_from_exe_file2(get_path())
 
 def get_exact_version():
     return get_version_from_exe_file(get_path())
@@ -221,6 +215,5 @@ def compress_and_encode_bitmap(bitmap_map):
     bitmap_json = json.dumps(bitmap_map)
     compressed_data = zlib.compress(bitmap_json.encode('utf-8'))
     return base64.b64encode(compressed_data).decode('utf-8')
-
 
 


### PR DESCRIPTION
## Summary

When kvmagent is stopped or hung, `restart` imports the QEMU utility before reaching the daemon stop path. The import-time `virsh version` call can enter terminal authentication and stop the remote pseudo-TTY process group, leaving the host in Connecting.

## Changes

- Read the static QEMU version from the local QEMU executable instead of `virsh`.
- Add a regression test proving module import and `get_version()` do not call libvirt through `virsh`.

## Testing

- [x] `python3 -m pytest -q zstacklib/zstacklib/test/test_qemu_version.py` — 1 passed
- [x] `python3 -m unittest zstacklib.zstacklib.test.test_qemu_version -v` — OK
- [x] Python syntax compilation for the changed source and test
- [ ] Production `python3.11` runtime — interpreter unavailable locally
- [ ] Real host SIGSTOP + SSH pseudo-TTY restart validation
- [ ] CI pipeline

Resolves: ZSTAC-86993

sync from gitlab !7597