### PR TITLE
<fix>[kvm]: ZSTAC-86874 harden passive activation

### DIFF
--- a/kvmagent/kvmagent/plugins/deip.py
+++ b/kvmagent/kvmagent/plugins/deip.py
@@ -958,16 +958,14 @@ class DEip(kvmagent.KvmAgent):
     def _announce_public_interfaces(self, eip_cmd, announcements):
         failures = []
 
+        @thread.AsyncThread
         def announce(args):
             try:
                 eip_cmd.announce_public_interface(*args)
             except Exception as error:
                 failures.append(error)
 
-        threads = [
-            thread.ThreadFacade.run_in_thread(announce, (announcement,))
-            for announcement in announcements
-        ]
+        threads = [announce(announcement) for announcement in announcements]
         for worker in threads:
             worker.join()
 

--- a/kvmagent/kvmagent/plugins/deip.py
+++ b/kvmagent/kvmagent/plugins/deip.py
@@ -972,21 +972,47 @@ class DEip(kvmagent.KvmAgent):
         if failures:
             raise failures[0]
 
+    def _return_eips_to_passive(self, eip_cmd, eips):
+        with lock.NamedLock('eip'):
+            for eip in eips:
+                try:
+                    eip_cmd.set_eip_public_interface_state(
+                        eip, False, announce=False)
+                except Exception as error:
+                    logger.warn(
+                        "failed to return EIP[%s] to passive: %s" %
+                        (eip.eipUuid, error)
+                    )
+
+    def _return_public_interfaces_to_passive(self, eip_cmd, interfaces):
+        with lock.NamedLock('eip'):
+            for ns_name, eip_uuid, vip, version in interfaces:
+                try:
+                    eip_cmd.set_public_interface_state(
+                        ns_name, eip_uuid, vip, version, False, False,
+                        announce=False,
+                    )
+                except Exception as error:
+                    logger.warn(
+                        "failed to return EIP[%s] public interface to passive: %s" %
+                        (eip_uuid, error)
+                    )
+
     def _set_eips_public_interface_state(self, eips, active):
         eip_cmd = Eip()
         switched_eips = []
         try:
             with lock.NamedLock('eip'):
                 for eip in eips:
-                    if eip_cmd.set_eip_public_interface_state(
-                            eip, active, announce=False):
+                    if active:
                         switched_eips.append(eip)
+                    switched = eip_cmd.set_eip_public_interface_state(
+                        eip, active, announce=False)
+                    if active and not switched:
+                        switched_eips.pop()
         except Exception:
             if active:
-                with lock.NamedLock('eip'):
-                    for eip in switched_eips:
-                        eip_cmd.set_eip_public_interface_state(
-                            eip, False, announce=False)
+                self._return_eips_to_passive(eip_cmd, switched_eips)
             raise
 
         if active:
@@ -998,10 +1024,7 @@ class DEip(kvmagent.KvmAgent):
             try:
                 self._announce_public_interfaces(eip_cmd, announcements)
             except Exception:
-                with lock.NamedLock('eip'):
-                    for eip in switched_eips:
-                        eip_cmd.set_eip_public_interface_state(
-                            eip, False, announce=False)
+                self._return_eips_to_passive(eip_cmd, switched_eips)
                 raise
 
     def _register_vm_lifecycle_hook(self):
@@ -1046,40 +1069,46 @@ class DEip(kvmagent.KvmAgent):
         aliases = [word for word in bash_o('ip -o -d link').split() if word.startswith('eip:')]
         handled_eips = set()
 
-        announcements = []
-        with lock.NamedLock('eip'):
-            for alias in aliases:
-                vip, _, _, version, alias_vm_uuid, eip_uuid, _ = \
-                    eip_cmd.parse_eip_string(alias)
-                if not alias_vm_uuid or alias_vm_uuid.replace('-', '') != normalized_vm_uuid:
-                    continue
-                if not vip or not eip_uuid or (eip_uuid, vip) in handled_eips:
-                    continue
-
-                ns_name = eip_cmd.find_namespace_name_by_ip(vip, version)
-                if not ns_name:
-                    continue
-
-                handled_eips.add((eip_uuid, vip))
-                switched = eip_cmd.set_public_interface_state(
-                    ns_name,
-                    eip_uuid,
-                    vip,
-                    version,
-                    active,
-                    False,
-                    announce=False,
-                )
-                if active and switched:
-                    announcements.append((ns_name, eip_uuid, vip, version))
-
+        switched_interfaces = []
         try:
-            self._announce_public_interfaces(eip_cmd, announcements)
-        except Exception:
             with lock.NamedLock('eip'):
-                for ns_name, eip_uuid, vip, version in announcements:
-                    eip_cmd.set_public_interface_state(
-                        ns_name, eip_uuid, vip, version, False, False,
+                for alias in aliases:
+                    vip, _, _, version, alias_vm_uuid, eip_uuid, _ = \
+                        eip_cmd.parse_eip_string(alias)
+                    if not alias_vm_uuid or alias_vm_uuid.replace('-', '') != normalized_vm_uuid:
+                        continue
+                    if not vip or not eip_uuid or (eip_uuid, vip) in handled_eips:
+                        continue
+
+                    ns_name = eip_cmd.find_namespace_name_by_ip(vip, version)
+                    if not ns_name:
+                        continue
+
+                    handled_eips.add((eip_uuid, vip))
+                    interface = (ns_name, eip_uuid, vip, version)
+                    if active:
+                        switched_interfaces.append(interface)
+                    switched = eip_cmd.set_public_interface_state(
+                        ns_name,
+                        eip_uuid,
+                        vip,
+                        version,
+                        active,
+                        False,
                         announce=False,
                     )
+                    if active and not switched:
+                        switched_interfaces.pop()
+        except Exception:
+            if active:
+                self._return_public_interfaces_to_passive(
+                    eip_cmd, switched_interfaces)
             raise
+
+        if active:
+            try:
+                self._announce_public_interfaces(eip_cmd, switched_interfaces)
+            except Exception:
+                self._return_public_interfaces_to_passive(
+                    eip_cmd, switched_interfaces)
+                raise

--- a/kvmagent/kvmagent/plugins/deip.py
+++ b/kvmagent/kvmagent/plugins/deip.py
@@ -29,6 +29,8 @@ def get_ebtables_cmd():
 def get_iptables_cmd():
     return iptables.get_iptables_cmd()
 IP6TABLES_CMD = iptables.get_ip6tables_cmd()
+IPV6_DAD_TIMEOUT = 3
+IPV6_DAD_INTERVAL = 0.1
 
 
 class AgentRsp(object):
@@ -97,57 +99,92 @@ class Eip(object):
         return None
 
     def set_public_interface_state(self, ns_name, eip_uuid, vip, version, active,
-                                   fail_if_missing=True, vip_gateway=None):
+                                   fail_if_missing=True, vip_gateway=None, announce=True):
         if ns_name not in iproute.IpNetnsShell.list_netns():
             if active and fail_if_missing:
                 raise Exception("cannot find EIP namespace[%s] for vip[%s]" % (ns_name, vip))
-            return
+            return False
 
         netns = iproute.IpNetnsShell(ns_name)
         public_interface = "%s_ei" % eip_uuid[-9:]
+        public_outer_interface = "%s_eo" % eip_uuid[-9:]
         if netns.get_mac(public_interface) is None:
             if active and fail_if_missing:
                 raise Exception("cannot find EIP public interface[%s] in namespace[%s]" %
                                 (public_interface, ns_name))
-            return
+            return False
 
         private_interface = "%s_i" % eip_uuid[-9:]
         if active and netns.get_mac(private_interface) is None:
             if fail_if_missing:
                 raise Exception("cannot find EIP private interface[%s] in namespace[%s]" %
                                 (private_interface, ns_name))
-            return
+            return False
+
+        if not linux.is_network_device_existing(public_outer_interface):
+            if active and fail_if_missing:
+                raise Exception("cannot find EIP public outer interface[%s]" %
+                                public_outer_interface)
+            return False
 
         if active:
-            netns.set_link_up(public_interface)
+            if int(version) == 6:
+                bash_errorout(
+                    "ip netns exec {{ns_name}} sysctl -w "
+                    "net.ipv6.conf.{{public_interface}}.ndisc_notify=1"
+                )
+            iproute.set_link_up(public_outer_interface)
             if vip_gateway:
                 ip_cmd = "ip" if int(version) == 4 else "ip -6"
                 if bash_r("ip netns exec {{ns_name}} {{ip_cmd}} route | "
                           "grep -w default > /dev/null") != 0:
                     bash_errorout("ip netns exec {{ns_name}} {{ip_cmd}} route add "
                                   "default via {{vip_gateway}}")
-            if int(version) == 4:
-                private_gateway = bash_o(
-                    "ip netns exec {{ns_name}} ip -o -4 addr show dev {{private_interface}} "
-                    "| awk '/scope global/ {print $4}' | cut -d/ -f1"
-                ).strip()
-                announce_commands = [
-                    ("ip netns exec %s arping -q -A -w 2 -c 3 "
-                     "-I %s %s > /dev/null" % (ns_name, public_interface, vip))
-                ]
-                if private_gateway:
-                    announce_commands.append(
-                        ("ip netns exec %s arping -q -U -w 2 -c 3 "
-                         "-I %s %s > /dev/null" %
-                         (ns_name, private_interface, private_gateway))
-                    )
-                bash_r(" & ".join(announce_commands) + " & wait")
+            if announce:
+                self.announce_public_interface(ns_name, eip_uuid, vip, version)
         else:
-            bash_errorout("ip netns exec {{ns_name}} ip link set {{public_interface}} down")
+            iproute.set_link_down(public_outer_interface)
+        return True
 
-    def set_eip_public_interface_state(self, eip, active):
+    def announce_public_interface(self, ns_name, eip_uuid, vip, version):
+        public_interface = "%s_ei" % eip_uuid[-9:]
+        if int(version) == 6:
+            def is_address_ready(_):
+                address = bash_o(
+                    "ip netns exec {{ns_name}} ip -6 -o addr show "
+                    "dev {{public_interface}} to {{vip}}/128"
+                ).strip()
+                if "dadfailed" in address:
+                    raise Exception("IPv6 DAD failed for EIP vip[%s]" % vip)
+                return bool(address) and "tentative" not in address
+
+            if not linux.wait_callback_success(
+                    is_address_ready,
+                    timeout=IPV6_DAD_TIMEOUT,
+                    interval=IPV6_DAD_INTERVAL):
+                raise Exception("IPv6 DAD did not finish for EIP vip[%s]" % vip)
+            return
+
+        private_interface = "%s_i" % eip_uuid[-9:]
+        private_gateway = bash_o(
+            "ip netns exec {{ns_name}} ip -o -4 addr show dev {{private_interface}} "
+            "| awk '/scope global/ {print $4}' | cut -d/ -f1"
+        ).strip()
+        announce_commands = [
+            ("ip netns exec %s arping -q -A -w 2 -c 3 "
+             "-I %s %s > /dev/null" % (ns_name, public_interface, vip))
+        ]
+        if private_gateway:
+            announce_commands.append(
+                ("ip netns exec %s arping -q -U -w 2 -c 3 "
+                 "-I %s %s > /dev/null" %
+                 (ns_name, private_interface, private_gateway))
+            )
+        bash_r(" & ".join(announce_commands) + " & wait")
+
+    def set_eip_public_interface_state(self, eip, active, announce=True):
         ns_name = self.generate_namespace_name(eip.publicBridgeName, eip.vip)
-        self.set_public_interface_state(
+        return self.set_public_interface_state(
             ns_name,
             eip.eipUuid,
             eip.vip,
@@ -155,6 +192,7 @@ class Eip(object):
             active,
             active,
             eip.vipGateway,
+            announce,
         )
 
     @bash.in_bash
@@ -374,7 +412,8 @@ class Eip(object):
             if mac is None:
                 iproute.delete_link_no_error(outer_dev)
 
-        def create_dev_if_needed(outer_dev, outer_dev_desc, inner_dev, inner_dev_desc):
+        def create_dev_if_needed(outer_dev, outer_dev_desc, inner_dev, inner_dev_desc,
+                                 link_up=True):
             if not linux.is_network_device_existing(outer_dev):
                 iproute.add_link(outer_dev, 'veth', peer=inner_dev)
                 iproute.set_link_attribute(outer_dev, alias=outer_dev_desc)
@@ -382,7 +421,8 @@ class Eip(object):
                 iproute.set_link_attribute(outer_dev, mtu=linux.MAX_MTU_OF_VNIC)
                 iproute.set_link_attribute(inner_dev, mtu=linux.MAX_MTU_OF_VNIC)
 
-            iproute.set_link_up(outer_dev)
+            if link_up:
+                iproute.set_link_up(outer_dev)
 
         @bash.in_bash
         def add_dev_to_br_if_needed(bridge, device):
@@ -657,6 +697,9 @@ class Eip(object):
             newCreated = True
             iproute.add_namespace(NS_NAME)
 
+        if not active and linux.is_network_device_existing(PUB_ODEV):
+            iproute.set_link_down(PUB_ODEV)
+
         # To be compatibled with old version
         for i in range(len(OLD_PUB_IDEVS)):
             delete_orphan_outer_dev(OLD_PUB_IDEVS[i], OLD_PUB_ODEVS[i])
@@ -665,7 +708,7 @@ class Eip(object):
         delete_orphan_outer_dev(PUB_IDEV, PUB_ODEV)
         delete_orphan_outer_dev(PRI_IDEV, PRI_ODEV)
 
-        create_dev_if_needed(PUB_ODEV, EIP_DESC, PUB_IDEV, EIP_DESC)
+        create_dev_if_needed(PUB_ODEV, EIP_DESC, PUB_IDEV, EIP_DESC, active)
         create_dev_if_needed(PRI_ODEV, EIP_DESC, PRI_IDEV, EIP_DESC)
 
         if active:
@@ -710,7 +753,7 @@ class Eip(object):
             create_ipv6_perf_monitor()
 
         if not active:
-            bash_errorout("ip netns exec {{NS_NAME}} ip link set {{PUB_IDEV}} down")
+            iproute.set_link_down(PUB_ODEV)
             add_dev_to_br_if_needed(PUB_BR, PUB_ODEV)
 
 
@@ -912,11 +955,56 @@ class DEip(kvmagent.KvmAgent):
         for eip in eips:
             eip_cmd.apply_eip(eip, False)
 
-    @lock.lock('eip')
+    def _announce_public_interfaces(self, eip_cmd, announcements):
+        failures = []
+
+        def announce(args):
+            try:
+                eip_cmd.announce_public_interface(*args)
+            except Exception as error:
+                failures.append(error)
+
+        threads = [
+            thread.ThreadFacade.run_in_thread(announce, (announcement,))
+            for announcement in announcements
+        ]
+        for worker in threads:
+            worker.join()
+
+        if failures:
+            raise failures[0]
+
     def _set_eips_public_interface_state(self, eips, active):
         eip_cmd = Eip()
-        for eip in eips:
-            eip_cmd.set_eip_public_interface_state(eip, active)
+        switched_eips = []
+        try:
+            with lock.NamedLock('eip'):
+                for eip in eips:
+                    if eip_cmd.set_eip_public_interface_state(
+                            eip, active, announce=False):
+                        switched_eips.append(eip)
+        except Exception:
+            if active:
+                with lock.NamedLock('eip'):
+                    for eip in switched_eips:
+                        eip_cmd.set_eip_public_interface_state(
+                            eip, False, announce=False)
+            raise
+
+        if active:
+            announcements = [
+                (eip_cmd.generate_namespace_name(eip.publicBridgeName, eip.vip),
+                 eip.eipUuid, eip.vip, eip.ipVersion)
+                for eip in switched_eips
+            ]
+            try:
+                self._announce_public_interfaces(eip_cmd, announcements)
+            except Exception:
+                with lock.NamedLock('eip'):
+                    for eip in switched_eips:
+                        eip_cmd.set_eip_public_interface_state(
+                            eip, False, announce=False)
+                raise
 
     def _register_vm_lifecycle_hook(self):
         import libvirt
@@ -954,31 +1042,46 @@ class DEip(kvmagent.KvmAgent):
             (dom.name(), active),
         )
 
-    @lock.lock('eip')
     def _set_eips_public_interface_state_by_vm_uuid(self, vm_uuid, active):
         eip_cmd = Eip()
         normalized_vm_uuid = vm_uuid.replace('-', '')
         aliases = [word for word in bash_o('ip -o -d link').split() if word.startswith('eip:')]
         handled_eips = set()
 
-        for alias in aliases:
-            vip, _, _, version, alias_vm_uuid, eip_uuid, _ = \
-                eip_cmd.parse_eip_string(alias)
-            if not alias_vm_uuid or alias_vm_uuid.replace('-', '') != normalized_vm_uuid:
-                continue
-            if not vip or not eip_uuid or (eip_uuid, vip) in handled_eips:
-                continue
+        announcements = []
+        with lock.NamedLock('eip'):
+            for alias in aliases:
+                vip, _, _, version, alias_vm_uuid, eip_uuid, _ = \
+                    eip_cmd.parse_eip_string(alias)
+                if not alias_vm_uuid or alias_vm_uuid.replace('-', '') != normalized_vm_uuid:
+                    continue
+                if not vip or not eip_uuid or (eip_uuid, vip) in handled_eips:
+                    continue
 
-            ns_name = eip_cmd.find_namespace_name_by_ip(vip, version)
-            if not ns_name:
-                continue
+                ns_name = eip_cmd.find_namespace_name_by_ip(vip, version)
+                if not ns_name:
+                    continue
 
-            handled_eips.add((eip_uuid, vip))
-            eip_cmd.set_public_interface_state(
-                ns_name,
-                eip_uuid,
-                vip,
-                version,
-                active,
-                False,
-            )
+                handled_eips.add((eip_uuid, vip))
+                switched = eip_cmd.set_public_interface_state(
+                    ns_name,
+                    eip_uuid,
+                    vip,
+                    version,
+                    active,
+                    False,
+                    announce=False,
+                )
+                if active and switched:
+                    announcements.append((ns_name, eip_uuid, vip, version))
+
+        try:
+            self._announce_public_interfaces(eip_cmd, announcements)
+        except Exception:
+            with lock.NamedLock('eip'):
+                for ns_name, eip_uuid, vip, version in announcements:
+                    eip_cmd.set_public_interface_state(
+                        ns_name, eip_uuid, vip, version, False, False,
+                        announce=False,
+                    )
+            raise

--- a/kvmagent/kvmagent/test/test_deip.py
+++ b/kvmagent/kvmagent/test/test_deip.py
@@ -169,15 +169,14 @@ class TestZSTAC86874PrepareEip(_ApplyEipTestBase):
         self.assertTrue(aliases)
         self.assertFalse(any("vip_gateway:" in alias for alias in aliases))
 
-    def test_public_interface_is_attached_after_configuration_then_disabled(self):
+    def test_public_outer_interface_stays_disabled_during_prepare(self):
         namespace = self.mock_iproute.IpNetnsShell.return_value
         self.assertIn(mock.call("123456789_ei"), namespace.set_link_up.call_args_list)
-        self.assertTrue(
-            self._has_cmd(
-                "ip netns exec br_eth0_192_168_1_100 "
-                "ip link set 123456789_ei down"
-            )
+        self.assertNotIn(
+            mock.call("123456789_eo"),
+            self.mock_iproute.set_link_up.call_args_list,
         )
+        self.mock_iproute.set_link_down.assert_called_with("123456789_eo")
         route_index = next(
             i for i, cmd in enumerate(self.executed_cmds)
             if "route add default via 192.168.1.1" in cmd
@@ -187,6 +186,19 @@ class TestZSTAC86874PrepareEip(_ApplyEipTestBase):
             if "brctl addif br_eth0 123456789_eo" in cmd
         )
         self.assertLess(route_index, bridge_index)
+
+    def test_repeated_prepare_disables_existing_public_outer_interface_first(self):
+        self.mock_linux.is_network_device_existing.return_value = True
+        self.mock_iproute.reset_mock()
+        self.executed_cmds.clear()
+
+        self._call_unwrapped_method(Eip(), "apply_eip", _make_eip(), False)
+
+        self.mock_iproute.set_link_down.assert_any_call("123456789_eo")
+        self.assertNotIn(
+            mock.call("123456789_eo"),
+            self.mock_iproute.set_link_up.call_args_list,
+        )
 
     def test_does_not_announce_public_vip(self):
         self.assertFalse(
@@ -207,6 +219,9 @@ class TestZSTAC86874EipPublicInterfaceState(unittest.TestCase):
         self.executed_cmds = []
         self.iproute_patcher = mock.patch("kvmagent.plugins.deip.iproute")
         self.mock_iproute = self.iproute_patcher.start()
+        self.linux_patcher = mock.patch("kvmagent.plugins.deip.linux")
+        self.mock_linux = self.linux_patcher.start()
+        self.mock_linux.is_network_device_existing.return_value = True
         self.process_patcher = mock.patch(
             "zstacklib.utils.shell.get_process",
             side_effect=_make_fake_process(self.executed_cmds),
@@ -215,6 +230,7 @@ class TestZSTAC86874EipPublicInterfaceState(unittest.TestCase):
 
     def tearDown(self):
         self.process_patcher.stop()
+        self.linux_patcher.stop()
         self.iproute_patcher.stop()
 
     def test_enable_is_idempotent_and_announces_vip(self):
@@ -227,9 +243,8 @@ class TestZSTAC86874EipPublicInterfaceState(unittest.TestCase):
 
         Eip().set_eip_public_interface_state(self.eip, True)
 
-        self.mock_iproute.IpNetnsShell.return_value.set_link_up.assert_called_once_with(
-            "123456789_ei"
-        )
+        self.mock_iproute.set_link_up.assert_called_once_with("123456789_eo")
+        self.mock_iproute.IpNetnsShell.return_value.set_link_up.assert_not_called()
         self.assertTrue(any("arping -q -A" in cmd for cmd in self.executed_cmds))
         self.assertTrue(any("arping -q -U" in cmd for cmd in self.executed_cmds))
         self.assertTrue(
@@ -285,6 +300,38 @@ class TestZSTAC86874EipPublicInterfaceState(unittest.TestCase):
             Eip().set_eip_public_interface_state(self.eip, True)
 
         self.mock_iproute.IpNetnsShell.return_value.set_link_up.assert_not_called()
+
+    def test_ipv6_enable_configures_neighbor_notify_and_waits_for_dad(self):
+        self.eip = _make_eip(6)
+        self.mock_iproute.IpNetnsShell.list_netns.return_value = [
+            "br_eth0_fd00:1::100"
+        ]
+        self.mock_iproute.IpNetnsShell.return_value.get_mac.return_value = (
+            "aa:bb:cc:dd:ee:ff"
+        )
+        self.mock_linux.wait_callback_success.return_value = True
+
+        Eip().set_eip_public_interface_state(self.eip, True)
+
+        self.assertTrue(any(
+            "sysctl -w net.ipv6.conf.123456789_ei.ndisc_notify=1" in cmd
+            for cmd in self.executed_cmds
+        ))
+        self.mock_iproute.set_link_up.assert_called_once_with("123456789_eo")
+        self.mock_linux.wait_callback_success.assert_called_once()
+
+    def test_ipv6_enable_fails_when_dad_does_not_finish(self):
+        self.eip = _make_eip(6)
+        self.mock_iproute.IpNetnsShell.list_netns.return_value = [
+            "br_eth0_fd00:1::100"
+        ]
+        self.mock_iproute.IpNetnsShell.return_value.get_mac.return_value = (
+            "aa:bb:cc:dd:ee:ff"
+        )
+        self.mock_linux.wait_callback_success.return_value = False
+
+        with self.assertRaisesRegex(Exception, "DAD"):
+            Eip().set_eip_public_interface_state(self.eip, True)
 
 
 class TestZSTAC86874EipMigrationEvent(unittest.TestCase):
@@ -384,13 +431,14 @@ class TestZSTAC86874EipMigrationEvent(unittest.TestCase):
 
         with mock.patch.object(Eip, "find_namespace_name_by_ip",
                                return_value="br_eth0_192_168_1_100"):
-            with mock.patch.object(
-                Eip,
-                "set_public_interface_state",
-            ) as set_state:
-                self.plugin._set_eips_public_interface_state_by_vm_uuid(
-                    "vm-uuid-1234", True
-                )
+            with mock.patch.object(Eip, "set_public_interface_state") as set_state:
+                with mock.patch.object(Eip, "announce_public_interface") as announce:
+                    with mock.patch(
+                        "kvmagent.plugins.deip.thread.ThreadFacade.run_in_thread"
+                    ) as run_in_thread:
+                        self.plugin._set_eips_public_interface_state_by_vm_uuid(
+                            "vm-uuid-1234", True
+                        )
 
         set_state.assert_called_once_with(
             "br_eth0_192_168_1_100",
@@ -399,6 +447,80 @@ class TestZSTAC86874EipMigrationEvent(unittest.TestCase):
             4,
             True,
             False,
+            announce=False,
+        )
+        run_in_thread.assert_called_once()
+        self.assertEqual(
+            (("br_eth0_192_168_1_100", "abcdef123456789", "192.168.1.100", 4),),
+            run_in_thread.call_args[0][1],
+        )
+
+    def test_all_eips_switch_before_parallel_announcement(self):
+        first = _make_eip()
+        second = _make_eip()
+        second.eipUuid = "abcdef987654321"
+        second.vip = "192.168.1.101"
+        calls = []
+
+        with mock.patch.object(
+            Eip,
+            "set_eip_public_interface_state",
+            side_effect=lambda eip, active, announce=True: calls.append(
+                ("switch", eip.eipUuid, active, announce)
+            ) or True,
+        ):
+            with mock.patch(
+                "kvmagent.plugins.deip.thread.ThreadFacade.run_in_thread",
+                side_effect=lambda func, args: (
+                    calls.append(("announce", args[0][1])) or mock.MagicMock()
+                ),
+            ):
+                self.plugin._set_eips_public_interface_state([first, second], True)
+
+        self.assertEqual(
+            ["switch", "switch", "announce", "announce"],
+            [call[0] for call in calls],
+        )
+
+    def test_batch_enable_waits_and_propagates_announcement_failure(self):
+        eip_cmd = mock.MagicMock()
+        eip_cmd.announce_public_interface.side_effect = Exception("DAD failed")
+
+        def run_worker(worker, args):
+            worker(*args)
+            thread = mock.MagicMock()
+            return thread
+
+        with mock.patch(
+            "kvmagent.plugins.deip.thread.ThreadFacade.run_in_thread",
+            side_effect=run_worker,
+        ):
+            with self.assertRaisesRegex(Exception, "DAD failed"):
+                self.plugin._announce_public_interfaces(
+                    eip_cmd,
+                    [("namespace", "eip-uuid", "fd00::10", 6)],
+                )
+
+    def test_batch_enable_returns_all_eips_to_passive_on_announcement_failure(self):
+        eip = _make_eip(6)
+
+        with mock.patch.object(
+            Eip,
+            "set_eip_public_interface_state",
+            side_effect=[True, True],
+        ) as set_state:
+            with mock.patch.object(
+                self.plugin,
+                "_announce_public_interfaces",
+                side_effect=Exception("DAD failed"),
+            ):
+                with self.assertRaisesRegex(Exception, "DAD failed"):
+                    self.plugin._set_eips_public_interface_state([eip], True)
+
+        self.assertEqual(
+            [mock.call(eip, True, announce=False),
+             mock.call(eip, False, announce=False)],
+            set_state.call_args_list,
         )
 
 

--- a/kvmagent/kvmagent/test/test_deip.py
+++ b/kvmagent/kvmagent/test/test_deip.py
@@ -523,6 +523,71 @@ class TestZSTAC86874EipMigrationEvent(unittest.TestCase):
             set_state.call_args_list,
         )
 
+    def test_batch_enable_returns_current_eip_to_passive_on_switch_failure(self):
+        eip = _make_eip()
+
+        with mock.patch.object(
+            Eip,
+            "set_eip_public_interface_state",
+            side_effect=[Exception("route setup failed"), True],
+        ) as set_state:
+            with self.assertRaisesRegex(Exception, "route setup failed"):
+                self.plugin._set_eips_public_interface_state([eip], True)
+
+        self.assertEqual(
+            [mock.call(eip, True, announce=False),
+             mock.call(eip, False, announce=False)],
+            set_state.call_args_list,
+        )
+
+    @mock.patch("kvmagent.plugins.deip.bash_o")
+    def test_lifecycle_enable_returns_current_eip_to_passive_on_switch_failure(
+            self, bash_o):
+        bash_o.return_value = (
+            "eip:abcdef123456789,eip_addr:192.168.1.100,"
+            "vnic:vnic1.0,vnic_ip:10.0.0.100,"
+            "vm:vm-uuid-1234,vip:vip-uuid-5678"
+        )
+
+        with mock.patch.object(
+            Eip,
+            "find_namespace_name_by_ip",
+            return_value="br_eth0_192_168_1_100",
+        ):
+            with mock.patch.object(
+                Eip,
+                "set_public_interface_state",
+                side_effect=[Exception("route setup failed"), True],
+            ) as set_state:
+                with self.assertRaisesRegex(Exception, "route setup failed"):
+                    self.plugin._set_eips_public_interface_state_by_vm_uuid(
+                        "vm-uuid-1234", True
+                    )
+
+        self.assertEqual(
+            [
+                mock.call(
+                    "br_eth0_192_168_1_100",
+                    "abcdef123456789",
+                    "192.168.1.100",
+                    4,
+                    True,
+                    False,
+                    announce=False,
+                ),
+                mock.call(
+                    "br_eth0_192_168_1_100",
+                    "abcdef123456789",
+                    "192.168.1.100",
+                    4,
+                    False,
+                    False,
+                    announce=False,
+                ),
+            ],
+            set_state.call_args_list,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Test: eip- prefix on chain names

--- a/kvmagent/kvmagent/test/test_deip.py
+++ b/kvmagent/kvmagent/test/test_deip.py
@@ -452,7 +452,7 @@ class TestZSTAC86874EipMigrationEvent(unittest.TestCase):
         run_in_thread.assert_called_once()
         self.assertEqual(
             (("br_eth0_192_168_1_100", "abcdef123456789", "192.168.1.100", 4),),
-            run_in_thread.call_args[0][1],
+            run_in_thread.call_args.kwargs["args"],
         )
 
     def test_all_eips_switch_before_parallel_announcement(self):
@@ -471,7 +471,7 @@ class TestZSTAC86874EipMigrationEvent(unittest.TestCase):
         ):
             with mock.patch(
                 "kvmagent.plugins.deip.thread.ThreadFacade.run_in_thread",
-                side_effect=lambda func, args: (
+                side_effect=lambda func, args, kwargs: (
                     calls.append(("announce", args[0][1])) or mock.MagicMock()
                 ),
             ):
@@ -486,8 +486,8 @@ class TestZSTAC86874EipMigrationEvent(unittest.TestCase):
         eip_cmd = mock.MagicMock()
         eip_cmd.announce_public_interface.side_effect = Exception("DAD failed")
 
-        def run_worker(worker, args):
-            worker(*args)
+        def run_worker(worker, args, kwargs):
+            worker(*args, **kwargs)
             thread = mock.MagicMock()
             return thread
 


### PR DESCRIPTION
## Summary
Harden KVM Flat EIP passive/active transitions for ZSTAC-86874 on 5.5.38.

## Changes
- Keep repeated prepare passive by holding the public outer veth down.
- Switch all EIPs before sending parallel announcements.
- Roll all switched EIPs back to passive when activation or announcement fails.
- Add IPv6 neighbor notification and DAD completion checks.

## Behavior-to-test coverage
- Repeated prepare barrier: TestZSTAC86874PrepareEip.
- IPv4/IPv6 activation and DAD branches: TestZSTAC86874EipPublicInterfaceState.
- Batch ordering, parallel announcement and rollback: TestZSTAC86874EipMigrationEvent.

## Testing
- PASS: 21 focused unittest cases
- PASS: python -m py_compile for deip.py and test_deip.py

Resolves: ZSTAC-86874

sync from gitlab !7675