### PR TITLE
<fix>[kvmagent]: report storage before cache creation

### DIFF
--- a/kvmagent/kvmagent/plugins/virtiofs_source.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_source.py
@@ -297,16 +297,38 @@ def _log_prepare_decision(decision, reason, expected, local_version, path, model
         ))
 
 
+def _ensure_report_source_root(root):
+    if os.path.exists(root):
+        if not os.path.isdir(root):
+            raise Exception('sourceRoot[%s] is not a directory' % root)
+        return root
+
+    if root == _normalize_root(HOST_SOURCE_ROOT):
+        _ensure_directory(root)
+        return root
+
+    parent = os.path.dirname(root)
+    if not parent or not os.path.exists(parent):
+        raise Exception('sourceRoot[%s] does not exist' % root)
+    if not os.path.isdir(parent):
+        raise Exception('sourceRoot[%s] parent[%s] is not a directory' % (root, parent))
+
+    # Reporting is a read-only operation for primary-storage roots.  Capacity
+    # belongs to the mounted parent and can be initialized before the cache
+    # leaf is created by the first prepare operation.
+    return parent
+
+
 def report_source_root(source_root):
     root = _normalize_root(source_root or HOST_SOURCE_ROOT)
-    if not os.path.exists(root):
-        raise Exception('sourceRoot[%s] does not exist' % root)
-    if not os.path.isdir(root):
-        raise Exception('sourceRoot[%s] is not a directory' % root)
+    capacity_root = _ensure_report_source_root(root)
 
-    result = statvfs_capacity(root)
+    result = statvfs_capacity(capacity_root)
     result['sourceRoot'] = root
     result['cacheEntries'] = []
+
+    if not os.path.isdir(root):
+        return result
 
     registry = SourceRegistry(os.path.join(root, '.registry')).load()
     for entry in registry.values():

--- a/tests/unit/kvmagent/test_virtiofs_handlers.py
+++ b/tests/unit/kvmagent/test_virtiofs_handlers.py
@@ -45,6 +45,28 @@ def test_prepare_host_model_cache_registers_sensitive_command(
         virtiofs_plugin.PrepareHostModelCacheCmd)
 
 
+def test_report_host_model_cache_reports_missing_cache_leaf_without_creating_it(tmp_path, monkeypatch):
+    parent = tmp_path / 'primary-storage'
+    parent.mkdir()
+    source_root = parent / 'ai-model-cache'
+    monkeypatch.setattr(
+        virtiofs_plugin.virtiofs_source,
+        'statvfs_capacity',
+        lambda path: {'physicalTotalBytes': 100, 'physicalAvailableBytes': 80})
+
+    req = {
+        http.REQUEST_BODY: json.dumps({'sourceRoot': str(source_root)})
+    }
+    rsp = json.loads(virtiofs_plugin.VirtiofsPlugin().report_host_model_cache(req))
+
+    assert rsp['success'] is True
+    assert not source_root.exists()
+    assert rsp['sourceRoot'] == os.path.realpath(str(source_root))
+    assert rsp['physicalTotalBytes'] == 100
+    assert rsp['physicalAvailableBytes'] == 80
+    assert rsp['cacheEntries'] == []
+
+
 class TestVerifySourcePath:
     """Test verify_source_path() security validation."""
 

--- a/tests/unit/kvmagent/test_virtiofs_source.py
+++ b/tests/unit/kvmagent/test_virtiofs_source.py
@@ -316,6 +316,64 @@ def test_prepare_model_center_cache_reuses_existing_cache_with_matching_strong_v
     assert entry['prepareActions'] == 'mount=0,copy=0'
 
 
+def test_report_source_root_uses_parent_capacity_without_creating_missing_leaf(tmp_path, monkeypatch):
+    parent = tmp_path / 'primary-storage'
+    parent.mkdir()
+    source_root = parent / 'ai-model-cache'
+
+    capacity_paths = []
+    monkeypatch.setattr(
+        virtiofs_source,
+        'statvfs_capacity',
+        lambda path: capacity_paths.append(path) or
+        {'physicalTotalBytes': 100, 'physicalAvailableBytes': 80})
+
+    report = virtiofs_source.report_source_root(str(source_root))
+
+    assert not source_root.exists()
+    assert capacity_paths == [os.path.realpath(str(parent))]
+    assert report['sourceRoot'] == os.path.realpath(str(source_root))
+    assert report['physicalTotalBytes'] == 100
+    assert report['physicalAvailableBytes'] == 80
+    assert report['cacheEntries'] == []
+
+
+def test_report_source_root_initializes_managed_default_root(tmp_path, monkeypatch):
+    source_root = tmp_path / 'zstack' / 'aios' / 'virtiofs-sources'
+    monkeypatch.setattr(virtiofs_source, 'HOST_SOURCE_ROOT', str(source_root))
+    monkeypatch.setattr(
+        virtiofs_source,
+        'statvfs_capacity',
+        lambda path: {'physicalTotalBytes': 100, 'physicalAvailableBytes': 80})
+
+    report = virtiofs_source.report_source_root(None)
+
+    assert source_root.is_dir()
+    assert report['sourceRoot'] == os.path.realpath(str(source_root))
+    assert report['cacheEntries'] == []
+
+
+def test_report_source_root_rejects_missing_parent_mount(tmp_path):
+    source_root = tmp_path / 'missing-mount' / 'ai-model-cache'
+
+    with pytest.raises(Exception) as exc_info:
+        virtiofs_source.report_source_root(str(source_root))
+
+    assert 'does not exist' in str(exc_info.value)
+
+
+def test_report_source_root_rejects_non_directory_parent(tmp_path):
+    parent_file = tmp_path / 'not-a-directory'
+    parent_file.write_text('file parent')
+    source_root = parent_file / 'ai-model-cache'
+
+    with pytest.raises(Exception) as exc_info:
+        virtiofs_source.report_source_root(str(source_root))
+
+    assert 'parent[' in str(exc_info.value)
+    assert 'is not a directory' in str(exc_info.value)
+
+
 def test_prepare_model_center_cache_refreshes_when_strong_version_mismatches(tmp_path, monkeypatch):
     source_root = tmp_path / 'primary-storage' / 'ai-model-cache'
     target = source_root / 'models' / 'model-uuid' / 'v1'


### PR DESCRIPTION
## 问题
新环境中主存储的 `ai-model-cache` 叶子目录尚未创建时，容量同步直接失败，导致页面无法初始化存储状态。

## 修复
- 缺失外部缓存叶子时读取已挂载父目录容量并返回空缓存列表
- 查询保持只读，不创建外部主存储目录
- Agent 管理的默认本地缓存根仍按需初始化
- 补充 source 与 HTTP handler 回归测试

## 验证
- `test_virtiofs_source.py`: 31 passed
- `test_virtiofs_handlers.py -k report_host_model_cache`: 1 passed
- `python3 -m py_compile`: passed
- 与 premium 补丁组合 Docker 全量 `./runMavenProfile premium`: 143/143 BUILD SUCCESS

Jira: ZSTAC-87753

sync from gitlab !7677