### PR TITLE
ZSTAC-86926 <fix>[zstacklib]: wait qemu-nbd before LV deactivate

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -11017,7 +11017,10 @@ host side snapshot files chian:
         volume_export_info = {}
         for volume in cmd.volumes:
             volume_export_info[volume.volumeUuid] = False
-            if qemu_nbd.find_qemu_nbd_process(volume.installPath) == 0:
+            real_path = self.get_cbt_volume_actual_install_path(volume.installPath)
+            if qemu_nbd.find_qemu_nbd_process(real_path) == 0:
+                volume_export_info[volume.volumeUuid] = True
+            elif real_path != volume.installPath and qemu_nbd.find_qemu_nbd_process(volume.installPath) == 0:
                 volume_export_info[volume.volumeUuid] = True
 
         rsp.volumeExportInfos = volume_export_info

--- a/tests/unit/kvmagent/test_vm_plugin_handlers.py
+++ b/tests/unit/kvmagent/test_vm_plugin_handlers.py
@@ -1941,18 +1941,49 @@ class TestKvmDetachUsbDeviceHandler:
 class TestListExportedVolumesHandler:
     def test_list_exported_volumes(self):
         plugin = _make_vm_plugin()
-        vm_plugin.qemu_nbd.find_qemu_nbd_process = MagicMock(side_effect=[0, 1])
         volume_one = MagicMock(volumeUuid='vol-1', installPath='/path/vol1')
         volume_two = MagicMock(volumeUuid='vol-2', installPath='/path/vol2')
         cmd = MagicMock(volumes=[volume_one, volume_two])
         with patch.object(vm_plugin.jsonobject, 'loads', return_value=cmd):
-            req = _make_req({})
-            result = plugin.list_exported_volumes(req)
-            rsp = json.loads(result)
+            with patch.object(vm_plugin.qemu_nbd, 'find_qemu_nbd_process', side_effect=[0, 1]) as find:
+                req = _make_req({})
+                result = plugin.list_exported_volumes(req)
+                rsp = json.loads(result)
 
         assert rsp['success'] is True
         assert rsp['volumeExportInfos']['vol-1'] is True
         assert rsp['volumeExportInfos']['vol-2'] is False
+        assert [call.args[0] for call in find.call_args_list] == ['/path/vol1', '/path/vol2']
+
+    def test_list_exported_volumes_checks_converted_real_path(self):
+        plugin = _make_vm_plugin()
+        volume = MagicMock(volumeUuid='vol-1', installPath='sharedblock://vg/vol')
+        cmd = MagicMock(volumes=[volume])
+
+        with patch.object(vm_plugin.jsonobject, 'loads', return_value=cmd):
+            with patch.object(vm_plugin.qemu_nbd, 'find_qemu_nbd_process', return_value=0) as find:
+                req = _make_req({})
+                result = plugin.list_exported_volumes(req)
+                rsp = json.loads(result)
+
+        assert rsp['success'] is True
+        assert rsp['volumeExportInfos']['vol-1'] is True
+        find.assert_called_once_with('/dev/vg/vol')
+
+    def test_list_exported_volumes_falls_back_to_install_path(self):
+        plugin = _make_vm_plugin()
+        volume = MagicMock(volumeUuid='vol-1', installPath='sharedblock://vg/vol')
+        cmd = MagicMock(volumes=[volume])
+
+        with patch.object(vm_plugin.jsonobject, 'loads', return_value=cmd):
+            with patch.object(vm_plugin.qemu_nbd, 'find_qemu_nbd_process', side_effect=[1, 0]) as find:
+                req = _make_req({})
+                result = plugin.list_exported_volumes(req)
+                rsp = json.loads(result)
+
+        assert rsp['success'] is True
+        assert rsp['volumeExportInfos']['vol-1'] is True
+        assert [call.args[0] for call in find.call_args_list] == ['/dev/vg/vol', 'sharedblock://vg/vol']
 
 
 @pytest.mark.kvmagent
@@ -2644,18 +2675,38 @@ class TestUnexportNbdVolumesHandler:
     def test_unexport_nbd_volumes(self):
         plugin = _make_vm_plugin()
         plugin.get_cbt_volume_actual_install_path = MagicMock(return_value='/path/vol')
-        vm_plugin.qemu_nbd.kill_nbd_process_by_flag = MagicMock()
         plugin.deactive_volume_if_need = MagicMock()
 
         volume = MagicMock(installPath='/path/vol')
         cmd = MagicMock(volumes=[volume])
         with patch.object(vm_plugin.jsonobject, 'loads', return_value=cmd):
-            req = _make_req({})
-            result = plugin.unexport_nbd_volumes(req)
-            rsp = json.loads(result)
+            with patch.object(vm_plugin.qemu_nbd, 'kill_nbd_process_by_flag') as kill_nbd:
+                req = _make_req({})
+                result = plugin.unexport_nbd_volumes(req)
+                rsp = json.loads(result)
 
         assert rsp['success'] is True
-        vm_plugin.qemu_nbd.kill_nbd_process_by_flag.assert_called_once_with('/path/vol')
+        kill_nbd.assert_called_once_with('/path/vol')
+        plugin.deactive_volume_if_need.assert_called_once_with('/path/vol', False)
+
+    def test_unexport_nbd_volumes_does_not_deactivate_when_kill_times_out(self):
+        plugin = _make_vm_plugin()
+        plugin.get_cbt_volume_actual_install_path = MagicMock(return_value='/path/vol')
+        plugin.deactive_volume_if_need = MagicMock()
+
+        volume = MagicMock(installPath='/path/vol')
+        cmd = MagicMock(volumes=[volume])
+        err = Exception('timeout waiting qemu-nbd process[/path/vol] gone after SIGTERM')
+        with patch.object(vm_plugin.jsonobject, 'loads', return_value=cmd):
+            with patch.object(vm_plugin.qemu_nbd, 'kill_nbd_process_by_flag', side_effect=err) as kill_nbd:
+                req = _make_req({})
+                result = plugin.unexport_nbd_volumes(req)
+                rsp = json.loads(result)
+
+        assert rsp['success'] is False
+        assert 'timeout waiting qemu-nbd process' in rsp['error']
+        kill_nbd.assert_called_once_with('/path/vol')
+        plugin.deactive_volume_if_need.assert_not_called()
 
 
 @pytest.mark.kvmagent

--- a/zstacklib/zstacklib/test/test_qemu_nbd.py
+++ b/zstacklib/zstacklib/test/test_qemu_nbd.py
@@ -1,0 +1,153 @@
+import errno
+import unittest
+
+from zstacklib.utils import qemu_nbd
+
+
+class TestQemuNbd(unittest.TestCase):
+    def test_kill_nbd_process_by_flag_sends_sigterm_and_waits_until_gone(self):
+        calls = []
+        original_find = qemu_nbd.linux.find_process_list_by_command
+        original_wait = qemu_nbd.linux.wait_callback_success
+        original_kill = qemu_nbd.os.kill
+        results = [['123', '456'], []]
+
+        def find(command, arguments):
+            calls.append(('find', command, arguments))
+            return results.pop(0)
+
+        def kill(pid, sig):
+            calls.append(('kill', pid, sig))
+
+        def wait(callback, callback_data=None, timeout=60, interval=1):
+            calls.append(('wait', timeout, interval))
+            return callback(callback_data)
+
+        qemu_nbd.linux.find_process_list_by_command = find
+        qemu_nbd.linux.wait_callback_success = wait
+        qemu_nbd.os.kill = kill
+        try:
+            ret = qemu_nbd.kill_nbd_process_by_flag('/dev/vg/volume', timeout=7, interval=2)
+        finally:
+            qemu_nbd.linux.find_process_list_by_command = original_find
+            qemu_nbd.linux.wait_callback_success = original_wait
+            qemu_nbd.os.kill = original_kill
+
+        self.assertEqual(0, ret)
+        self.assertEqual(('find', 'qemu-nbd', ['/dev/vg/volume']), calls[0])
+        self.assertEqual(('kill', 123, qemu_nbd.signal.SIGTERM), calls[1])
+        self.assertEqual(('kill', 456, qemu_nbd.signal.SIGTERM), calls[2])
+        self.assertEqual(('wait', 7, 2), calls[3])
+        self.assertEqual(('find', 'qemu-nbd', ['/dev/vg/volume']), calls[4])
+
+    def test_kill_nbd_process_by_flag_returns_1_when_no_process(self):
+        original_find = qemu_nbd.linux.find_process_list_by_command
+        original_wait = qemu_nbd.linux.wait_callback_success
+        original_kill = qemu_nbd.os.kill
+
+        qemu_nbd.linux.find_process_list_by_command = lambda command, arguments: []
+        qemu_nbd.linux.wait_callback_success = lambda *args, **kwargs: self.fail('wait should not run')
+        qemu_nbd.os.kill = lambda *args, **kwargs: self.fail('kill should not run')
+        try:
+            self.assertEqual(1, qemu_nbd.kill_nbd_process_by_flag('/dev/vg/volume'))
+        finally:
+            qemu_nbd.linux.find_process_list_by_command = original_find
+            qemu_nbd.linux.wait_callback_success = original_wait
+            qemu_nbd.os.kill = original_kill
+
+    def test_kill_nbd_fails_when_process_still_exists(self):
+        original_find = qemu_nbd.linux.find_process_list_by_command
+        original_wait = qemu_nbd.linux.wait_callback_success
+        original_kill = qemu_nbd.os.kill
+
+        qemu_nbd.linux.find_process_list_by_command = lambda command, arguments: ['123']
+        qemu_nbd.linux.wait_callback_success = lambda callback, callback_data=None, timeout=60, interval=1: False
+        qemu_nbd.os.kill = lambda pid, sig: None
+        try:
+            try:
+                qemu_nbd.kill_nbd_process_by_flag('/dev/vg/volume')
+                self.fail('expected qemu-nbd timeout')
+            except Exception as e:
+                self.assertIn('timeout waiting qemu-nbd process', str(e))
+        finally:
+            qemu_nbd.linux.find_process_list_by_command = original_find
+            qemu_nbd.linux.wait_callback_success = original_wait
+            qemu_nbd.os.kill = original_kill
+
+    def test_find_qemu_nbd_process_uses_process_list(self):
+        original_find = qemu_nbd.linux.find_process_list_by_command
+        calls = []
+        results = [[], ['123']]
+
+        def find(command, arguments):
+            calls.append((command, arguments))
+            return results.pop(0)
+
+        qemu_nbd.linux.find_process_list_by_command = find
+        try:
+            self.assertEqual(1, qemu_nbd.find_qemu_nbd_process('/dev/vg/missing'))
+            self.assertEqual(0, qemu_nbd.find_qemu_nbd_process('/dev/vg/present'))
+        finally:
+            qemu_nbd.linux.find_process_list_by_command = original_find
+
+        self.assertEqual(('qemu-nbd', ['/dev/vg/missing']), calls[0])
+        self.assertEqual(('qemu-nbd', ['/dev/vg/present']), calls[1])
+
+    def test_find_qemu_nbd_process_propagates_probe_error(self):
+        original_find = qemu_nbd.linux.find_process_list_by_command
+
+        def find(command, arguments):
+            raise OSError('cannot read proc')
+
+        qemu_nbd.linux.find_process_list_by_command = find
+        try:
+            self.assertRaises(OSError, qemu_nbd.find_qemu_nbd_process, '/dev/vg/volume')
+        finally:
+            qemu_nbd.linux.find_process_list_by_command = original_find
+
+    def test_find_qemu_nbd_process_logs_proc_read_error(self):
+        original_listdir = qemu_nbd.linux.os.listdir
+        original_readlink = qemu_nbd.linux.os.readlink
+        original_warn = qemu_nbd.linux.logger.warn
+        warnings = []
+        errors = [errno.EACCES, errno.ENOENT]
+
+        qemu_nbd.linux.os.listdir = lambda path: ['123']
+
+        def readlink(path):
+            raise OSError(errors.pop(0), 'cannot read proc')
+
+        qemu_nbd.linux.os.readlink = readlink
+        qemu_nbd.linux.logger.warn = lambda message: warnings.append(message)
+        try:
+            self.assertEqual(1, qemu_nbd.find_qemu_nbd_process('/dev/vg/volume'))
+            self.assertEqual(1, qemu_nbd.find_qemu_nbd_process('/dev/vg/volume'))
+        finally:
+            qemu_nbd.linux.os.listdir = original_listdir
+            qemu_nbd.linux.os.readlink = original_readlink
+            qemu_nbd.linux.logger.warn = original_warn
+
+        self.assertEqual(1, len(warnings))
+        self.assertIn('process[123]', warnings[0])
+
+    def test_kill_nbd_process_by_flag_ignores_exited_process(self):
+        original_find = qemu_nbd.linux.find_process_list_by_command
+        original_wait = qemu_nbd.linux.wait_callback_success
+        original_kill = qemu_nbd.os.kill
+
+        def kill(pid, sig):
+            raise OSError(errno.ESRCH, 'process gone')
+
+        qemu_nbd.linux.find_process_list_by_command = lambda command, arguments: ['123']
+        qemu_nbd.linux.wait_callback_success = lambda callback, callback_data=None, timeout=60, interval=1: True
+        qemu_nbd.os.kill = kill
+        try:
+            self.assertEqual(0, qemu_nbd.kill_nbd_process_by_flag('/dev/vg/volume'))
+        finally:
+            qemu_nbd.linux.find_process_list_by_command = original_find
+            qemu_nbd.linux.wait_callback_success = original_wait
+            qemu_nbd.os.kill = original_kill
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -2468,7 +2468,10 @@ def find_process_list_by_command(comm, cmdlines=None):
                 if all(c in cmdline for c in cmdlines):
                     match_pids.append(pid)
                     continue
-        except (IOError, OSError):
+        except (IOError, OSError) as e:
+            if e.errno not in (errno.ENOENT, errno.ESRCH):
+                logger.warn("failed to inspect process[%s] when looking for command[%s]: %s" %
+                            (pid, comm, str(e)))
             continue
     return match_pids
 

--- a/zstacklib/zstacklib/utils/qemu_nbd.py
+++ b/zstacklib/zstacklib/utils/qemu_nbd.py
@@ -1,6 +1,9 @@
-from zstacklib.utils import linux
-from zstacklib.utils import shell
+import errno
+import os
+import signal
 import subprocess
+
+from zstacklib.utils import linux
 
 
 def export(port, *args):
@@ -11,11 +14,25 @@ def export(port, *args):
     return process
 
 
-def kill_nbd_process_by_flag(flag):
-    regex = 'qemu-nbd.*%s' % flag
-    return linux.pkill_by_pattern(regex)
-
-
 def find_qemu_nbd_process(pattern):
-    command = "pgrep -a qemu-nbd | grep %s" % pattern
-    return shell.run(command)
+    return 0 if linux.find_process_list_by_command('qemu-nbd', [pattern]) else 1
+
+
+def kill_nbd_process_by_flag(flag, timeout=60, interval=1):
+    pids = linux.find_process_list_by_command('qemu-nbd', [flag])
+    if not pids:
+        return 1
+
+    for pid in pids:
+        try:
+            os.kill(int(pid), signal.SIGTERM)
+        except OSError as e:
+            if e.errno != errno.ESRCH:
+                raise
+
+    def gone(_):
+        return find_qemu_nbd_process(flag) != 0
+
+    if not linux.wait_callback_success(gone, timeout=timeout, interval=interval):
+        raise Exception('timeout waiting qemu-nbd process[%s] gone after SIGTERM' % flag)
+    return 0


### PR DESCRIPTION
Cherry-pick for ZSTAC-86926 from ZSTAC-86920.

Source MRs:
- http://dev.zstack.io:9080/zstackio/zstack-utility/-/merge_requests/7435
- http://dev.zstack.io:9080/zstackio/zstack-utility/-/merge_requests/7567

Target branch: 5.5.38

Verification:
- git diff --check upstream/5.5.38...HEAD
- python3 -m py_compile changed Python files
- PYTHONPATH=... python3 -m unittest zstacklib.test.test_qemu_nbd not run successfully: current environment lacks simplejson

sync from gitlab !7591