### PR TITLE
<fix>[yum]: ZSTAC-87461 use official ALinux 4 repositories

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -3968,14 +3968,12 @@ EOF
 #create zstack local yum repo
 create_yum_repo(){
     trap 'traplogger $LINENO "$BASH_COMMAND" $?'  DEBUG
-    if [ -f /etc/redhat-release ]; then
-        os_release=`cat /etc/redhat-release`
-        if [[ $os_release =~ 'Alibaba Cloud Linux' ]]; then
-            cat << 'EOF' > $zstack_ali_repo_file
+    if is_alinux4_host; then
+        cat << 'EOF' > $zstack_ali_repo_file
 #aliyun alinux4 base
 [alibase]
 name=ALinux-4 - OS - mirrors.aliyun.com
-baseurl=https://mirrors.aliyun.com/alinux/4/os/$basearch/
+baseurl=https://mirrors.aliyun.com/alinux/4.0/os/$basearch/os/
 gpgcheck=0
 enabled=0
 module_hotfixes=true
@@ -3983,13 +3981,17 @@ module_hotfixes=true
 #released updates
 [aliupdates]
 name=ALinux-4 - Updates - mirrors.aliyun.com
-baseurl=https://mirrors.aliyun.com/alinux/4/updates/$basearch/
+baseurl=https://mirrors.aliyun.com/alinux/4.0/updates/$basearch/os/
 enabled=0
 gpgcheck=0
 module_hotfixes=true
 
 EOF
-        elif [[ $os_release =~ ' 8' ]]; then
+        [ $? -eq 0 ] || fail2 "Failed to write Alibaba Cloud Linux 4 yum repository"
+        rm -f $zstack_163_repo_file || fail2 "Failed to remove unsupported 163 yum repository"
+    elif [ -f /etc/redhat-release ]; then
+        os_release=`cat /etc/redhat-release`
+        if [[ $os_release =~ ' 8' ]]; then
             cat << 'EOF' > $zstack_ali_repo_file
 #aliyun base
 [alibase]

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -463,14 +463,12 @@ zstone_db_dump_skip_tables = ""
 # pre install scripts
 # prepare yum configurations
 configure_yum_repo_script = '''
-if [ -f /etc/redhat-release ]; then
-    os_release=`cat /etc/redhat-release`
-    if [[ $os_release =~ 'Alibaba Cloud Linux' ]] && grep -Eq '^VERSION_ID="?4(\.|")' /etc/os-release 2>/dev/null; then
-        [ -d /etc/yum.repos.d/ ] && [ ! -f /etc/yum.repos.d/zstack-aliyun-yum.repo ] && cat << 'EOF' > /etc/yum.repos.d/zstack-aliyun-yum.repo
+if grep -qi 'Alibaba Cloud Linux' /etc/os-release 2>/dev/null && grep -Eq '^VERSION_ID="?4(\.|")' /etc/os-release; then
+    [ -d /etc/yum.repos.d/ ] && cat << 'EOF' > /etc/yum.repos.d/zstack-aliyun-yum.repo
 #aliyun alinux4 base
 [alibase]
 name=ALinux-4 - OS - mirrors.aliyun.com
-baseurl=https://mirrors.aliyun.com/alinux/4/os/$basearch/
+baseurl=https://mirrors.aliyun.com/alinux/4.0/os/$basearch/os/
 gpgcheck=0
 enabled=0
 module_hotfixes=true
@@ -478,13 +476,18 @@ module_hotfixes=true
 #released updates
 [aliupdates]
 name=ALinux-4 - Updates - mirrors.aliyun.com
-baseurl=https://mirrors.aliyun.com/alinux/4/updates/$basearch/
+baseurl=https://mirrors.aliyun.com/alinux/4.0/updates/$basearch/os/
 enabled=0
 gpgcheck=0
 module_hotfixes=true
 
 EOF
-    elif [[ $os_release =~ ' 7' ]]; then
+    repo_rc=$?
+    [ $repo_rc -eq 0 ] || exit $repo_rc
+    rm -f /etc/yum.repos.d/zstack-163-yum.repo || exit $?
+elif [ -f /etc/redhat-release ]; then
+    os_release=`cat /etc/redhat-release`
+    if [[ $os_release =~ ' 7' ]]; then
         [ -d /etc/yum.repos.d/ ] &&  [ ! -f /etc/yum.repos.d/epel.repo ] && cat << 'EOF' > /etc/yum.repos.d/epel.repo
 [epel]
 name=Extra Packages for Enterprise Linux $releasever - $basearce - mirrors.aliyun.com

--- a/zstacklib/ansible/alibaba/4/zstack-aliyun-yum.repo
+++ b/zstacklib/ansible/alibaba/4/zstack-aliyun-yum.repo
@@ -1,0 +1,15 @@
+# aliyun alinux4 base
+[alibase]
+name=ALinux-4 - OS - mirrors.aliyun.com
+baseurl=https://mirrors.aliyun.com/alinux/4.0/os/$basearch/os/
+gpgcheck=0
+enabled=0
+module_hotfixes=true
+
+# released updates
+[aliupdates]
+name=ALinux-4 - Updates - mirrors.aliyun.com
+baseurl=https://mirrors.aliyun.com/alinux/4.0/updates/$basearch/os/
+enabled=0
+gpgcheck=0
+module_hotfixes=true

--- a/zstacklib/ansible/zstacklib.yaml
+++ b/zstacklib/ansible/zstacklib.yaml
@@ -30,10 +30,12 @@
 
 - name: set ALIYUN mirror yum repo
   when: ansible_os_family == 'RedHat' or ansible_os_family == 'Alibaba Cloud Linux'
-  shell: echo -e "#aliyun base\n[alibase]\nname=CentOS-\$releasever - Base - mirrors.aliyun.com\nfailovermethod=priority\nbaseurl=http://mirrors.aliyun.com/centos/\$releasever/os/\$basearch/\ngpgcheck=0\nenabled=0\n \n#released updates \n[aliupdates]\nname=CentOS-\$releasever - Updates - mirrors.aliyun.com\nfailovermethod=priority\nbaseurl=http://mirrors.aliyun.com/centos/\$releasever/updates/\$basearch/\nenabled=0\ngpgcheck=0\n \n[aliextras]\nname=CentOS-\$releasever - Extras - mirrors.aliyun.com\nfailovermethod=priority\nbaseurl=http://mirrors.aliyun.com/centos/\$releasever/extras/\$basearch/\nenabled=0\ngpgcheck=0\n \n[aliepel]\nname=Extra Packages for Enterprise Linux \$releasever - \$basearce - mirrors.aliyun.com\nbaseurl=http://mirrors.aliyun.com/epel/\$releasever/\$basearch\nfailovermethod=priority\nenabled=0\ngpgcheck=0\n" > /etc/yum.repos.d/zstack-aliyun-yum.repo
+  copy: src="files/zstacklib/{{ 'alibaba/4/zstack-aliyun-yum.repo' if ((ansible_distribution == 'Alibaba' or ansible_distribution == 'Alibaba Cloud Linux') and (ansible_distribution_major_version | int) == 4) else 'zstack-aliyun-yum.repo' }}"
+        dest=/etc/yum.repos.d/zstack-aliyun-yum.repo
+        owner=root group=root mode=0644
 
 - name: set 163 mirror yum repo
-  when: (ansible_os_family == 'RedHat' or ansible_os_family == 'Alibaba Cloud Linux') and yum_repos != 'false'
+  when: (ansible_os_family == 'RedHat' or ansible_os_family == 'Alibaba Cloud Linux') and not ((ansible_distribution == 'Alibaba' or ansible_distribution == 'Alibaba Cloud Linux') and (ansible_distribution_major_version | int) == 4) and yum_repos != 'false'
   shell: echo -e "#163 base\n[163base]\nname=CentOS-\$releasever - Base - mirrors.163.com\nfailovermethod=priority\nbaseurl=http://mirrors.163.com/centos/\$releasever/os/\$basearch/\ngpgcheck=0\nenabled=0\n \n#released updates \n[163updates]\nname=CentOS-\$releasever - Updates - mirrors.163.com\nfailovermethod=priority\nbaseurl=http://mirrors.163.com/centos/\$releasever/updates/\$basearch/\nenabled=0\ngpgcheck=0\n \n#additional packages that may be useful\n[163extras]\nname=CentOS-\$releasever - Extras - mirrors.163.com\nfailovermethod=priority\nbaseurl=http://mirrors.163.com/centos/\$releasever/extras/\$basearch/\nenabled=0\ngpgcheck=0\n \n[ustcepel]\nname=Extra Packages for Enterprise Linux \$releasever - \$basearch - ustc \nbaseurl=http://centos.ustc.edu.cn/epel/\$releasever/\$basearch\nfailovermethod=priority\nenabled=0\ngpgcheck=0\n" > /etc/yum.repos.d/zstack-163-yum.repo
 
 - name: install libselinux-python and other command system libs from user defined repos


### PR DESCRIPTION
## Summary

修复 ALinux 4 ISO/公网 repo 错误回退到 CentOS 源，以及阿里云镜像路径无效的问题。

## Changes

- 将 ALinux 4 OS/Updates 地址修正为有效的 Alibaba Cloud Linux 4.0 路径。
- 新增 `alibaba/4` 专用 repo 模板。
- legacy Ansible 根据 ALinux 4 系统 facts 使用专用模板，并排除 CentOS/163 回退分支。

## Validation

- [x] `bash -n installation/install.sh`
- [x] YAML 解析和 ALinux 4/RedHat Jinja 分流检查
- [x] `ctl.py` Python 语法编译（仅有既存的转义字符警告）
- [x] x86_64/aarch64 的 OS/Updates repomd 地址均返回 HTTP 200
- [x] `git diff --check`
- [ ] CI pipeline
- [ ] 真实环境安装/部署验证

Resolves: ZSTAC-87461

sync from gitlab !7634