### PR TITLE
<fix>[kvm]: ZSTAC-86942 persist destination VM after migration

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -5244,7 +5244,8 @@ class Vm(object):
 
         flag = (libvirt.VIR_MIGRATE_LIVE |
                 libvirt.VIR_MIGRATE_PEER2PEER |
-                libvirt.VIR_MIGRATE_UNDEFINE_SOURCE)
+                libvirt.VIR_MIGRATE_UNDEFINE_SOURCE |
+                libvirt.VIR_MIGRATE_PERSIST_DEST)
 
         if cmd.downTime:
             self.domain.migrateSetMaxDowntime(cmd.downTime)
@@ -5271,9 +5272,6 @@ class Vm(object):
         if get_libvirt_major_version() >= 4:
             if is_external_shared_storage():
                 flag |= libvirt.VIR_MIGRATE_UNSAFE
-
-        if cmd.useNuma or storage_migration_required:
-            flag |= libvirt.VIR_MIGRATE_PERSIST_DEST
 
         if use_tls and hasattr(libvirt, 'VIR_MIGRATE_TLS'):
             flag |= libvirt.VIR_MIGRATE_TLS


### PR DESCRIPTION
Always set VIR_MIGRATE_PERSIST_DEST for every live migration so the destination libvirt domain remains persistent. Testing not run per request. Resolves: ZSTAC-86942

sync from gitlab !7604