### PR TITLE
Draft: <fix>[gpu] ZSTAC-87347 link Ascend npu-smi into kvm venv

### DIFF
--- a/kvmagent/ansible/gpu_tools.py
+++ b/kvmagent/ansible/gpu_tools.py
@@ -1,0 +1,8 @@
+import os
+import shlex
+
+
+def build_npu_smi_link_command(virtualenv_path, source_path="/usr/local/sbin/npu-smi"):
+    source = shlex.quote(source_path)
+    target = shlex.quote(os.path.join(virtualenv_path, "bin", "npu-smi"))
+    return "if [ -x {0} ]; then ln -sf {0} {1}; fi".format(source, target)

--- a/kvmagent/ansible/kvm.py
+++ b/kvmagent/ansible/kvm.py
@@ -7,6 +7,7 @@ import os
 import re
 from uuid import uuid4
 
+from gpu_tools import build_npu_smi_link_command
 from zstacklib import *
 
 # create log
@@ -979,6 +980,14 @@ def install_virtualenv():
         host_post_info.post_label_param = None
         run_remote_command(command, host_post_info)
 
+
+def link_npu_smi():
+    command = build_npu_smi_link_command(virtenv_path)
+    host_post_info.post_label = "ansible.shell.link.npu-smi"
+    host_post_info.post_label_param = None
+    run_remote_command(command, host_post_info)
+
+
 def install_agent_pkg():
     """install zstacklib and kvmagent on host"""
 
@@ -1234,6 +1243,7 @@ do_libvirt_qemu_config()
 do_network_config()
 copy_spice_certificates_to_host()
 install_virtualenv()
+link_npu_smi()
 set_legacy_iptables_ebtables()
 create_ovmf_symlinks()
 install_agent_pkg()

--- a/tests/unit/kvmagent/test_ansible_gpu_tools.py
+++ b/tests/unit/kvmagent/test_ansible_gpu_tools.py
@@ -1,0 +1,46 @@
+import importlib.util
+import os
+import pathlib
+import subprocess
+
+
+def _load_gpu_tools():
+    path = pathlib.Path(__file__).parents[3] / "kvmagent/ansible/gpu_tools.py"
+    spec = importlib.util.spec_from_file_location("kvm_ansible_gpu_tools", str(path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_npu_smi_link_command_exposes_executable_in_kvm_virtualenv(tmp_path):
+    gpu_tools = _load_gpu_tools()
+    source = tmp_path / "usr/local/sbin/npu-smi"
+    virtualenv = tmp_path / "virtualenv/kvm"
+    source.parent.mkdir(parents=True)
+    (virtualenv / "bin").mkdir(parents=True)
+    source.write_text("#!/bin/sh\n")
+    source.chmod(0o755)
+
+    command = gpu_tools.build_npu_smi_link_command(
+        str(virtualenv), str(source))
+
+    subprocess.check_call(command, shell=True)
+    subprocess.check_call(command, shell=True)
+
+    target = virtualenv / "bin/npu-smi"
+    assert target.is_symlink()
+    assert os.path.realpath(str(target)) == str(source)
+
+
+def test_npu_smi_link_command_skips_missing_executable(tmp_path):
+    gpu_tools = _load_gpu_tools()
+    source = tmp_path / "usr/local/sbin/npu-smi"
+    virtualenv = tmp_path / "virtualenv/kvm"
+    (virtualenv / "bin").mkdir(parents=True)
+
+    command = gpu_tools.build_npu_smi_link_command(
+        str(virtualenv), str(source))
+
+    subprocess.check_call(command, shell=True)
+
+    assert not (virtualenv / "bin/npu-smi").exists()


### PR DESCRIPTION
## Jira

- [ZSTAC-87347](http://jira.zstack.io/browse/ZSTAC-87347)

## 问题

Ascend `npu-smi` 安装在 `/usr/local/sbin` 时，kvmagent 运行环境无法通过 PATH 找到该命令，导致 GPU 发现失败。

## 修改

- kvmagent 部署创建虚拟环境后，将可执行的 `/usr/local/sbin/npu-smi` 链接到 `${virtenv_path}/bin/npu-smi`
- 源文件不存在或不可执行时跳过，不影响非 Ascend 主机
- 增加创建链接、重复执行幂等及源文件缺失场景的单元测试

## 本地验证

- Python 3.11 Docker 聚焦测试：`2 passed`
- 变更涉及的三个 Python 文件语法编译通过
- `git diff --check` 通过
- 完整 GPU 测试与纯 `origin/5.5.22` 基线结果一致：`129 passed / 4 failed`，4 个失败为基线已有问题
- 独立代码审查：`APPROVE`

## Draft 状态

037 Ascend 环境部署及实际 GPU 规格发现尚待验证，请暂勿发起正式 Review。环境验证通过并补充结果后再 Mark as ready。

sync from gitlab !7670