### PR TITLE
<fix>[cephbackupstorage]: support IPv6 image URLs

### DIFF
--- a/cephbackupstorage/cephbackupstorage/cephagent.py
+++ b/cephbackupstorage/cephbackupstorage/cephagent.py
@@ -53,6 +53,31 @@ def build_sftp_batch_cmd(port, username, hostname):
     return SFTP_BATCH_CMD_FORMAT % (port, build_sftp_target(username, hostname))
 
 
+def encode_download_url(url):
+    parsed = urllib.parse.urlsplit(url)
+    path = urllib.parse.quote(parsed.path, safe="/:=@%")
+    query = urllib.parse.quote(parsed.query, safe=":/?=&%")
+    fragment = urllib.parse.quote(parsed.fragment, safe=":/?=&%")
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, query, fragment))
+
+
+def get_http_content_length(command_shell, url):
+    headers = command_shell.call(
+        "curl -fsSIL --globoff -- %s" % linux.shellquote(url)
+    )
+    content_lengths = []
+    for line in headers.splitlines():
+        if line.strip().upper().startswith('HTTP/'):
+            content_lengths = []
+            continue
+        name, separator, value = line.partition(':')
+        if separator and name.strip().lower() == 'content-length' and value.strip():
+            content_lengths.append(value.strip())
+    if not content_lengths:
+        raise Exception('cannot get Content-Length from url[%s]' % url)
+    return content_lengths[-1]
+
+
 class CephPoolCapacity(object):
     def __init__(self, name, available, used, total, replicated_size, security_policy, disk_utilization, related_osds, related_osd_capacity):
         self.name = name
@@ -1044,17 +1069,17 @@ class CephAgent(object):
         report.resourceUuid = cmd.imageUuid
         report.progress_report("0", "start")
 
-        cmd.url = urllib.parse.quote(cmd.url, safe=':/?=')
+        cmd.url = encode_download_url(cmd.url)
 
         url = urllib.parse.urlparse(cmd.url)
         if url.scheme in ('http', 'https', 'ftp'):
             image_format = get_origin_format(cmd.url, True)
-            cmd.url = linux.shellquote(cmd.url)
+            quoted_url = linux.shellquote(cmd.url)
             # roll back tmp ceph file after import it
             _1()
 
             PFILE = linux.create_temp_file()
-            content_length = shell.call("""curl -sLI %s|awk '/[cC]ontent-[lL]ength/{print $NF}'""" % cmd.url).splitlines()[-1]
+            content_length = get_http_content_length(shell, cmd.url)
             total = _getRealSize(content_length)
 
             def _getProgress(synced):
@@ -1073,11 +1098,11 @@ class CephAgent(object):
             logger.debug("content-length is: %s" % total)
 
             _, _, err = shell.bash_progress_1('wget --no-check-certificate -O - %s 2>%s| rbd import '
-                                              '--image-format 2 - %s/%s ' % (cmd.url, PFILE, pool, tmp_image_name)
+                                              '--image-format 2 - %s/%s ' % (quoted_url, PFILE, pool, tmp_image_name)
                                               , _getProgress, pipe_fail=True)
             if err:
                 raise err
-            actual_size = linux.get_file_size_by_http_head(cmd.url)
+            actual_size = linux.get_file_size_by_http_head(quoted_url)
 
             if os.path.exists(PFILE):
                 os.remove(PFILE)

--- a/tests/unit/ceph/test_ceph_backup_handlers.py
+++ b/tests/unit/ceph/test_ceph_backup_handlers.py
@@ -77,6 +77,68 @@ class TestCephBackupSftpCommandFormatting:
 
 
 # ---------------------------------------------------------------------------
+# Download URL handling
+# ---------------------------------------------------------------------------
+@pytest.mark.ceph
+class TestCephBackupDownloadUrl:
+    def test_ZSTAC_87499_preserves_ipv6_authority(self):
+        url = "http://[fd11:5:5:29::66:571d]:18080/centos image.qcow2"
+
+        encoded_url = module.encode_download_url(url)
+
+        assert encoded_url == "http://[fd11:5:5:29::66:571d]:18080/centos%20image.qcow2"
+
+    def test_preserves_sftp_userinfo_and_ipv6_authority(self):
+        url = "sftp://root:password@[2001:db8::10]:22/backup/image.qcow2"
+
+        encoded_url = module.encode_download_url(url)
+
+        assert encoded_url == url
+
+    def test_encodes_path_without_changing_query_structure(self):
+        url = "https://example.com/镜像/image.qcow2?token=a%20b&name=测试"
+
+        encoded_url = module.encode_download_url(url)
+
+        assert encoded_url == (
+            "https://example.com/%E9%95%9C%E5%83%8F/image.qcow2"
+            "?token=a%20b&name=%E6%B5%8B%E8%AF%95"
+        )
+
+    def test_extracts_last_content_length_after_redirect(self):
+        command_shell = MagicMock()
+        command_shell.call.return_value = (
+            "HTTP/1.1 302 Found\r\nContent-Length: 0\r\n\r\n"
+            "HTTP/1.1 200 OK\r\nContent-Length: 21474836480\r\n"
+        )
+        url = "http://[2001:db8::10]:18080/image.qcow2"
+
+        content_length = module.get_http_content_length(command_shell, url)
+
+        assert content_length == "21474836480"
+        command_shell.call.assert_called_once_with(
+            "curl -fsSIL --globoff -- 'http://[2001:db8::10]:18080/image.qcow2'"
+        )
+
+    def test_missing_content_length_has_explicit_error(self):
+        command_shell = MagicMock()
+        command_shell.call.return_value = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n"
+
+        with pytest.raises(Exception, match="cannot get Content-Length"):
+            module.get_http_content_length(command_shell, "https://example.com/image.qcow2")
+
+    def test_missing_content_length_in_final_redirect_response_has_explicit_error(self):
+        command_shell = MagicMock()
+        command_shell.call.return_value = (
+            "HTTP/1.1 302 Found\r\nContent-Length: 0\r\n\r\n"
+            "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n"
+        )
+
+        with pytest.raises(Exception, match="cannot get Content-Length"):
+            module.get_http_content_length(command_shell, "https://example.com/image.qcow2")
+
+
+# ---------------------------------------------------------------------------
 # echo
 # ---------------------------------------------------------------------------
 @pytest.mark.ceph


### PR DESCRIPTION
## Root Cause

Quoting the entire download URL encoded IPv6 authority brackets. Curl then returned no Content-Length and the agent raised `IndexError`.

## Solution

Preserve the URL authority while encoding path and query components. Parse Content-Length from the final curl response and report a clear error when it is absent.

## Tests

- 6 focused download URL tests passed
- 57 Ceph unit tests passed
- The target branch has 2 pre-existing SFTP mock failures unrelated to this change

Jira: http://jira.zstack.io/browse/ZSTAC-87499

sync from gitlab !7637