### PR TITLE
<fix>[build]: correct proxy manifest metadata

### DIFF
--- a/tests/unit/zstackbuild/test_zns_proxy_package.py
+++ b/tests/unit/zstackbuild/test_zns_proxy_package.py
@@ -44,6 +44,8 @@ class ZnsProxyPackageTest(unittest.TestCase):
                 "\t@\"$(GO)\" version > target/go-version.log\n"
                 "\t@printf '%s\\n' \"$(ARCH)\" > target/zns-proxy-arch.log\n"
                 "\t@printf 'fake-zns-proxy\\n' > target/zns-proxy.bin\n"
+                "print-zns-proxy-version:\n"
+                "\t@printf '1.2.0.1\\n'\n"
             )
         subprocess.check_call(["git", "init", "-q"], cwd=source)
         subprocess.check_call(["git", "add", "Makefile", "go.mod"], cwd=source)
@@ -144,6 +146,8 @@ class ZnsProxyPackageTest(unittest.TestCase):
         self.assertEqual(["amd64"], manifest["arch"])
         with open(os.path.join(source, "target", "zns-proxy-arch.log")) as stream:
             self.assertEqual("amd64", stream.read().strip())
+        self.assertEqual("zns-proxy", manifest["component"])
+        self.assertEqual("1.2.0.1", manifest["version"])
 
         ansible_dir = os.path.join(
             self.build_dir,
@@ -173,6 +177,27 @@ class ZnsProxyPackageTest(unittest.TestCase):
                     os.path.join(root, name),
                 )
 
+        assembled_manifest = expected[1]
+        invalid_fields = [
+            ("version", 1, "manifest version must be a non-empty string"),
+            ("sha256", None, "manifest sha256 must be a non-empty string"),
+            ("arch", [0], "manifest arch must be a non-empty list of strings"),
+            ("buildTime", True, "manifest buildTime must be a non-empty string"),
+        ]
+        for field, value, message in invalid_fields:
+            invalid_manifest = manifest.copy()
+            invalid_manifest[field] = value
+            with open(assembled_manifest, "w") as stream:
+                json.dump(invalid_manifest, stream)
+            guard_result = self._run_ant(
+                self._write_go("go1.24.12"),
+                ["verify-zstack-zns-proxy-package"],
+            )
+            self.assertNotEqual(0, guard_result.returncode, guard_result.stdout)
+            self.assertIn(message, guard_result.stdout)
+        with open(assembled_manifest, "w") as stream:
+            json.dump(manifest, stream)
+
         forbidden = os.path.join(ansible_dir, "znsproxy", "zns-agent.bin")
         with open(forbidden, "w") as stream:
             stream.write("must be rejected\n")
@@ -182,6 +207,57 @@ class ZnsProxyPackageTest(unittest.TestCase):
         )
         self.assertNotEqual(0, guard_result.returncode, guard_result.stdout)
         self.assertIn("zns-agent binary must not be packaged", guard_result.stdout)
+
+    def test_manifest_rejects_same_version_with_different_sha(self):
+        package = os.path.join(self.temp_dir, "zns-proxy.bin")
+        output = os.path.join(self.temp_dir, "zns-proxy-manifest.json")
+        script = os.path.join(
+            REPO_ROOT,
+            "zstackbuild",
+            "scripts",
+            "zns_proxy_manifest.py",
+        )
+
+        with open(package, "wb") as stream:
+            stream.write(b"first")
+        command = [
+            "python",
+            script,
+            "--package",
+            package,
+            "--output",
+            output,
+            "--version",
+            "1.2.0.1",
+            "--arch",
+            "amd64",
+            "--path",
+            "zns-proxy.bin",
+        ]
+        subprocess.check_call(command)
+
+        with open(output) as stream:
+            legacy_manifest = json.load(stream)
+        legacy_manifest.pop("component")
+        with open(output, "w") as stream:
+            json.dump(legacy_manifest, stream)
+
+        subprocess.check_call(command)
+        with open(output) as stream:
+            refreshed_manifest = json.load(stream)
+        self.assertEqual("zns-proxy", refreshed_manifest["component"])
+
+        with open(package, "wb") as stream:
+            stream.write(b"second")
+        result = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+
+        self.assertNotEqual(0, result.returncode, result.stdout)
+        self.assertIn("already exists with a different sha256", result.stdout)
 
 
 if __name__ == "__main__":

--- a/zstackbuild/projects/zstack-znsproxy.xml
+++ b/zstackbuild/projects/zstack-znsproxy.xml
@@ -42,6 +42,17 @@
             <arg value="GO=${zstackzns.go}" />
         </exec>
 
+        <exec executable="make" dir="${zstackzns.source}" failonerror="true"
+              outputproperty="zstackzns.proxy.version">
+            <env key="GOWORK" value="off" />
+            <env key="GOROOT" value="" />
+            <arg value="-s" />
+            <arg value="--no-print-directory" />
+            <arg value="print-zns-proxy-version" />
+            <arg value="GO=${zstackzns.go}" />
+        </exec>
+        <echo message="zns-proxy component version: ${zstackzns.proxy.version}" />
+
         <copy todir="${znsproxy.bdir}/">
             <fileset dir="${zstackzns.source}/target">
                 <include name="zns-proxy.bin" />
@@ -55,7 +66,7 @@
             <arg value="--output" />
             <arg value="${znsproxy.bdir}/zns-proxy-manifest.json" />
             <arg value="--version" />
-            <arg value="${bin.version}" />
+            <arg value="${zstackzns.proxy.version}" />
             <arg value="--arch" />
             <arg value="amd64" />
             <arg value="--path" />

--- a/zstackbuild/scripts/zns_proxy_iso_guard.py
+++ b/zstackbuild/scripts/zns_proxy_iso_guard.py
@@ -3,6 +3,18 @@ import argparse
 import hashlib
 import json
 import os
+import re
+
+
+COMPONENT_VERSION_PATTERN = re.compile(
+    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"
+)
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+try:
+    STRING_TYPES = (basestring,)
+except NameError:
+    STRING_TYPES = (str,)
 
 
 def sha256sum(path):
@@ -36,14 +48,38 @@ def main():
 
     with open(manifest_path) as stream:
         manifest = json.load(stream)
+    if not isinstance(manifest, dict):
+        fail("manifest must be a JSON object")
 
     expected = {
+        "component": "zns-proxy",
         "packageName": "zns-proxy.bin",
         "path": "zns-proxy.bin",
     }
     for key, value in expected.items():
         if manifest.get(key) != value:
             fail("manifest %s must be %s, got %s" % (key, value, manifest.get(key)))
+
+    version = manifest.get("version")
+    if not isinstance(version, STRING_TYPES) or not version.strip():
+        fail("manifest version must be a non-empty string")
+    if not COMPONENT_VERSION_PATTERN.match(version):
+        fail("manifest version must be a canonical four-part version")
+    sha256 = manifest.get("sha256")
+    if not isinstance(sha256, STRING_TYPES) or not sha256.strip():
+        fail("manifest sha256 must be a non-empty string")
+    if not SHA256_PATTERN.match(sha256):
+        fail("manifest sha256 must be lowercase hexadecimal")
+    arch = manifest.get("arch")
+    if (
+        not isinstance(arch, list)
+        or not arch
+        or any(not isinstance(item, STRING_TYPES) or not item.strip() for item in arch)
+    ):
+        fail("manifest arch must be a non-empty list of strings")
+    build_time = manifest.get("buildTime")
+    if not isinstance(build_time, STRING_TYPES) or not build_time.strip():
+        fail("manifest buildTime must be a non-empty string")
 
     if manifest.get("sha256") != sha256sum(package_path):
         fail("manifest sha256 does not match znsproxy/zns-proxy.bin")

--- a/zstackbuild/scripts/zns_proxy_manifest.py
+++ b/zstackbuild/scripts/zns_proxy_manifest.py
@@ -4,6 +4,13 @@ import datetime
 import hashlib
 import json
 import os
+import re
+
+
+COMPONENT_VERSION_PATTERN = re.compile(
+    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"
+)
 
 
 def sha256sum(path):
@@ -28,8 +35,14 @@ def main():
 
     if not os.path.isfile(args.package):
         raise SystemExit("zns-proxy package not found: %s" % args.package)
+    if not COMPONENT_VERSION_PATTERN.match(args.version):
+        raise SystemExit(
+            "zns-proxy version must be a canonical four-part version: %s"
+            % args.version
+        )
 
     manifest = {
+        "component": "zns-proxy",
         "packageName": os.path.basename(args.package),
         "version": args.version,
         "arch": [item.strip() for item in args.arch.split(",") if item.strip()],
@@ -41,6 +54,16 @@ def main():
     output_dir = os.path.dirname(args.output)
     if output_dir and not os.path.isdir(output_dir):
         os.makedirs(output_dir)
+
+    if os.path.isfile(args.output):
+        with open(args.output) as stream:
+            existing = json.load(stream)
+        if existing.get("version") == manifest["version"]:
+            if existing.get("sha256") != manifest["sha256"]:
+                raise SystemExit(
+                    "zns-proxy version %s already exists with a different sha256"
+                    % manifest["version"]
+                )
 
     with open(args.output, "w") as stream:
         json.dump(manifest, stream, indent=2, sort_keys=True)


### PR DESCRIPTION
## Summary

Correct the `zns-proxy` package manifest generated for the Cloud installer.
The manifest now identifies the component and carries the proxy component
version instead of the Cloud or Jenkins build version.

## Root Cause

The installer passed `${bin.version}` to the manifest generator and the
manifest omitted the component identity. This produced values such as
`feature-zns-agent-2608050922-9`, which the Cloud runtime rejects because
`zns-proxy` requires a canonical four-part component version.

## Fix

- Read the proxy version from the zstack-zns
  `print-zns-proxy-version` target.
- Emit `component: zns-proxy` and a canonical four-part version.
- Validate the component, version, SHA256, architecture, and build time in
  the ISO package guard.
- Reject rebuilding a different binary under the same component version.

## Test

- `python3 -m unittest tests.unit.zstackbuild.test_zns_proxy_package`
- `python -m py_compile zstackbuild/scripts/zns_proxy_manifest.py zstackbuild/scripts/zns_proxy_iso_guard.py zstackznsproxy/ansible/znsproxy.py`
- `git diff --check`

## Dependency

The `zstack-zns` source used by the installer must provide the
`print-zns-proxy-version` Make target. The current `feature-zns-agent` source
returns `1.2.0.1`.

Resolves ZCF-3881.

sync from gitlab !7616