### PR TITLE
<fix>[agent]: keep host ping during manual dumps

### DIFF
--- a/zstacklib/zstacklib/utils/debug.py
+++ b/zstacklib/zstacklib/utils/debug.py
@@ -123,7 +123,6 @@ def track_memory_growth():
         logger.warn("get error when track memory info %s" % str(e))
 
 
-@dump_track
 def dump_threads():
     logger.debug('dumping threads')
     output = []
@@ -310,7 +309,6 @@ def track_objects(times=5, interval=300):
     return
 
 
-@dump_track
 def dump_objects():
     old_num_stats, old_size_stats, total_num, total_size = type_stats()
     log_objs_statistics(old_num_stats, old_size_stats, {}, {}, total_size, total_num)


### PR DESCRIPTION
ZSTAC-78964: SIGUSR2 diagnostics no longer pause host ping; memory-growth tracking still reports busy and available. Unit tests and Python compile checks passed.

sync from gitlab !7642