### PR TITLE
<fix>[ha]: report failed network group VMs

### DIFF
--- a/kvmagent/kvmagent/plugins/ha_plugin.py
+++ b/kvmagent/kvmagent/plugins/ha_plugin.py
@@ -219,6 +219,7 @@ class ReportHaNetworkGroupStatusCmd(object):
     def __init__(self):
         self.hostUuid = None
         self.networkGroupStatus = None
+        self.failedVmUuids = None
 
 
 class FencerStateRsp(AgentRsp):
@@ -3376,14 +3377,15 @@ class HaPlugin(kvmagent.KvmAgent):
 
         return failed_groups
 
-    def _kill_vms_by_network_group_rule(self, vm_rules, down_monitors):
+    def _collect_failed_vms_by_network_group_rule(self, vm_rules, down_monitors):
         if not vm_rules:
             return []
 
-        killed_vms = []
+        failed_vms = set()
         down_str = ','.join(sorted(list(down_monitors))) if down_monitors else 'none'
 
-        for vm_uuid, vm_cfg in vm_rules.items():
+        for vm_uuid in sorted(vm_rules.keys()):
+            vm_cfg = vm_rules[vm_uuid]
             failed_groups = self._get_failed_vm_network_groups(vm_cfg, down_monitors)
             if not failed_groups:
                 continue
@@ -3400,18 +3402,12 @@ class HaPlugin(kvmagent.KvmAgent):
                 '%s:%s/%s' % (group['groupUuid'], group['score'], group['minScore'])
                 for group in failed_groups
             ])
-            reason = 'because vm network groups[%s] are lower than required minScore, down resources[%s]' % (
-                failed_groups_str, down_str
-            )
-            kill_vm_use_pid({vm_uuid: vm_pid}, reason)
-            killed_vms.append(vm_uuid)
-            logger.warn('ha network group fencer killed vm[uuid:%s], failedGroups:%s, down:%s' % (
+            failed_vms.add(vm_uuid)
+            logger.debug('ha network group fencer detected failed vm[uuid:%s], failedGroups:%s, down:%s' % (
                 vm_uuid, failed_groups_str, down_str
             ))
 
-        if killed_vms:
-            clean_network_config(killed_vms)
-        return killed_vms
+        return sorted(failed_vms)
 
     def _calculate_network_group_status(self, network_groups, down_monitors):
         if not network_groups:
@@ -3440,7 +3436,8 @@ class HaPlugin(kvmagent.KvmAgent):
 
         return status
 
-    def _dump_ha_network_group_debug(self, stage, down_monitors=None, network_group_status=None):
+    def _dump_ha_network_group_debug(self, stage, down_monitors=None, network_group_status=None,
+                                     failed_vm_uuids=None):
         try:
             with self.ha_network_group_lock:
                 content = {
@@ -3459,6 +3456,8 @@ class HaPlugin(kvmagent.KvmAgent):
                 content['downMonitors'] = sorted(list(down_monitors))
             if network_group_status is not None:
                 content['networkGroupStatus'] = network_group_status
+            if failed_vm_uuids is not None:
+                content['failedVmUuids'] = sorted(list(failed_vm_uuids))
 
             with lock.NamedLock('ha-network-group-debug-dump'):
                 dump_dir = os.path.dirname(self.NETWORK_GROUP_DEBUG_DUMP_PATH)
@@ -3477,7 +3476,7 @@ class HaPlugin(kvmagent.KvmAgent):
         except Exception as e:
             logger.debug('failed to dump ha network group debug file, %s' % e)
 
-    def _do_report_ha_network_group_status(self, network_group_status, report_generation):
+    def _do_report_ha_network_group_status(self, network_group_status, failed_vm_uuids, report_generation):
         try:
             url, host_uuid = self._get_report_url_and_host_uuid()
             if not url:
@@ -3491,12 +3490,15 @@ class HaPlugin(kvmagent.KvmAgent):
             cmd = ReportHaNetworkGroupStatusCmd()
             cmd.hostUuid = host_uuid
             cmd.networkGroupStatus = network_group_status
+            cmd.failedVmUuids = sorted(list(set(failed_vm_uuids or [])))
             http.json_dump_post(url, cmd, {'commandpath': self.REPORT_HA_NETWORK_GROUP_STATUS_PATH}, fail_soon=True)
             with self.ha_network_group_lock:
                 if report_generation == self.ha_network_group_report_generation:
                     self.ha_network_group_last_status = dict(network_group_status)
-            logger.debug('reported ha network group status for host[%s], status:%s' % (host_uuid, network_group_status))
-            self._dump_ha_network_group_debug('report-status', network_group_status=network_group_status)
+            logger.debug('reported ha network group status for host[%s], status:%s, failedVmCount:%s' % (
+                host_uuid, network_group_status, len(cmd.failedVmUuids)))
+            self._dump_ha_network_group_debug('report-status', network_group_status=network_group_status,
+                                              failed_vm_uuids=cmd.failedVmUuids)
         except Exception as e:
             logger.warn('failed to report ha network group status to management node, %s' % e)
         finally:
@@ -3504,19 +3506,20 @@ class HaPlugin(kvmagent.KvmAgent):
                 self.ha_network_group_reporting_in_flight = False
 
     @thread.AsyncThread
-    def _async_report_ha_network_group_status(self, network_group_status, report_generation):
-        self._do_report_ha_network_group_status(network_group_status, report_generation)
+    def _async_report_ha_network_group_status(self, network_group_status, failed_vm_uuids, report_generation):
+        self._do_report_ha_network_group_status(network_group_status, failed_vm_uuids, report_generation)
 
-    def _report_ha_network_group_status(self, network_group_status):
-        if not network_group_status:
+    def _report_ha_network_group_status(self, network_group_status, failed_vm_uuids=None):
+        failed_to_report = sorted(list(set(failed_vm_uuids or [])))
+        if not network_group_status and not failed_to_report:
             with self.ha_network_group_lock:
                 self.ha_network_group_last_status = {}
                 self.ha_network_group_report_generation += 1
             return
 
-        status_to_report = dict(network_group_status)
+        status_to_report = dict(network_group_status or {})
         with self.ha_network_group_lock:
-            if status_to_report == self.ha_network_group_last_status:
+            if not failed_to_report and status_to_report == self.ha_network_group_last_status:
                 return
             if self.ha_network_group_reporting_in_flight:
                 return
@@ -3526,7 +3529,7 @@ class HaPlugin(kvmagent.KvmAgent):
             report_generation = self.ha_network_group_report_generation
             self.ha_network_group_reporting_in_flight = True
 
-        self._async_report_ha_network_group_status(status_to_report, report_generation)
+        self._async_report_ha_network_group_status(status_to_report, failed_to_report, report_generation)
 
     def _wait_ha_network_group_monitor(self, interval):
         return self.ha_network_group_monitor_stop_event.wait(max(interval, 0))
@@ -3556,13 +3559,14 @@ class HaPlugin(kvmagent.KvmAgent):
                     continue
 
                 down_monitors = self._get_down_monitors(monitors, max_attempts)
-                killed_vms = self._kill_vms_by_network_group_rule(vm_rules, down_monitors)
+                failed_vm_uuids = self._collect_failed_vms_by_network_group_rule(vm_rules, down_monitors)
                 network_group_status = self._calculate_network_group_status(network_groups, down_monitors)
-                self._report_ha_network_group_status(network_group_status)
+                self._report_ha_network_group_status(network_group_status, failed_vm_uuids)
 
-                if killed_vms:
-                    logger.warn('ha network group monitor killed vms: %s' % ','.join(killed_vms))
-                    self._dump_ha_network_group_debug('kill-vm', down_monitors, network_group_status)
+                if failed_vm_uuids:
+                    logger.debug('ha network group monitor reported failed vms: %s' % ','.join(failed_vm_uuids))
+                    self._dump_ha_network_group_debug('failed-vm-report', down_monitors,
+                                                      network_group_status, failed_vm_uuids)
             except Exception as e:
                 logger.warn('ha network group monitor loop hit exception, %s' % e)
                 logger.debug(traceback.format_exc())

--- a/kvmagent/kvmagent/test/ha/test_ha_network_group_reporting.py
+++ b/kvmagent/kvmagent/test/ha/test_ha_network_group_reporting.py
@@ -1,0 +1,142 @@
+import threading
+import unittest
+from unittest import mock
+
+from kvmagent.plugins import ha_plugin
+from kvmagent.plugins.ha_plugin import HaPlugin
+
+
+def _make_plugin():
+    plugin = HaPlugin.__new__(HaPlugin)
+    plugin.ha_network_group_lock = threading.RLock()
+    plugin.ha_network_group_last_status = {}
+    plugin.ha_network_group_reporting_in_flight = False
+    plugin.ha_network_group_report_generation = 0
+    return plugin
+
+
+def _vm_rule(min_score=2):
+    return {
+        'groups': {
+            'group-1': {
+                'rules': [
+                    {'resource': 'eth0', 'weight': 1},
+                    {'resource': 'eth1', 'weight': 1},
+                ],
+                'minScore': min_score,
+            }
+        }
+    }
+
+
+class TestHaNetworkGroupFailedVmReporting(unittest.TestCase):
+    def setUp(self):
+        self.plugin = _make_plugin()
+
+    @mock.patch.object(ha_plugin, 'clean_network_config')
+    @mock.patch.object(ha_plugin, 'kill_vm_use_pid')
+    @mock.patch.object(ha_plugin.linux, 'get_vm_pid', return_value='1234')
+    def test_failed_vm_is_collected_without_kill_or_network_cleanup(self, get_pid, kill_vm, clean_network):
+        self.plugin._get_vm_enable_ha = mock.Mock(return_value=True)
+
+        failed = self.plugin._collect_failed_vms_by_network_group_rule(
+            {'vm-b': _vm_rule(), 'vm-a': _vm_rule()}, {'eth0'})
+
+        self.assertEqual(['vm-a', 'vm-b'], failed)
+        self.assertEqual(2, get_pid.call_count)
+        kill_vm.assert_not_called()
+        clean_network.assert_not_called()
+
+    @mock.patch.object(ha_plugin, 'clean_network_config')
+    @mock.patch.object(ha_plugin, 'kill_vm_use_pid')
+    @mock.patch.object(ha_plugin.linux, 'get_vm_pid')
+    def test_vm_without_qemu_or_enable_ha_is_not_reported(self, get_pid, kill_vm, clean_network):
+        get_pid.side_effect = lambda vm_uuid: None if vm_uuid == 'vm-no-qemu' else '2345'
+        self.plugin._get_vm_enable_ha = mock.Mock(return_value=False)
+
+        failed = self.plugin._collect_failed_vms_by_network_group_rule(
+            {'vm-no-qemu': _vm_rule(), 'vm-ha-disabled': _vm_rule()}, {'eth0'})
+
+        self.assertEqual([], failed)
+        kill_vm.assert_not_called()
+        clean_network.assert_not_called()
+
+    @mock.patch.object(ha_plugin.linux, 'get_vm_pid', return_value='1234')
+    def test_vm_above_threshold_is_not_reported(self, _get_pid):
+        self.plugin._get_vm_enable_ha = mock.Mock(return_value=True)
+
+        failed = self.plugin._collect_failed_vms_by_network_group_rule(
+            {'vm-1': _vm_rule(min_score=1)}, {'eth0'})
+
+        self.assertEqual([], failed)
+
+    def test_non_empty_failed_list_is_reported_each_fencer_cycle(self):
+        reports = []
+
+        def complete_report(status, failed_vm_uuids, generation):
+            reports.append((status, failed_vm_uuids, generation))
+            self.plugin.ha_network_group_last_status = dict(status)
+            self.plugin.ha_network_group_reporting_in_flight = False
+
+        self.plugin._async_report_ha_network_group_status = complete_report
+
+        self.plugin._report_ha_network_group_status({'group-1': 'Down'}, ['vm-1'])
+        self.plugin._report_ha_network_group_status({'group-1': 'Down'}, ['vm-1'])
+
+        self.assertEqual(2, len(reports))
+        self.assertEqual(['vm-1'], reports[0][1])
+        self.assertEqual(['vm-1'], reports[1][1])
+
+    def test_unchanged_status_without_failed_vm_is_not_reported(self):
+        self.plugin.ha_network_group_last_status = {'group-1': 'Available'}
+        self.plugin._async_report_ha_network_group_status = mock.Mock()
+
+        self.plugin._report_ha_network_group_status({'group-1': 'Available'}, [])
+
+        self.plugin._async_report_ha_network_group_status.assert_not_called()
+
+    def test_http_in_flight_skips_concurrent_report(self):
+        self.plugin.ha_network_group_reporting_in_flight = True
+        self.plugin._async_report_ha_network_group_status = mock.Mock()
+
+        self.plugin._report_ha_network_group_status({'group-1': 'Down'}, ['vm-1'])
+
+        self.plugin._async_report_ha_network_group_status.assert_not_called()
+
+    @mock.patch.object(ha_plugin.http, 'json_dump_post', side_effect=RuntimeError('mn unavailable'))
+    def test_http_failure_releases_in_flight_for_next_cycle(self, _post):
+        self.plugin._get_report_url_and_host_uuid = mock.Mock(return_value=('http://mn/report', 'host-1'))
+        self.plugin._dump_ha_network_group_debug = mock.Mock()
+        self.plugin.ha_network_group_reporting_in_flight = True
+
+        self.plugin._do_report_ha_network_group_status({'group-1': 'Down'}, ['vm-1'], 0)
+
+        self.assertFalse(self.plugin.ha_network_group_reporting_in_flight)
+        self.plugin._async_report_ha_network_group_status = mock.Mock()
+        self.plugin._report_ha_network_group_status({'group-1': 'Down'}, ['vm-1'])
+        self.plugin._async_report_ha_network_group_status.assert_called_once()
+
+    def test_restart_recalculates_and_reports_current_status(self):
+        restarted = _make_plugin()
+        restarted._async_report_ha_network_group_status = mock.Mock()
+
+        restarted._report_ha_network_group_status({'group-1': 'Available'}, [])
+
+        restarted._async_report_ha_network_group_status.assert_called_once()
+
+    @mock.patch.object(ha_plugin.http, 'json_dump_post')
+    def test_report_command_contains_sorted_deduplicated_failed_vm_uuids(self, post):
+        self.plugin._get_report_url_and_host_uuid = mock.Mock(return_value=('http://mn/report', 'host-1'))
+        self.plugin._dump_ha_network_group_debug = mock.Mock()
+
+        self.plugin._do_report_ha_network_group_status(
+            {'group-1': 'Down'}, ['vm-b', 'vm-a', 'vm-a'], 0)
+
+        cmd = post.call_args[0][1]
+        self.assertEqual('host-1', cmd.hostUuid)
+        self.assertEqual({'group-1': 'Down'}, cmd.networkGroupStatus)
+        self.assertEqual(['vm-a', 'vm-b'], cmd.failedVmUuids)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kvmagent/kvmagent/test/ha/test_physical_nic_fencer.py
+++ b/kvmagent/kvmagent/test/ha/test_physical_nic_fencer.py
@@ -127,11 +127,11 @@ class TestFindVmUseFaultNicWithVirsh(unittest.TestCase):
     def setUp(self):
         self.fencer = _make_fencer()
 
-    @mock.patch('kvmagent.plugins.ha_plugin.linux.find_vm_pid_by_uuid')
+    @mock.patch.object(PhysicalNicFencer, '_get_vm_pid')
     @mock.patch('kvmagent.plugins.ha_plugin.shell.call')
     @mock.patch('kvmagent.plugins.ha_plugin.linux.read_file')
     @mock.patch('kvmagent.plugins.ha_plugin.find_vm_uuid_list_by_virsh')
-    @mock.patch.object(PhysicalNicFencer, 'skip_vm_bussiness_nic_check', return_value=False)
+    @mock.patch.object(PhysicalNicFencer, 'get_vm_business_nic_route', return_value='hostBusinessNic')
     def test_skips_virsh_for_vms_not_using_faulted_nic(
             self, mock_skip, mock_virsh_list, mock_read_file, mock_shell_call, mock_find_pid):
         """Core scenario: 3 VMs on host, only vm-3 uses faulted NIC eth0.
@@ -154,10 +154,14 @@ class TestFindVmUseFaultNicWithVirsh(unittest.TestCase):
         mock_shell_call.return_value = "br_eth0\n"  # virsh domiflist output for vm3
         mock_find_pid.return_value = "12345"
 
-        result = self.fencer.find_vm_use_falut_nic_with_virsh(['eth0'])
+        result, affected_host_vms, affected_group_vms = (
+            self.fencer.find_vm_use_falut_nic_with_virsh(['eth0'])
+        )
 
         # Only vm3 should be in result
         self.assertEqual(result, {vm3: "12345"})
+        self.assertEqual(affected_host_vms, [vm3])
+        self.assertEqual(affected_group_vms, [])
         # virsh domiflist should be called exactly once (for vm3 only)
         self.assertEqual(mock_shell_call.call_count, 1)
         self.assertIn(vm3, mock_shell_call.call_args[0][0])
@@ -165,7 +169,7 @@ class TestFindVmUseFaultNicWithVirsh(unittest.TestCase):
     @mock.patch('kvmagent.plugins.ha_plugin.shell.call')
     @mock.patch('kvmagent.plugins.ha_plugin.linux.read_file')
     @mock.patch('kvmagent.plugins.ha_plugin.find_vm_uuid_list_by_virsh')
-    @mock.patch.object(PhysicalNicFencer, 'skip_vm_bussiness_nic_check', return_value=False)
+    @mock.patch.object(PhysicalNicFencer, 'get_vm_business_nic_route', return_value='hostBusinessNic')
     def test_all_vms_no_match_zero_virsh_calls(
             self, mock_skip, mock_virsh_list, mock_read_file, mock_shell_call):
         """100-VM scenario from Jira: none use faulted NIC → zero virsh domiflist calls."""
@@ -173,16 +177,20 @@ class TestFindVmUseFaultNicWithVirsh(unittest.TestCase):
         mock_virsh_list.return_value = vm_uuids
         mock_read_file.return_value = SAMPLE_XML_NO_MATCH_BRIDGE  # all have eth1 only
 
-        result = self.fencer.find_vm_use_falut_nic_with_virsh(['eth0'])
+        result, affected_host_vms, affected_group_vms = (
+            self.fencer.find_vm_use_falut_nic_with_virsh(['eth0'])
+        )
 
         self.assertEqual(result, {})
+        self.assertEqual(affected_host_vms, [])
+        self.assertEqual(affected_group_vms, [])
         mock_shell_call.assert_not_called()
 
-    @mock.patch('kvmagent.plugins.ha_plugin.linux.find_vm_pid_by_uuid')
+    @mock.patch.object(PhysicalNicFencer, '_get_vm_pid')
     @mock.patch('kvmagent.plugins.ha_plugin.shell.call')
     @mock.patch('kvmagent.plugins.ha_plugin.linux.read_file')
     @mock.patch('kvmagent.plugins.ha_plugin.find_vm_uuid_list_by_virsh')
-    @mock.patch.object(PhysicalNicFencer, 'skip_vm_bussiness_nic_check', return_value=False)
+    @mock.patch.object(PhysicalNicFencer, 'get_vm_business_nic_route', return_value='hostBusinessNic')
     def test_xml_unreadable_falls_back_to_virsh(
             self, mock_skip, mock_virsh_list, mock_read_file, mock_shell_call, mock_find_pid):
         """If XML can't be read, virsh domiflist is still called (safe fallback)."""
@@ -192,9 +200,13 @@ class TestFindVmUseFaultNicWithVirsh(unittest.TestCase):
         mock_shell_call.return_value = "br_eth0\n"
         mock_find_pid.return_value = "99999"
 
-        result = self.fencer.find_vm_use_falut_nic_with_virsh(['eth0'])
+        result, affected_host_vms, affected_group_vms = (
+            self.fencer.find_vm_use_falut_nic_with_virsh(['eth0'])
+        )
 
         self.assertEqual(result, {vm1: "99999"})
+        self.assertEqual(affected_host_vms, [vm1])
+        self.assertEqual(affected_group_vms, [])
         self.assertEqual(mock_shell_call.call_count, 1)
 
 


### PR DESCRIPTION
Report failed VM UUIDs to MN without stopping guests in KVM Agent.
Keep network group reporting deduplicated and retryable.

Resolves: ZSTAC-87164
Test: test_ha_network_group_reporting.py
Test: test_physical_nic_fencer.py

Change-Id: Ifc73cbfc9082fc0d1fa6bbec8a6fa2bda48c7c03

sync from gitlab !7602