### PR TITLE
<fix>[kvm]: ZSTAC-87496 select console listener by management IP version

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -1670,7 +1670,11 @@ def delete_zstack_metadata_live(vm_uuid, metadata_key):
     return _sync_zstack_metadata_live(vm_uuid, metadata_key, None, True)
 
 
-def get_console_listen_address(host_management_ip):
+def get_console_listen_address(host_management_ip, management_network_ip_version=None):
+    if management_network_ip_version == 'ipv6':
+        return CONSOLE_LISTEN_IPV6_ADDRESS
+    if management_network_ip_version == 'ipv4':
+        return CONSOLE_LISTEN_IPV4_ADDRESS
     if host_management_ip and network_ipv6.IPV6_SEPARATOR in host_management_ip:
         return CONSOLE_LISTEN_IPV6_ADDRESS
     return CONSOLE_LISTEN_IPV4_ADDRESS
@@ -7652,7 +7656,7 @@ class Vm(object):
 
         def make_vnc():
             devices = elements['devices']
-            listen_address = get_console_listen_address(cmd.hostManagementIp)
+            listen_address = get_console_listen_address(cmd.hostManagementIp, cmd.managementNetworkIpVersion)
             if cmd.consolePassword == None:
                 vnc = e(devices, 'graphics', None, {'type': 'vnc', 'port': '5900', 'autoport': 'yes'})
             else:
@@ -7662,7 +7666,7 @@ class Vm(object):
 
         def make_spice():
             devices = elements['devices']
-            listen_address = get_console_listen_address(cmd.hostManagementIp)
+            listen_address = get_console_listen_address(cmd.hostManagementIp, cmd.managementNetworkIpVersion)
             if cmd.consolePassword == None:
                 spice = e(devices, 'graphics', None, {'type': 'spice', 'port': '5900', 'autoport': 'yes'})
             else:

--- a/tests/unit/kvmagent/test_vm_plugin_handlers.py
+++ b/tests/unit/kvmagent/test_vm_plugin_handlers.py
@@ -41,6 +41,23 @@ def test_console_listen_address_uses_dual_stack_for_ipv6_host():
     assert vm_plugin.get_console_listen_address('2001:db8::10') == '::'
 
 
+def test_zstac_87496_console_listen_address_uses_explicit_ipv6_for_hostname():
+    assert vm_plugin.get_console_listen_address('host01.ipv6.test', 'ipv6') == '::'
+
+
+def test_zstac_87496_console_listen_address_uses_explicit_ipv4_for_hostname():
+    assert vm_plugin.get_console_listen_address('host01.ipv4.test', 'ipv4') == '0.0.0.0'
+
+
+def test_zstac_87496_console_listen_address_falls_back_for_legacy_command():
+    assert vm_plugin.get_console_listen_address('2001:db8::10', None) == '::'
+    assert vm_plugin.get_console_listen_address('192.168.1.10', None) == '0.0.0.0'
+
+
+def test_zstac_87496_console_listen_address_falls_back_for_unknown_ip_version():
+    assert vm_plugin.get_console_listen_address('2001:db8::10', 'unknown') == '::'
+
+
 def test_build_migration_hostname_supports_ipv4():
     assert vm_plugin.build_migration_hostname('172.24.1.2') == '172-24-1-2.zstack.org'
 


### PR DESCRIPTION
## Summary
Fix QEMU console listener selection for hosts managed through IPv6-only hostnames.

## Changes
- Map explicit ipv6 to :: and ipv4 to 0.0.0.0 for VNC and SPICE
- Preserve legacy literal-address fallback when the field is missing or unknown
- Add hostname, literal, compatibility, and boundary tests

## Testing
- [x] 6 console listener tests passed
- [x] test_vm_plugin_handlers.py: 171 passed

Resolves: ZSTAC-87496

sync from gitlab !7639