### PR TITLE
<feature>[kvm]: ZSTAC-87595 port host model cache virtiofs handlers

### DIFF
--- a/kvmagent/kvmagent/plugins/virtiofs_plugin.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_plugin.py
@@ -203,6 +203,20 @@ def _get_cmd_attr(obj, name, default=None):
     return getattr(obj, name, default)
 
 
+def _classify_host_model_cache_failure(error):
+    error = str(error or '')
+    lowered = error.lower()
+    if 'capacity' in lowered or 'available' in lowered:
+        return 'CapacityCheck', 'InsufficientHostCacheStorage'
+    if 'permission' in lowered or 'denied' in lowered:
+        return 'AgentExecution', 'PermissionDenied'
+    if 'outside allowed' in lowered or 'must be absolute' in lowered or 'does not exist' in lowered or 'not a directory' in lowered:
+        return 'PreparedSourceValidation', 'SourcePathInvalid'
+    if 'timeout' in lowered:
+        return 'AgentExecution', 'AgentTimeout'
+    return 'AgentExecution', 'Unknown'
+
+
 def get_vm_domain(vm_uuid):
     """Get libvirt domain for VM
 
@@ -480,6 +494,9 @@ class VirtiofsPlugin(kvmagent.KvmAgent):
     ATTACH_VIRTIOFS_PATH = "/virtiofs/attach"
     DETACH_VIRTIOFS_PATH = "/virtiofs/detach"
     STATUS_VIRTIOFS_PATH = "/virtiofs/status"
+    HOST_MODEL_CACHE_REPORT_PATH = "/virtiofs/host-model-cache/report"
+    HOST_MODEL_CACHE_PREPARE_PATH = "/virtiofs/host-model-cache/prepare"
+    HOST_MODEL_CACHE_CLEANUP_PATH = "/virtiofs/host-model-cache/cleanup"
 
     def start(self):
         """Initialize virtiofsd path and register HTTP endpoints."""
@@ -489,6 +506,9 @@ class VirtiofsPlugin(kvmagent.KvmAgent):
         http_server.register_async_uri(self.ATTACH_VIRTIOFS_PATH, self.attach_virtiofs)
         http_server.register_async_uri(self.DETACH_VIRTIOFS_PATH, self.detach_virtiofs)
         http_server.register_async_uri(self.STATUS_VIRTIOFS_PATH, self.virtiofs_status)
+        http_server.register_async_uri(self.HOST_MODEL_CACHE_REPORT_PATH, self.report_host_model_cache)
+        http_server.register_async_uri(self.HOST_MODEL_CACHE_PREPARE_PATH, self.prepare_host_model_cache)
+        http_server.register_async_uri(self.HOST_MODEL_CACHE_CLEANUP_PATH, self.cleanup_host_model_cache)
 
     def stop(self):
         """No-op; virtiofs plugin has no background resources to clean up."""
@@ -661,4 +681,72 @@ class VirtiofsPlugin(kvmagent.KvmAgent):
         supported, version = check_libvirt_version()
         rsp.libvirtVersion = version
         rsp.virtiofsHotplugSupported = supported
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def report_host_model_cache(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = jsonobject.JsonObject()
+        rsp.success = False
+        try:
+            source_root = _get_cmd_attr(cmd, 'sourceRoot', _get_cmd_attr(cmd, 'sourceRootPath', None))
+            report = virtiofs_source.report_source_root(source_root)
+            rsp.sourceRoot = report.get('sourceRoot')
+            rsp.physicalTotalBytes = report.get('physicalTotalBytes')
+            rsp.physicalAvailableBytes = report.get('physicalAvailableBytes')
+            rsp.cacheEntries = report.get('cacheEntries', [])
+            rsp.success = True
+            logger.info("Reported host model cache root[%s], entries=%s, available=%s" % (
+                rsp.sourceRoot, len(rsp.cacheEntries), rsp.physicalAvailableBytes))
+        except Exception as e:
+            logger.warning("Failed to report host model cache: %s" % str(e))
+            rsp.error = str(e)
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def prepare_host_model_cache(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = jsonobject.JsonObject()
+        rsp.success = False
+        try:
+            source_root = _get_cmd_attr(cmd, 'sourceRoot', _get_cmd_attr(cmd, 'sourceRootPath', None))
+            source_path = _get_cmd_attr(cmd, 'sourcePath', None)
+            required_capacity = _get_cmd_attr(cmd, 'requiredCapacityBytes', None)
+            entry = virtiofs_source.prepare_host_model_cache(source_root, source_path, required_capacity)
+            rsp.cacheEntry = entry
+            rsp.success = True
+            logger.info("Prepared host model cache path[%s], size=%s" % (
+                entry.get('sourcePath'), entry.get('sizeBytes')))
+        except Exception as e:
+            phase, code = _classify_host_model_cache_failure(e)
+            rsp.failurePhase = phase
+            rsp.failureCode = code
+            rsp.failureMessage = str(e)
+            rsp.error = str(e)
+            logger.warning("Failed to prepare host model cache, phase=%s code=%s error=%s" % (
+                phase, code, str(e)))
+        return jsonobject.dumps(rsp)
+
+    @kvmagent.replyerror
+    def cleanup_host_model_cache(self, req):
+        cmd = jsonobject.loads(req[http.REQUEST_BODY])
+        rsp = jsonobject.JsonObject()
+        rsp.success = False
+        try:
+            source_root = _get_cmd_attr(cmd, 'sourceRoot', _get_cmd_attr(cmd, 'sourceRootPath', None))
+            source_path = _get_cmd_attr(cmd, 'sourcePath', None)
+            result = virtiofs_source.cleanup_host_model_cache(source_root, source_path)
+            rsp.sourcePath = result.get('sourcePath')
+            rsp.bytesReclaimed = result.get('bytesReclaimed')
+            rsp.success = True
+            logger.info("Cleaned host model cache path[%s], bytesReclaimed=%s" % (
+                rsp.sourcePath, rsp.bytesReclaimed))
+        except Exception as e:
+            phase, code = _classify_host_model_cache_failure(e)
+            rsp.failurePhase = phase
+            rsp.failureCode = code
+            rsp.failureMessage = str(e)
+            rsp.error = str(e)
+            logger.warning("Failed to cleanup host model cache, phase=%s code=%s error=%s" % (
+                phase, code, str(e)))
         return jsonobject.dumps(rsp)

--- a/kvmagent/kvmagent/plugins/virtiofs_plugin.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_plugin.py
@@ -745,17 +745,29 @@ class VirtiofsPlugin(kvmagent.KvmAgent):
             else:
                 entry = virtiofs_source.prepare_host_model_cache(source_root, source_path, required_capacity)
             rsp.cacheEntry = entry
+            if isinstance(entry, dict):
+                rsp.prepareDecision = entry.get('prepareDecision')
+                rsp.prepareReason = entry.get('prepareReason')
             rsp.success = True
-            logger.info("Prepared host model cache path[%s], size=%s" % (
-                entry.get('sourcePath'), entry.get('sizeBytes')))
+            logger.info(
+                "[host-model-cache-prepare] path=%s size=%s decision=%s reason=%s "
+                "contentVersion=%s actions=%s" % (
+                    entry.get('sourcePath') if isinstance(entry, dict) else None,
+                    entry.get('sizeBytes') if isinstance(entry, dict) else None,
+                    entry.get('prepareDecision') if isinstance(entry, dict) else None,
+                    entry.get('prepareReason') if isinstance(entry, dict) else None,
+                    entry.get('contentVersion') if isinstance(entry, dict) else None,
+                    entry.get('prepareActions') if isinstance(entry, dict) else None,
+                ))
         except Exception as e:
             phase, code = _classify_host_model_cache_failure(e)
             rsp.failurePhase = phase
             rsp.failureCode = code
             rsp.failureMessage = str(e)
             rsp.error = str(e)
-            logger.warning("Failed to prepare host model cache, phase=%s code=%s error=%s" % (
-                phase, code, str(e)))
+            logger.warning(
+                "[host-model-cache-prepare] failed phase=%s code=%s path=%s error=%s" % (
+                    phase, code, _get_cmd_attr(cmd, 'sourcePath', None), str(e)))
         return jsonobject.dumps(rsp)
 
     @kvmagent.replyerror

--- a/kvmagent/kvmagent/plugins/virtiofs_plugin.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_plugin.py
@@ -740,7 +740,8 @@ class VirtiofsPlugin(kvmagent.KvmAgent):
                     artifact_relative_path,
                     required_capacity,
                     storage_subdir,
-                    register_cache)
+                    register_cache,
+                    _get_cmd_attr(cmd, 'contentVersion', None))
             else:
                 entry = virtiofs_source.prepare_host_model_cache(source_root, source_path, required_capacity)
             rsp.cacheEntry = entry

--- a/kvmagent/kvmagent/plugins/virtiofs_plugin.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_plugin.py
@@ -725,13 +725,22 @@ class VirtiofsPlugin(kvmagent.KvmAgent):
             required_capacity = _get_cmd_attr(cmd, 'requiredCapacityBytes', None)
             source_type = _get_cmd_attr(cmd, 'sourceType', 'preparedPath')
             if source_type == 'juicefsModelCenter':
+                artifact_relative_path = _get_cmd_attr(cmd, 'artifactRelativePath', None)
+                if not artifact_relative_path:
+                    artifact_relative_path = _get_cmd_attr(cmd, 'modelRelativePath', None)
+                storage_subdir = _get_cmd_attr(cmd, 'storageSubdir', None) or 'models'
+                register_cache = _get_cmd_attr(cmd, 'registerCache', None)
+                if register_cache is None:
+                    register_cache = True
                 entry = virtiofs_source.prepare_model_center_cache(
                     source_root,
                     source_path,
                     _get_cmd_attr(cmd, 'modelCenterUuid', None),
                     _get_cmd_attr(cmd, 'storageUrl', None),
-                    _get_cmd_attr(cmd, 'modelRelativePath', None),
-                    required_capacity)
+                    artifact_relative_path,
+                    required_capacity,
+                    storage_subdir,
+                    register_cache)
             else:
                 entry = virtiofs_source.prepare_host_model_cache(source_root, source_path, required_capacity)
             rsp.cacheEntry = entry

--- a/kvmagent/kvmagent/plugins/virtiofs_plugin.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_plugin.py
@@ -206,6 +206,8 @@ def _get_cmd_attr(obj, name, default=None):
 def _classify_host_model_cache_failure(error):
     error = str(error or '')
     lowered = error.lower()
+    if 'mount model center' in lowered or 'model center mount' in lowered:
+        return 'ModelSourceMount', 'JuicefsMountFailed'
     if 'capacity' in lowered or 'available' in lowered:
         return 'CapacityCheck', 'InsufficientHostCacheStorage'
     if 'permission' in lowered or 'denied' in lowered:
@@ -712,7 +714,17 @@ class VirtiofsPlugin(kvmagent.KvmAgent):
             source_root = _get_cmd_attr(cmd, 'sourceRoot', _get_cmd_attr(cmd, 'sourceRootPath', None))
             source_path = _get_cmd_attr(cmd, 'sourcePath', None)
             required_capacity = _get_cmd_attr(cmd, 'requiredCapacityBytes', None)
-            entry = virtiofs_source.prepare_host_model_cache(source_root, source_path, required_capacity)
+            source_type = _get_cmd_attr(cmd, 'sourceType', 'preparedPath')
+            if source_type == 'juicefsModelCenter':
+                entry = virtiofs_source.prepare_model_center_cache(
+                    source_root,
+                    source_path,
+                    _get_cmd_attr(cmd, 'modelCenterUuid', None),
+                    _get_cmd_attr(cmd, 'storageUrl', None),
+                    _get_cmd_attr(cmd, 'modelRelativePath', None),
+                    required_capacity)
+            else:
+                entry = virtiofs_source.prepare_host_model_cache(source_root, source_path, required_capacity)
             rsp.cacheEntry = entry
             rsp.success = True
             logger.info("Prepared host model cache path[%s], size=%s" % (

--- a/kvmagent/kvmagent/plugins/virtiofs_plugin.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_plugin.py
@@ -117,6 +117,12 @@ class VirtiofsStatusResponse(jsonobject.JsonObject):
     virtiofsHotplugSupported = bool
 
 
+class PrepareHostModelCacheCmd(object):
+    @log.sensitive_fields("storageUrl")
+    def __init__(self):
+        pass
+
+
 def check_libvirt_version():
     """Check if libvirt version supports virtiofs hotplug (>= 7.9.0)"""
     try:
@@ -509,7 +515,10 @@ class VirtiofsPlugin(kvmagent.KvmAgent):
         http_server.register_async_uri(self.DETACH_VIRTIOFS_PATH, self.detach_virtiofs)
         http_server.register_async_uri(self.STATUS_VIRTIOFS_PATH, self.virtiofs_status)
         http_server.register_async_uri(self.HOST_MODEL_CACHE_REPORT_PATH, self.report_host_model_cache)
-        http_server.register_async_uri(self.HOST_MODEL_CACHE_PREPARE_PATH, self.prepare_host_model_cache)
+        http_server.register_async_uri(
+            self.HOST_MODEL_CACHE_PREPARE_PATH,
+            self.prepare_host_model_cache,
+            cmd=PrepareHostModelCacheCmd())
         http_server.register_async_uri(self.HOST_MODEL_CACHE_CLEANUP_PATH, self.cleanup_host_model_cache)
 
     def stop(self):

--- a/kvmagent/kvmagent/plugins/virtiofs_source.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_source.py
@@ -4,6 +4,17 @@ import hashlib
 import json
 import os
 import re
+import shutil
+
+
+try:
+    basestring
+except NameError:
+    basestring = str
+try:
+    long
+except NameError:
+    long = int
 
 
 HOST_SOURCE_ROOT = '/var/lib/zstack/aios/virtiofs-sources'
@@ -22,6 +33,198 @@ def get_attr(obj, name, default=None):
     except Exception:
         pass
     return getattr(obj, name, default)
+
+
+def has_attr(obj, name):
+    if obj is None:
+        return False
+    if isinstance(obj, dict):
+        return name in obj
+    try:
+        if hasattr(obj, 'hasattr') and obj.hasattr(name):
+            return True
+    except Exception:
+        pass
+    return hasattr(obj, name)
+
+
+def as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
+def _normalize_root(root):
+    root = str(root or '').strip()
+    if not root:
+        return None
+    if not os.path.isabs(root):
+        raise Exception('virtiofs source root[%s] must be an absolute path' % root)
+    return os.path.realpath(root)
+
+
+def _append_root(roots, root):
+    root = _normalize_root(root)
+    if root and root not in roots:
+        roots.append(root)
+
+
+def _split_roots(value):
+    roots = []
+    for item in as_list(value):
+        if item is None:
+            continue
+        if isinstance(item, basestring):
+            parts = item.split(',')
+        else:
+            parts = [item]
+        for part in parts:
+            _append_root(roots, part)
+    return roots
+
+
+def source_roots_from_raw(raw, include_vm_view=True):
+    roots = []
+    for field in ('allowedRoots', 'allowedSourceRoots'):
+        for root in _split_roots(get_attr(raw, field)):
+            _append_root(roots, root)
+    has_explicit_source_root = False
+    for field in ('hostSourceRoot', 'sourceRootPath'):
+        if not has_attr(raw, field):
+            continue
+        has_explicit_source_root = True
+        root = get_attr(raw, field)
+        if root is None or str(root).strip() == '':
+            raise Exception('virtiofs %s must not be empty' % field)
+        _append_root(roots, root)
+    if not has_explicit_source_root:
+        _append_root(roots, HOST_SOURCE_ROOT)
+    if include_vm_view and not has_explicit_source_root:
+        _append_root(roots, VM_VIEW_ROOT)
+    return tuple(roots)
+
+
+def has_source_root_fields(raw):
+    for field in ('allowedRoots', 'allowedSourceRoots', 'hostSourceRoot', 'sourceRootPath'):
+        if get_attr(raw, field) is not None:
+            return True
+    return False
+
+
+def _parse_required_capacity(value):
+    if value is None or value == '':
+        return None
+    try:
+        required = long(value)
+    except Exception:
+        raise Exception('requiredCapacityBytes[%s] must be a number' % value)
+    if required < 0:
+        raise Exception('requiredCapacityBytes[%s] must not be negative' % value)
+    return required
+
+
+def check_available_capacity(path, required_capacity_bytes):
+    if required_capacity_bytes is None or required_capacity_bytes == 0:
+        return
+    try:
+        stat = os.statvfs(path)
+        available = stat.f_bavail * stat.f_frsize
+    except OSError as exc:
+        raise Exception('failed to check virtiofs source capacity for path[%s]: %s' % (path, exc))
+    if available < required_capacity_bytes:
+        raise Exception('virtiofs source path[%s] available capacity[%s bytes] is less than required capacity[%s bytes]. '
+                        'Please move the virtiofs source root to a disk with enough capacity or free host storage space.' % (
+                            path, available, required_capacity_bytes))
+
+
+def statvfs_capacity(path):
+    try:
+        stat = os.statvfs(path)
+    except OSError as exc:
+        raise Exception('failed to check virtiofs source root capacity for path[%s]: %s' % (path, exc))
+    return {
+        'physicalTotalBytes': long(stat.f_blocks * stat.f_frsize),
+        'physicalAvailableBytes': long(stat.f_bavail * stat.f_frsize),
+    }
+
+
+def directory_size(path):
+    total = 0
+    for root, dirs, files in os.walk(path):
+        for name in files:
+            fpath = os.path.join(root, name)
+            try:
+                total += os.path.getsize(fpath)
+            except OSError:
+                pass
+    return long(total)
+
+
+def cache_entry(source_root, source_path):
+    root = _normalize_root(source_root)
+    path = ensure_under(source_path, root, 'sourcePath', allow_root=False)
+    if not os.path.exists(path):
+        raise Exception('sourcePath[%s] does not exist' % source_path)
+    if not os.path.isdir(path):
+        raise Exception('sourcePath[%s] is not a directory' % source_path)
+    return {
+        'sourcePath': path,
+        'sizeBytes': directory_size(path),
+        'sourceMtime': long(os.path.getmtime(path)),
+        'checksum': None,
+        'contentVersion': None,
+    }
+
+
+def report_source_root(source_root):
+    root = _normalize_root(source_root or HOST_SOURCE_ROOT)
+    if not os.path.exists(root):
+        raise Exception('sourceRoot[%s] does not exist' % root)
+    if not os.path.isdir(root):
+        raise Exception('sourceRoot[%s] is not a directory' % root)
+
+    result = statvfs_capacity(root)
+    result['sourceRoot'] = root
+    result['cacheEntries'] = []
+
+    registry = SourceRegistry(os.path.join(root, '.registry')).load()
+    for entry in registry.values():
+        path = entry.get('path') if isinstance(entry, dict) else None
+        if not path:
+            continue
+        try:
+            result['cacheEntries'].append(cache_entry(root, path))
+        except Exception:
+            pass
+    return result
+
+
+def prepare_host_model_cache(source_root, source_path, required_capacity_bytes=None):
+    root = _normalize_root(source_root or HOST_SOURCE_ROOT)
+    if not os.path.exists(root):
+        raise Exception('sourceRoot[%s] does not exist' % root)
+    check_available_capacity(root, required_capacity_bytes)
+    return cache_entry(root, source_path)
+
+
+def cleanup_host_model_cache(source_root, source_path):
+    root = _normalize_root(source_root or HOST_SOURCE_ROOT)
+    path = ensure_under(source_path, root, 'sourcePath', allow_root=False)
+    if not os.path.exists(path):
+        return {
+            'sourcePath': path,
+            'bytesReclaimed': 0,
+        }
+    if not os.path.isdir(path):
+        raise Exception('sourcePath[%s] is not a directory' % source_path)
+    bytes_reclaimed = directory_size(path)
+    shutil.rmtree(path)
+    return {
+        'sourcePath': path,
+        'bytesReclaimed': bytes_reclaimed,
+    }
 
 
 def _safe_id(value, prefix):
@@ -83,10 +286,13 @@ class SourceCapability(object):
 
 
 class SourceSpec(object):
-    def __init__(self, source_type='preparedPath', path=None, source_uuid=None):
+    def __init__(self, source_type='preparedPath', path=None, source_uuid=None,
+                 allowed_roots=None, required_capacity_bytes=None):
         self.source_type = source_type or 'preparedPath'
         self.path = path
         self.source_uuid = source_uuid
+        self.allowed_roots = allowed_roots
+        self.required_capacity_bytes = required_capacity_bytes
 
     @staticmethod
     def from_raw(raw):
@@ -96,7 +302,10 @@ class SourceSpec(object):
         path = (get_attr(raw, 'path') or get_attr(raw, 'sourcePath') or
                 get_attr(raw, 'preparedPath'))
         source_uuid = get_attr(raw, 'sourceUuid', get_attr(raw, 'uuid'))
-        return SourceSpec(source_type, path, source_uuid)
+        required_capacity = _parse_required_capacity(
+            get_attr(raw, 'requiredCapacityBytes', get_attr(raw, 'requiredBytes')))
+        allowed_roots = source_roots_from_raw(raw) if has_source_root_fields(raw) else None
+        return SourceSpec(source_type, path, source_uuid, allowed_roots, required_capacity)
 
     @staticmethod
     def from_command(cmd):
@@ -107,6 +316,8 @@ class SourceSpec(object):
             get_attr(cmd, 'sourceType', 'preparedPath'),
             get_attr(cmd, 'sourcePath'),
             get_attr(cmd, 'sourceUuid'),
+            source_roots_from_raw(cmd) if has_source_root_fields(cmd) else None,
+            _parse_required_capacity(get_attr(cmd, 'requiredCapacityBytes', get_attr(cmd, 'requiredBytes'))),
         )
 
 
@@ -142,7 +353,9 @@ class PreparedPathSourceProvider(object):
         if not os.path.isdir(spec.path):
             raise Exception('sourcePath[%s] is not a directory' % spec.path)
 
-        path = ensure_under_any(spec.path, self.allowed_roots, 'sourcePath', allow_root=False)
+        allowed_roots = spec.allowed_roots or self.allowed_roots
+        path = ensure_under_any(spec.path, allowed_roots, 'sourcePath', allow_root=False)
+        check_available_capacity(path, spec.required_capacity_bytes)
         source_uuid = _safe_id(spec.source_uuid, None) if spec.source_uuid else _path_id(path)
         capability = SourceCapability(
             migratable=False,

--- a/kvmagent/kvmagent/plugins/virtiofs_source.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_source.py
@@ -297,16 +297,38 @@ def _log_prepare_decision(decision, reason, expected, local_version, path, model
         ))
 
 
+def _ensure_report_source_root(root):
+    if os.path.exists(root):
+        if not os.path.isdir(root):
+            raise Exception('sourceRoot[%s] is not a directory' % root)
+        return root
+
+    if root == _normalize_root(HOST_SOURCE_ROOT):
+        _ensure_directory(root)
+        return root
+
+    parent = os.path.dirname(root)
+    if not parent or not os.path.exists(parent):
+        raise Exception('sourceRoot[%s] does not exist' % root)
+    if not os.path.isdir(parent):
+        raise Exception('sourceRoot[%s] parent[%s] is not a directory' % (root, parent))
+
+    # Reporting is a read-only operation for primary-storage roots.  Capacity
+    # belongs to the mounted parent and can be initialized before the cache
+    # leaf is created by the first prepare operation.
+    return parent
+
+
 def report_source_root(source_root):
     root = _normalize_root(source_root or HOST_SOURCE_ROOT)
-    if not os.path.exists(root):
-        raise Exception('sourceRoot[%s] does not exist' % root)
-    if not os.path.isdir(root):
-        raise Exception('sourceRoot[%s] is not a directory' % root)
+    capacity_root = _ensure_report_source_root(root)
 
-    result = statvfs_capacity(root)
+    result = statvfs_capacity(capacity_root)
     result['sourceRoot'] = root
     result['cacheEntries'] = []
+
+    if not os.path.isdir(root):
+        return result
 
     registry = SourceRegistry(os.path.join(root, '.registry')).load()
     for entry in registry.values():

--- a/kvmagent/kvmagent/plugins/virtiofs_source.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_source.py
@@ -4,11 +4,14 @@ import errno
 import fcntl
 import hashlib
 import json
+import logging
 import os
 import re
 import shutil
 import subprocess
 import time
+
+logger = logging.getLogger(__name__)
 
 
 try:
@@ -246,7 +249,8 @@ def remote_directory_meta(path):
     return format_meta_content_version(directory_size(path), int(os.path.getmtime(path)))
 
 
-def cache_entry(source_root, source_path, content_version=None):
+def cache_entry(source_root, source_path, content_version=None,
+                prepare_decision=None, prepare_reason=None, prepare_actions=None):
     root = _normalize_root(source_root)
     path = ensure_under(source_path, root, 'sourcePath', allow_root=False)
     if not os.path.exists(path):
@@ -254,13 +258,43 @@ def cache_entry(source_root, source_path, content_version=None):
     if not os.path.isdir(path):
         raise Exception('sourcePath[%s] is not a directory' % source_path)
     version = content_version if content_version is not None else read_local_content_version(path)
-    return {
+    entry = {
         'sourcePath': path,
         'sizeBytes': directory_size(path),
         'sourceMtime': int(os.path.getmtime(path)),
         'checksum': None,
         'contentVersion': version,
     }
+    if prepare_decision is not None:
+        entry['prepareDecision'] = prepare_decision
+    if prepare_reason is not None:
+        entry['prepareReason'] = prepare_reason
+    if prepare_actions is not None:
+        entry['prepareActions'] = prepare_actions
+    return entry
+
+
+def _prepare_actions(mounted, copied):
+    return 'mount=%s,copy=%s' % (1 if mounted else 0, 1 if copied else 0)
+
+
+def _log_prepare_decision(decision, reason, expected, local_version, path, model_center_uuid,
+                          storage_subdir, actions, entry, elapsed_ms):
+    logger.info(
+        '[host-model-cache-prepare] decision=%s reason=%s expected=%s local=%s '
+        'path=%s mc=%s subdir=%s actions=%s elapsedMs=%s sizeBytes=%s contentVersion=%s' % (
+            decision,
+            reason,
+            expected or 'none',
+            local_version or 'none',
+            path,
+            model_center_uuid,
+            storage_subdir,
+            actions,
+            int(elapsed_ms),
+            entry.get('sizeBytes'),
+            entry.get('contentVersion') or 'none',
+        ))
 
 
 def report_source_root(source_root):
@@ -366,6 +400,7 @@ def prepare_model_center_cache(source_root, source_path, model_center_uuid, stor
     - strong contentVersion (v:...) matching local sidecar skips remount
     - otherwise mount JuiceFS and compare weak meta (size+mtime); refresh on mismatch
     """
+    started = time.time()
     root = _normalize_root(source_root or HOST_SOURCE_ROOT)
     target = ensure_under(source_path, root, 'sourcePath', allow_root=False)
     model_center_uuid = _validate_source_id(model_center_uuid, 'modelCenterUuid')
@@ -374,6 +409,8 @@ def prepare_model_center_cache(source_root, source_path, model_center_uuid, stor
     storage_subdir = _validate_relative_path(storage_subdir, 'storageSubdir')
     relative_path = _validate_relative_path(artifact_relative_path, 'artifactRelativePath')
     expected_strong = format_strong_content_version(content_version)
+    had_local = os.path.exists(target)
+    local_before = read_local_content_version(target) if had_local else None
 
     if not os.path.exists(root):
         _ensure_directory(root)
@@ -392,13 +429,23 @@ def prepare_model_center_cache(source_root, source_path, model_center_uuid, stor
             _unmount_model_center(mount_path)
 
         # Strong-version hit: local sidecar already matches shared truth → skip mount.
-        if os.path.exists(target) and expected_strong and is_local_content_aligned(target, expected_strong):
-            entry = cache_entry(root, target, expected_strong)
+        if had_local and expected_strong and is_local_content_aligned(target, expected_strong):
+            actions = _prepare_actions(False, False)
+            entry = cache_entry(
+                root, target, expected_strong,
+                'strong_hit', 'strong_match', actions)
             if register_cache:
                 _register_model_center_cache(root, target)
+            _log_prepare_decision(
+                'strong_hit', 'strong_match', expected_strong, local_before,
+                target, model_center_uuid, storage_subdir, actions, entry,
+                (time.time() - started) * 1000)
             return entry
 
         aligned_version = None
+        decision = None
+        reason = None
+        copied = False
         try:
             _mount_model_center(str(storage_url).strip(), mount_path, storage_subdir)
             remote_source = ensure_under(
@@ -410,6 +457,10 @@ def prepare_model_center_cache(source_root, source_path, model_center_uuid, stor
 
             if os.path.exists(target) and is_local_content_aligned(target, expected_version):
                 aligned_version = expected_version
+                if expected_strong:
+                    decision, reason = 'strong_hit', 'strong_match'
+                else:
+                    decision, reason = 'meta_hit', 'meta_match'
             else:
                 if os.path.exists(target):
                     if not os.path.isdir(target):
@@ -424,11 +475,28 @@ def prepare_model_center_cache(source_root, source_path, model_center_uuid, stor
                     required_capacity_bytes)
                 write_local_content_version(target, expected_version)
                 aligned_version = expected_version
+                copied = True
+                if not had_local:
+                    decision, reason = 'cold_copy', 'missing_local'
+                elif not local_before:
+                    decision, reason = 'refresh', 'no_sidecar'
+                elif expected_strong:
+                    decision, reason = 'refresh', 'strong_mismatch'
+                else:
+                    decision, reason = 'refresh', 'meta_mismatch'
         finally:
             _unmount_model_center(mount_path)
-        entry = cache_entry(root, target, aligned_version)
+
+        actions = _prepare_actions(True, copied)
+        entry = cache_entry(
+            root, target, aligned_version,
+            decision, reason, actions)
         if register_cache:
             _register_model_center_cache(root, target)
+        _log_prepare_decision(
+            decision, reason, expected_strong or aligned_version, local_before,
+            target, model_center_uuid, storage_subdir, actions, entry,
+            (time.time() - started) * 1000)
         return entry
     finally:
         try:

--- a/kvmagent/kvmagent/plugins/virtiofs_source.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_source.py
@@ -261,7 +261,7 @@ def _run_process(args, error_message):
     return stdout, stderr
 
 
-def _mount_model_center(storage_url, mount_path):
+def _mount_model_center(storage_url, mount_path, storage_subdir='models'):
     if os.path.ismount(mount_path):
         _unmount_model_center(mount_path)
     if not os.path.exists(mount_path):
@@ -271,7 +271,7 @@ def _mount_model_center(storage_url, mount_path):
     juicefs = _find_juicefs_binary()
     _run_process([
         juicefs, 'mount',
-        '--read-only', '-d', '--subdir', 'models',
+        '--read-only', '-d', '--subdir', storage_subdir,
         '--cache-dir', JUICEFS_CACHE_DIR,
         storage_url, mount_path,
     ], 'failed to mount model center')
@@ -292,13 +292,15 @@ def _unmount_model_center(mount_path):
 
 
 def prepare_model_center_cache(source_root, source_path, model_center_uuid, storage_url,
-                               model_relative_path, required_capacity_bytes=None):
+                               artifact_relative_path, required_capacity_bytes=None,
+                               storage_subdir='models', register_cache=True):
     root = _normalize_root(source_root or HOST_SOURCE_ROOT)
     target = ensure_under(source_path, root, 'sourcePath', allow_root=False)
     model_center_uuid = _validate_source_id(model_center_uuid, 'modelCenterUuid')
     if not storage_url or not str(storage_url).strip():
         raise Exception('storageUrl is required')
-    relative_path = _validate_relative_path(model_relative_path, 'modelRelativePath')
+    storage_subdir = _validate_relative_path(storage_subdir, 'storageSubdir')
+    relative_path = _validate_relative_path(artifact_relative_path, 'artifactRelativePath')
 
     if not os.path.exists(root):
         _ensure_directory(root)
@@ -317,12 +319,13 @@ def prepare_model_center_cache(source_root, source_path, model_center_uuid, stor
             _unmount_model_center(mount_path)
         if os.path.exists(target):
             entry = cache_entry(root, target)
-            _register_model_center_cache(root, target)
+            if register_cache:
+                _register_model_center_cache(root, target)
             return entry
 
         check_available_capacity(root, required_capacity_bytes)
         try:
-            _mount_model_center(str(storage_url).strip(), mount_path)
+            _mount_model_center(str(storage_url).strip(), mount_path, storage_subdir)
             remote_source = ensure_under(
                 os.path.join(mount_path, relative_path),
                 mount_path,
@@ -337,7 +340,8 @@ def prepare_model_center_cache(source_root, source_path, model_center_uuid, stor
         finally:
             _unmount_model_center(mount_path)
         entry = cache_entry(root, target)
-        _register_model_center_cache(root, target)
+        if register_cache:
+            _register_model_center_cache(root, target)
         return entry
     finally:
         try:

--- a/kvmagent/kvmagent/plugins/virtiofs_source.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_source.py
@@ -1,10 +1,14 @@
 # Copyright (c) 2025, ZStack, Inc.
 
+import errno
+import fcntl
 import hashlib
 import json
 import os
 import re
 import shutil
+import subprocess
+import time
 
 
 try:
@@ -20,6 +24,22 @@ except NameError:
 HOST_SOURCE_ROOT = '/var/lib/zstack/aios/virtiofs-sources'
 VM_VIEW_ROOT = '/var/lib/zstack/aios/vm-views'
 SOURCE_REGISTRY_FILE = os.path.join(HOST_SOURCE_ROOT, '.registry')
+MODEL_CENTER_PROVIDER_ROOT = '/var/lib/zstack/aios/provider-mounts/model-centers'
+MODEL_CENTER_LOCK_ROOT = '/var/lib/zstack/aios/provider-locks/model-centers'
+JUICEFS_CACHE_DIR = '/var/cache/virtiofs/juicefs'
+JUICEFS_CANDIDATE_PATHS = (
+    '/usr/local/bin/juicefs',
+    '/usr/bin/juicefs',
+    '/opt/zstack/bin/juicefs',
+)
+
+
+def _ensure_directory(path):
+    try:
+        os.makedirs(path, 0o755)
+    except OSError as exc:
+        if exc.errno != errno.EEXIST or not os.path.isdir(path):
+            raise
 
 
 def get_attr(obj, name, default=None):
@@ -117,7 +137,7 @@ def _parse_required_capacity(value):
     if value is None or value == '':
         return None
     try:
-        required = long(value)
+        required = int(value)
     except Exception:
         raise Exception('requiredCapacityBytes[%s] must be a number' % value)
     if required < 0:
@@ -145,8 +165,8 @@ def statvfs_capacity(path):
     except OSError as exc:
         raise Exception('failed to check virtiofs source root capacity for path[%s]: %s' % (path, exc))
     return {
-        'physicalTotalBytes': long(stat.f_blocks * stat.f_frsize),
-        'physicalAvailableBytes': long(stat.f_bavail * stat.f_frsize),
+        'physicalTotalBytes': int(stat.f_blocks * stat.f_frsize),
+        'physicalAvailableBytes': int(stat.f_bavail * stat.f_frsize),
     }
 
 
@@ -159,7 +179,7 @@ def directory_size(path):
                 total += os.path.getsize(fpath)
             except OSError:
                 pass
-    return long(total)
+    return int(total)
 
 
 def cache_entry(source_root, source_path):
@@ -172,7 +192,7 @@ def cache_entry(source_root, source_path):
     return {
         'sourcePath': path,
         'sizeBytes': directory_size(path),
-        'sourceMtime': long(os.path.getmtime(path)),
+        'sourceMtime': int(os.path.getmtime(path)),
         'checksum': None,
         'contentVersion': None,
     }
@@ -207,6 +227,123 @@ def prepare_host_model_cache(source_root, source_path, required_capacity_bytes=N
         raise Exception('sourceRoot[%s] does not exist' % root)
     check_available_capacity(root, required_capacity_bytes)
     return cache_entry(root, source_path)
+
+
+def _validate_source_id(value, field_name):
+    value = str(value or '').strip()
+    if not value or not re.match(r'^[A-Za-z0-9][A-Za-z0-9_.-]*$', value):
+        raise Exception('invalid %s[%s]' % (field_name, value))
+    return value
+
+
+def _validate_relative_path(value, field_name):
+    value = str(value or '').strip()
+    if not value or os.path.isabs(value):
+        raise Exception('%s[%s] must be a non-empty relative path' % (field_name, value))
+    normalized = os.path.normpath(value)
+    if normalized == '..' or normalized.startswith('..' + os.sep):
+        raise Exception('%s[%s] escapes its source root' % (field_name, value))
+    return normalized
+
+
+def _find_juicefs_binary():
+    for path in JUICEFS_CANDIDATE_PATHS:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+    raise Exception('juicefs binary not found')
+
+
+def _run_process(args, error_message):
+    process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = process.communicate()
+    if process.returncode != 0:
+        raise Exception('%s, exitCode[%s]' % (error_message, process.returncode))
+    return stdout, stderr
+
+
+def _mount_model_center(storage_url, mount_path):
+    if os.path.ismount(mount_path):
+        _unmount_model_center(mount_path)
+    if not os.path.exists(mount_path):
+        _ensure_directory(mount_path)
+    if not os.path.exists(JUICEFS_CACHE_DIR):
+        _ensure_directory(JUICEFS_CACHE_DIR)
+    juicefs = _find_juicefs_binary()
+    _run_process([
+        juicefs, 'mount',
+        '--read-only', '-d', '--subdir', 'models',
+        '--cache-dir', JUICEFS_CACHE_DIR,
+        storage_url, mount_path,
+    ], 'failed to mount model center')
+    for _ in range(20):
+        if os.path.ismount(mount_path):
+            return
+        time.sleep(0.5)
+    raise Exception('model center mount did not become ready')
+
+
+def _unmount_model_center(mount_path):
+    if not os.path.ismount(mount_path):
+        return
+    juicefs = _find_juicefs_binary()
+    _run_process([juicefs, 'umount', '--force', mount_path], 'failed to unmount model center')
+    if os.path.ismount(mount_path):
+        raise Exception('model center mount is still active after unmount')
+
+
+def prepare_model_center_cache(source_root, source_path, model_center_uuid, storage_url,
+                               model_relative_path, required_capacity_bytes=None):
+    root = _normalize_root(source_root or HOST_SOURCE_ROOT)
+    target = ensure_under(source_path, root, 'sourcePath', allow_root=False)
+    model_center_uuid = _validate_source_id(model_center_uuid, 'modelCenterUuid')
+    if not storage_url or not str(storage_url).strip():
+        raise Exception('storageUrl is required')
+    relative_path = _validate_relative_path(model_relative_path, 'modelRelativePath')
+
+    if not os.path.exists(root):
+        _ensure_directory(root)
+
+    if not os.path.exists(MODEL_CENTER_PROVIDER_ROOT):
+        _ensure_directory(MODEL_CENTER_PROVIDER_ROOT)
+    if not os.path.exists(MODEL_CENTER_LOCK_ROOT):
+        _ensure_directory(MODEL_CENTER_LOCK_ROOT)
+
+    mount_path = os.path.join(MODEL_CENTER_PROVIDER_ROOT, model_center_uuid)
+    lock_path = os.path.join(MODEL_CENTER_LOCK_ROOT, model_center_uuid + '.lock')
+    lock_fd = open(lock_path, 'a+')
+    try:
+        fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
+        if os.path.ismount(mount_path):
+            _unmount_model_center(mount_path)
+        if os.path.exists(target):
+            entry = cache_entry(root, target)
+            _register_model_center_cache(root, target)
+            return entry
+
+        check_available_capacity(root, required_capacity_bytes)
+        try:
+            _mount_model_center(str(storage_url).strip(), mount_path)
+            remote_source = ensure_under(
+                os.path.join(mount_path, relative_path),
+                mount_path,
+                'modelRelativePath',
+                allow_root=False)
+            prepare_copy_source(
+                target,
+                (root,),
+                remote_source,
+                (mount_path,),
+                required_capacity_bytes)
+        finally:
+            _unmount_model_center(mount_path)
+        entry = cache_entry(root, target)
+        _register_model_center_cache(root, target)
+        return entry
+    finally:
+        try:
+            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
+        finally:
+            lock_fd.close()
 
 
 def cleanup_host_model_cache(source_root, source_path):
@@ -287,12 +424,15 @@ class SourceCapability(object):
 
 class SourceSpec(object):
     def __init__(self, source_type='preparedPath', path=None, source_uuid=None,
-                 allowed_roots=None, required_capacity_bytes=None):
+                 allowed_roots=None, required_capacity_bytes=None,
+                 remote_source_path=None, remote_allowed_roots=None):
         self.source_type = source_type or 'preparedPath'
         self.path = path
         self.source_uuid = source_uuid
         self.allowed_roots = allowed_roots
         self.required_capacity_bytes = required_capacity_bytes
+        self.remote_source_path = remote_source_path
+        self.remote_allowed_roots = remote_allowed_roots
 
     @staticmethod
     def from_raw(raw):
@@ -304,8 +444,13 @@ class SourceSpec(object):
         source_uuid = get_attr(raw, 'sourceUuid', get_attr(raw, 'uuid'))
         required_capacity = _parse_required_capacity(
             get_attr(raw, 'requiredCapacityBytes', get_attr(raw, 'requiredBytes')))
+        remote_source_path = get_attr(raw, 'remoteSourcePath')
+        remote_allowed_roots = source_roots_from_raw({
+            'sourceRootPath': get_attr(raw, 'remoteSourceRootPath')
+        }, include_vm_view=False) if get_attr(raw, 'remoteSourceRootPath') else None
         allowed_roots = source_roots_from_raw(raw) if has_source_root_fields(raw) else None
-        return SourceSpec(source_type, path, source_uuid, allowed_roots, required_capacity)
+        return SourceSpec(source_type, path, source_uuid, allowed_roots, required_capacity,
+                          remote_source_path, remote_allowed_roots)
 
     @staticmethod
     def from_command(cmd):
@@ -318,6 +463,10 @@ class SourceSpec(object):
             get_attr(cmd, 'sourceUuid'),
             source_roots_from_raw(cmd) if has_source_root_fields(cmd) else None,
             _parse_required_capacity(get_attr(cmd, 'requiredCapacityBytes', get_attr(cmd, 'requiredBytes'))),
+            get_attr(cmd, 'remoteSourcePath'),
+            source_roots_from_raw({
+                'sourceRootPath': get_attr(cmd, 'remoteSourceRootPath')
+            }, include_vm_view=False) if get_attr(cmd, 'remoteSourceRootPath') else None,
         )
 
 
@@ -348,12 +497,16 @@ class PreparedPathSourceProvider(object):
     def prepare(self, spec):
         if not spec.path:
             raise Exception('sourcePath is required')
+        allowed_roots = spec.allowed_roots or self.allowed_roots
+        if spec.remote_source_path:
+            prepare_copy_source(spec.path, allowed_roots, spec.remote_source_path,
+                                spec.remote_allowed_roots or self.allowed_roots,
+                                spec.required_capacity_bytes)
         if not os.path.exists(spec.path):
             raise Exception('sourcePath[%s] does not exist' % spec.path)
         if not os.path.isdir(spec.path):
             raise Exception('sourcePath[%s] is not a directory' % spec.path)
 
-        allowed_roots = spec.allowed_roots or self.allowed_roots
         path = ensure_under_any(spec.path, allowed_roots, 'sourcePath', allow_root=False)
         check_available_capacity(path, spec.required_capacity_bytes)
         source_uuid = _safe_id(spec.source_uuid, None) if spec.source_uuid else _path_id(path)
@@ -364,6 +517,42 @@ class PreparedPathSourceProvider(object):
             shared_across_hosts=False,
         )
         return HostSource(source_uuid, spec.source_type, path, capability)
+
+
+def prepare_copy_source(target_path, target_roots, remote_source_path, remote_roots, required_capacity_bytes=None):
+    target = ensure_under_any(target_path, target_roots, 'sourcePath', allow_root=False)
+    if os.path.exists(target):
+        if not os.path.isdir(target):
+            raise Exception('sourcePath[%s] exists but is not a directory' % target_path)
+        return target
+
+    remote = ensure_under_any(remote_source_path, remote_roots, 'remoteSourcePath', allow_root=False)
+    if not os.path.exists(remote):
+        raise Exception('remoteSourcePath[%s] does not exist' % remote_source_path)
+    if not os.path.isdir(remote):
+        raise Exception('remoteSourcePath[%s] is not a directory' % remote_source_path)
+
+    parent = os.path.dirname(target)
+    if parent and not os.path.exists(parent):
+        os.makedirs(parent, 0o755)
+    check_available_capacity(parent, required_capacity_bytes)
+
+    tmp = '%s.tmp.%s.%s' % (target, os.getpid(), int(time.time() * 1000))
+    if os.path.exists(tmp):
+        shutil.rmtree(tmp, ignore_errors=True)
+    try:
+        shutil.copytree(remote, tmp, symlinks=True)
+        try:
+            os.rename(tmp, target)
+        except OSError:
+            if os.path.exists(target) and os.path.isdir(target):
+                shutil.rmtree(tmp, ignore_errors=True)
+                return target
+            raise
+    except Exception:
+        shutil.rmtree(tmp, ignore_errors=True)
+        raise
+    return target
 
 
 class SourceRegistry(object):
@@ -394,6 +583,30 @@ class SourceRegistry(object):
             return True
         except (IOError, OSError):
             return False
+
+
+def _register_model_center_cache(source_root, source_path):
+    source = HostSource(
+        _path_id(source_path),
+        'juicefsModelCenter',
+        source_path,
+        SourceCapability(
+            migratable=False,
+            snapshotable=False,
+            persistent=True,
+            shared_across_hosts=False,
+        ))
+    registry = SourceRegistry(os.path.join(source_root, '.registry'))
+    lock_fd = open(registry.path + '.lock', 'a+')
+    try:
+        fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
+        if not registry.save_host_source(source):
+            raise Exception('failed to register prepared model center cache[%s]' % source_path)
+    finally:
+        try:
+            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
+        finally:
+            lock_fd.close()
 
 
 class SourceManager(object):

--- a/kvmagent/kvmagent/plugins/virtiofs_source.py
+++ b/kvmagent/kvmagent/plugins/virtiofs_source.py
@@ -32,6 +32,10 @@ JUICEFS_CANDIDATE_PATHS = (
     '/usr/bin/juicefs',
     '/opt/zstack/bin/juicefs',
 )
+# Local alignment sidecar: strong "v:<shared>" or weak "meta:<size>:<mtime>" from JuiceFS.
+CONTENT_VERSION_SIDECAR = '.aios-content-version'
+CONTENT_VERSION_STRONG_PREFIX = 'v:'
+CONTENT_VERSION_META_PREFIX = 'meta:'
 
 
 def _ensure_directory(path):
@@ -182,19 +186,80 @@ def directory_size(path):
     return int(total)
 
 
-def cache_entry(source_root, source_path):
+def format_strong_content_version(content_version):
+    value = str(content_version or '').strip()
+    if not value:
+        return None
+    if value.startswith(CONTENT_VERSION_STRONG_PREFIX) or value.startswith(CONTENT_VERSION_META_PREFIX):
+        return value
+    return CONTENT_VERSION_STRONG_PREFIX + value
+
+
+def format_meta_content_version(size_bytes, source_mtime):
+    return '%s%s:%s' % (CONTENT_VERSION_META_PREFIX, int(size_bytes), int(source_mtime))
+
+
+def read_local_content_version(path):
+    sidecar = os.path.join(path, CONTENT_VERSION_SIDECAR)
+    if not os.path.isfile(sidecar):
+        return None
+    try:
+        with open(sidecar, 'r') as fd:
+            value = fd.read().strip()
+        return value or None
+    except (IOError, OSError):
+        return None
+
+
+def write_local_content_version(path, content_version):
+    value = str(content_version or '').strip()
+    if not value:
+        return
+    sidecar = os.path.join(path, CONTENT_VERSION_SIDECAR)
+    tmp = '%s.tmp.%s' % (sidecar, os.getpid())
+    try:
+        with open(tmp, 'w') as fd:
+            fd.write(value)
+        os.rename(tmp, sidecar)
+    except (IOError, OSError):
+        try:
+            if os.path.exists(tmp):
+                os.remove(tmp)
+        except (IOError, OSError):
+            pass
+        raise
+
+
+def is_local_content_aligned(path, expected_version):
+    expected = str(expected_version or '').strip()
+    if not expected:
+        return False
+    local = read_local_content_version(path)
+    return bool(local) and local == expected
+
+
+def remote_directory_meta(path):
+    if not os.path.exists(path):
+        raise Exception('remoteSourcePath[%s] does not exist' % path)
+    if not os.path.isdir(path):
+        raise Exception('remoteSourcePath[%s] is not a directory' % path)
+    return format_meta_content_version(directory_size(path), int(os.path.getmtime(path)))
+
+
+def cache_entry(source_root, source_path, content_version=None):
     root = _normalize_root(source_root)
     path = ensure_under(source_path, root, 'sourcePath', allow_root=False)
     if not os.path.exists(path):
         raise Exception('sourcePath[%s] does not exist' % source_path)
     if not os.path.isdir(path):
         raise Exception('sourcePath[%s] is not a directory' % source_path)
+    version = content_version if content_version is not None else read_local_content_version(path)
     return {
         'sourcePath': path,
         'sizeBytes': directory_size(path),
         'sourceMtime': int(os.path.getmtime(path)),
         'checksum': None,
-        'contentVersion': None,
+        'contentVersion': version,
     }
 
 
@@ -293,7 +358,14 @@ def _unmount_model_center(mount_path):
 
 def prepare_model_center_cache(source_root, source_path, model_center_uuid, storage_url,
                                artifact_relative_path, required_capacity_bytes=None,
-                               storage_subdir='models', register_cache=True):
+                               storage_subdir='models', register_cache=True,
+                               content_version=None):
+    """Prepare host-local cache from JuiceFS model center.
+
+    Deploy always calls prepare. Local dir existence alone is not a hit:
+    - strong contentVersion (v:...) matching local sidecar skips remount
+    - otherwise mount JuiceFS and compare weak meta (size+mtime); refresh on mismatch
+    """
     root = _normalize_root(source_root or HOST_SOURCE_ROOT)
     target = ensure_under(source_path, root, 'sourcePath', allow_root=False)
     model_center_uuid = _validate_source_id(model_center_uuid, 'modelCenterUuid')
@@ -301,6 +373,7 @@ def prepare_model_center_cache(source_root, source_path, model_center_uuid, stor
         raise Exception('storageUrl is required')
     storage_subdir = _validate_relative_path(storage_subdir, 'storageSubdir')
     relative_path = _validate_relative_path(artifact_relative_path, 'artifactRelativePath')
+    expected_strong = format_strong_content_version(content_version)
 
     if not os.path.exists(root):
         _ensure_directory(root)
@@ -317,13 +390,15 @@ def prepare_model_center_cache(source_root, source_path, model_center_uuid, stor
         fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
         if os.path.ismount(mount_path):
             _unmount_model_center(mount_path)
-        if os.path.exists(target):
-            entry = cache_entry(root, target)
+
+        # Strong-version hit: local sidecar already matches shared truth → skip mount.
+        if os.path.exists(target) and expected_strong and is_local_content_aligned(target, expected_strong):
+            entry = cache_entry(root, target, expected_strong)
             if register_cache:
                 _register_model_center_cache(root, target)
             return entry
 
-        check_available_capacity(root, required_capacity_bytes)
+        aligned_version = None
         try:
             _mount_model_center(str(storage_url).strip(), mount_path, storage_subdir)
             remote_source = ensure_under(
@@ -331,15 +406,27 @@ def prepare_model_center_cache(source_root, source_path, model_center_uuid, stor
                 mount_path,
                 'modelRelativePath',
                 allow_root=False)
-            prepare_copy_source(
-                target,
-                (root,),
-                remote_source,
-                (mount_path,),
-                required_capacity_bytes)
+            expected_version = expected_strong or remote_directory_meta(remote_source)
+
+            if os.path.exists(target) and is_local_content_aligned(target, expected_version):
+                aligned_version = expected_version
+            else:
+                if os.path.exists(target):
+                    if not os.path.isdir(target):
+                        raise Exception('sourcePath[%s] exists but is not a directory' % source_path)
+                    shutil.rmtree(target)
+                check_available_capacity(root, required_capacity_bytes)
+                prepare_copy_source(
+                    target,
+                    (root,),
+                    remote_source,
+                    (mount_path,),
+                    required_capacity_bytes)
+                write_local_content_version(target, expected_version)
+                aligned_version = expected_version
         finally:
             _unmount_model_center(mount_path)
-        entry = cache_entry(root, target)
+        entry = cache_entry(root, target, aligned_version)
         if register_cache:
             _register_model_center_cache(root, target)
         return entry

--- a/tests/unit/kvmagent/test_virtiofs_handlers.py
+++ b/tests/unit/kvmagent/test_virtiofs_handlers.py
@@ -313,14 +313,17 @@ class TestHostModelCachePrepareHandler:
         captured = {}
 
         def prepare(source_root, source_path, model_center_uuid, storage_url,
-                    model_relative_path, required_capacity):
+                    artifact_relative_path, required_capacity, storage_subdir,
+                    register_cache):
             captured.update({
                 'sourceRoot': source_root,
                 'sourcePath': source_path,
                 'modelCenterUuid': model_center_uuid,
                 'storageUrl': storage_url,
-                'modelRelativePath': model_relative_path,
+                'artifactRelativePath': artifact_relative_path,
                 'requiredCapacityBytes': required_capacity,
+                'storageSubdir': storage_subdir,
+                'registerCache': register_cache,
             })
             return {'sourcePath': source_path, 'sizeBytes': 1024}
 
@@ -340,8 +343,46 @@ class TestHostModelCachePrepareHandler:
 
         assert response['success'] is True
         assert response['cacheEntry']['sourcePath'] == '/cache/models/model/v1'
-        assert captured['modelRelativePath'] == 'qwen/v1'
+        assert captured['artifactRelativePath'] == 'qwen/v1'
+        assert captured['storageSubdir'] == 'models'
+        assert captured['registerCache'] is True
         assert captured['storageUrl'] == 'redis://model-center'
+
+    def test_dispatches_non_model_artifact_source(self, monkeypatch):
+        captured = {}
+
+        def prepare(source_root, source_path, model_center_uuid, storage_url,
+                    artifact_relative_path, required_capacity, storage_subdir,
+                    register_cache):
+            captured.update({
+                'artifactRelativePath': artifact_relative_path,
+                'storageSubdir': storage_subdir,
+                'registerCache': register_cache,
+            })
+            return {'sourcePath': source_path, 'sizeBytes': 256}
+
+        monkeypatch.setattr(virtiofs_plugin.virtiofs_source, 'prepare_model_center_cache', prepare)
+        plugin = virtiofs_plugin.VirtiofsPlugin()
+        response = json.loads(plugin.prepare_host_model_cache({
+            http.REQUEST_BODY: json.dumps({
+                'sourceType': 'juicefsModelCenter',
+                'sourceRoot': '/sources',
+                'sourcePath': '/sources/model-centers/mc/root/datasets/eval',
+                'modelCenterUuid': 'mc',
+                'storageUrl': 'redis://model-center',
+                'storageSubdir': 'datasets',
+                'artifactRelativePath': 'eval',
+                'registerCache': False,
+                'requiredCapacityBytes': 256,
+            })
+        }))
+
+        assert response['success'] is True
+        assert captured == {
+            'artifactRelativePath': 'eval',
+            'storageSubdir': 'datasets',
+            'registerCache': False,
+        }
 
 
 class TestVirtiofsAttachHandler:

--- a/tests/unit/kvmagent/test_virtiofs_handlers.py
+++ b/tests/unit/kvmagent/test_virtiofs_handlers.py
@@ -314,7 +314,7 @@ class TestHostModelCachePrepareHandler:
 
         def prepare(source_root, source_path, model_center_uuid, storage_url,
                     artifact_relative_path, required_capacity, storage_subdir,
-                    register_cache):
+                    register_cache, content_version=None):
             captured.update({
                 'sourceRoot': source_root,
                 'sourcePath': source_path,
@@ -324,8 +324,9 @@ class TestHostModelCachePrepareHandler:
                 'requiredCapacityBytes': required_capacity,
                 'storageSubdir': storage_subdir,
                 'registerCache': register_cache,
+                'contentVersion': content_version,
             })
-            return {'sourcePath': source_path, 'sizeBytes': 1024}
+            return {'sourcePath': source_path, 'sizeBytes': 1024, 'contentVersion': 'v:abc'}
 
         monkeypatch.setattr(virtiofs_plugin.virtiofs_source, 'prepare_model_center_cache', prepare)
         plugin = virtiofs_plugin.VirtiofsPlugin()
@@ -338,6 +339,7 @@ class TestHostModelCachePrepareHandler:
                 'storageUrl': 'redis://model-center',
                 'modelRelativePath': 'qwen/v1',
                 'requiredCapacityBytes': 1024,
+                'contentVersion': 'abc',
             })
         }))
 
@@ -347,17 +349,19 @@ class TestHostModelCachePrepareHandler:
         assert captured['storageSubdir'] == 'models'
         assert captured['registerCache'] is True
         assert captured['storageUrl'] == 'redis://model-center'
+        assert captured['contentVersion'] == 'abc'
 
     def test_dispatches_non_model_artifact_source(self, monkeypatch):
         captured = {}
 
         def prepare(source_root, source_path, model_center_uuid, storage_url,
                     artifact_relative_path, required_capacity, storage_subdir,
-                    register_cache):
+                    register_cache, content_version=None):
             captured.update({
                 'artifactRelativePath': artifact_relative_path,
                 'storageSubdir': storage_subdir,
                 'registerCache': register_cache,
+                'contentVersion': content_version,
             })
             return {'sourcePath': source_path, 'sizeBytes': 256}
 
@@ -374,6 +378,7 @@ class TestHostModelCachePrepareHandler:
                 'artifactRelativePath': 'eval',
                 'registerCache': False,
                 'requiredCapacityBytes': 256,
+                'contentVersion': 'tpl-v2',
             })
         }))
 
@@ -382,6 +387,7 @@ class TestHostModelCachePrepareHandler:
             'artifactRelativePath': 'eval',
             'storageSubdir': 'datasets',
             'registerCache': False,
+            'contentVersion': 'tpl-v2',
         }
 
 

--- a/tests/unit/kvmagent/test_virtiofs_handlers.py
+++ b/tests/unit/kvmagent/test_virtiofs_handlers.py
@@ -28,6 +28,23 @@ from zstacklib.utils import http
 from kvmagent.plugins import virtiofs_plugin
 
 
+@patch('kvmagent.plugins.virtiofs_plugin._init_virtiofsd_path')
+@patch('kvmagent.plugins.virtiofs_plugin.kvmagent.get_http_server')
+def test_prepare_host_model_cache_registers_sensitive_command(
+        mock_get_http_server, _mock_init_virtiofsd_path):
+    server = MagicMock()
+    mock_get_http_server.return_value = server
+
+    virtiofs_plugin.VirtiofsPlugin().start()
+
+    prepare_call = next(
+        call for call in server.register_async_uri.call_args_list
+        if call.args[0] == virtiofs_plugin.VirtiofsPlugin.HOST_MODEL_CACHE_PREPARE_PATH)
+    assert isinstance(
+        prepare_call.kwargs["cmd"],
+        virtiofs_plugin.PrepareHostModelCacheCmd)
+
+
 class TestVerifySourcePath:
     """Test verify_source_path() security validation."""
 

--- a/tests/unit/kvmagent/test_virtiofs_handlers.py
+++ b/tests/unit/kvmagent/test_virtiofs_handlers.py
@@ -45,6 +45,28 @@ def test_prepare_host_model_cache_registers_sensitive_command(
         virtiofs_plugin.PrepareHostModelCacheCmd)
 
 
+def test_report_host_model_cache_reports_missing_cache_leaf_without_creating_it(tmp_path, monkeypatch):
+    parent = tmp_path / 'primary-storage'
+    parent.mkdir()
+    source_root = parent / 'ai-model-cache'
+    monkeypatch.setattr(
+        virtiofs_plugin.virtiofs_source,
+        'statvfs_capacity',
+        lambda path: {'physicalTotalBytes': 100, 'physicalAvailableBytes': 80})
+
+    req = {
+        http.REQUEST_BODY: json.dumps({'sourceRoot': str(source_root)})
+    }
+    rsp = json.loads(virtiofs_plugin.VirtiofsPlugin().report_host_model_cache(req))
+
+    assert rsp['success'] is True
+    assert not source_root.exists()
+    assert rsp['sourceRoot'] == os.path.realpath(str(source_root))
+    assert rsp['physicalTotalBytes'] == 100
+    assert rsp['physicalAvailableBytes'] == 80
+    assert rsp['cacheEntries'] == []
+
+
 class TestVerifySourcePath:
     """Test verify_source_path() security validation."""
 

--- a/tests/unit/kvmagent/test_virtiofs_handlers.py
+++ b/tests/unit/kvmagent/test_virtiofs_handlers.py
@@ -290,6 +290,43 @@ class TestVerifySourcePath:
 
 
 @pytest.mark.kvmagent
+class TestHostModelCachePrepareHandler:
+
+    def test_dispatches_juicefs_model_center_source(self, monkeypatch):
+        captured = {}
+
+        def prepare(source_root, source_path, model_center_uuid, storage_url,
+                    model_relative_path, required_capacity):
+            captured.update({
+                'sourceRoot': source_root,
+                'sourcePath': source_path,
+                'modelCenterUuid': model_center_uuid,
+                'storageUrl': storage_url,
+                'modelRelativePath': model_relative_path,
+                'requiredCapacityBytes': required_capacity,
+            })
+            return {'sourcePath': source_path, 'sizeBytes': 1024}
+
+        monkeypatch.setattr(virtiofs_plugin.virtiofs_source, 'prepare_model_center_cache', prepare)
+        plugin = virtiofs_plugin.VirtiofsPlugin()
+        response = json.loads(plugin.prepare_host_model_cache({
+            http.REQUEST_BODY: json.dumps({
+                'sourceType': 'juicefsModelCenter',
+                'sourceRoot': '/cache',
+                'sourcePath': '/cache/models/model/v1',
+                'modelCenterUuid': 'mc',
+                'storageUrl': 'redis://model-center',
+                'modelRelativePath': 'qwen/v1',
+                'requiredCapacityBytes': 1024,
+            })
+        }))
+
+        assert response['success'] is True
+        assert response['cacheEntry']['sourcePath'] == '/cache/models/model/v1'
+        assert captured['modelRelativePath'] == 'qwen/v1'
+        assert captured['storageUrl'] == 'redis://model-center'
+
+
 class TestVirtiofsAttachHandler:
     """Test virtiofs attach handler."""
 

--- a/tests/unit/kvmagent/test_virtiofs_source.py
+++ b/tests/unit/kvmagent/test_virtiofs_source.py
@@ -154,6 +154,9 @@ def test_prepare_model_center_cache_mounts_copies_and_unmounts(tmp_path, monkeyp
     assert (target / 'config.json').read_text() == '{}'
     assert entry['contentVersion'].startswith('meta:')
     assert virtiofs_source.read_local_content_version(str(target)) == entry['contentVersion']
+    assert entry['prepareDecision'] == 'cold_copy'
+    assert entry['prepareReason'] == 'missing_local'
+    assert entry['prepareActions'] == 'mount=1,copy=1'
     registry = json.loads((source_root / '.registry').read_text())
     assert list(registry.values())[0]['path'] == os.path.realpath(str(target))
     assert events[0][0] == 'mount'
@@ -308,6 +311,9 @@ def test_prepare_model_center_cache_reuses_existing_cache_with_matching_strong_v
 
     assert entry['sourcePath'] == os.path.realpath(str(target))
     assert entry['contentVersion'] == 'v:checksum-abc'
+    assert entry['prepareDecision'] == 'strong_hit'
+    assert entry['prepareReason'] == 'strong_match'
+    assert entry['prepareActions'] == 'mount=0,copy=0'
 
 
 def test_prepare_model_center_cache_refreshes_when_strong_version_mismatches(tmp_path, monkeypatch):
@@ -347,6 +353,9 @@ def test_prepare_model_center_cache_refreshes_when_strong_version_mismatches(tmp
     assert (target / 'config.json').read_text() == 'fresh'
     assert entry['contentVersion'] == 'v:new'
     assert virtiofs_source.read_local_content_version(str(target)) == 'v:new'
+    assert entry['prepareDecision'] == 'refresh'
+    assert entry['prepareReason'] == 'strong_mismatch'
+    assert entry['prepareActions'] == 'mount=1,copy=1'
 
 
 def test_prepare_model_center_cache_refreshes_when_meta_mismatches(tmp_path, monkeypatch):
@@ -386,6 +395,8 @@ def test_prepare_model_center_cache_refreshes_when_meta_mismatches(tmp_path, mon
     assert (target / 'template.yaml').read_text() == 'new-template-content'
     assert entry['contentVersion'].startswith('meta:')
     assert entry['contentVersion'] != 'meta:1:1'
+    assert entry['prepareDecision'] == 'refresh'
+    assert entry['prepareReason'] == 'meta_mismatch'
 
 
 def test_prepare_model_center_cache_reuses_when_meta_matches_after_mount(tmp_path, monkeypatch):
@@ -430,6 +441,9 @@ def test_prepare_model_center_cache_reuses_when_meta_matches_after_mount(tmp_pat
     assert mounted
     assert entry['contentVersion'].startswith('meta:')
     assert (target / 'template.yaml').read_text() == 'same'
+    assert entry['prepareDecision'] == 'meta_hit'
+    assert entry['prepareReason'] == 'meta_match'
+    assert entry['prepareActions'] == 'mount=1,copy=0'
 
 
 def test_prepare_model_center_cache_without_sidecar_refreshes_existing_dir(tmp_path, monkeypatch):
@@ -468,6 +482,8 @@ def test_prepare_model_center_cache_without_sidecar_refreshes_existing_dir(tmp_p
     assert events == ['mount', 'unmount']
     assert (target / 'template.yaml').read_text() == 'refreshed'
     assert entry['contentVersion'].startswith('meta:')
+    assert entry['prepareDecision'] == 'refresh'
+    assert entry['prepareReason'] == 'no_sidecar'
 
 
 def test_prepare_path_source_rejects_empty_command_source_root(tmp_path):

--- a/tests/unit/kvmagent/test_virtiofs_source.py
+++ b/tests/unit/kvmagent/test_virtiofs_source.py
@@ -152,6 +152,8 @@ def test_prepare_model_center_cache_mounts_copies_and_unmounts(tmp_path, monkeyp
 
     assert entry['sourcePath'] == os.path.realpath(str(target))
     assert (target / 'config.json').read_text() == '{}'
+    assert entry['contentVersion'].startswith('meta:')
+    assert virtiofs_source.read_local_content_version(str(target)) == entry['contentVersion']
     registry = json.loads((source_root / '.registry').read_text())
     assert list(registry.values())[0]['path'] == os.path.realpath(str(target))
     assert events[0][0] == 'mount'
@@ -271,11 +273,12 @@ def test_prepare_model_center_artifact_uses_requested_subdir_without_cache_regis
     assert (target / 'dataset.json').read_text() == '{}'
 
 
-def test_prepare_model_center_cache_reuses_existing_cache_without_mounting(tmp_path, monkeypatch):
+def test_prepare_model_center_cache_reuses_existing_cache_with_matching_strong_version(tmp_path, monkeypatch):
     source_root = tmp_path / 'primary-storage' / 'ai-model-cache'
     target = source_root / 'models' / 'model-uuid' / 'v1'
     target.mkdir(parents=True)
     (target / 'config.json').write_text('{}')
+    virtiofs_source.write_local_content_version(str(target), 'v:checksum-abc')
     monkeypatch.setattr(
         virtiofs_source,
         'MODEL_CENTER_PROVIDER_ROOT',
@@ -287,7 +290,8 @@ def test_prepare_model_center_cache_reuses_existing_cache_without_mounting(tmp_p
     monkeypatch.setattr(
         virtiofs_source,
         '_mount_model_center',
-        lambda storage_url, mount_path: pytest.fail('existing cache must not remount model center'))
+        lambda storage_url, mount_path, storage_subdir='models': pytest.fail(
+            'existing cache with matching strong version must not remount model center'))
     monkeypatch.setattr(
         virtiofs_source,
         'check_available_capacity',
@@ -299,9 +303,171 @@ def test_prepare_model_center_cache_reuses_existing_cache_without_mounting(tmp_p
         'model-center-uuid',
         'redis://model-center',
         'qwen/v1',
-        1024)
+        1024,
+        content_version='checksum-abc')
 
     assert entry['sourcePath'] == os.path.realpath(str(target))
+    assert entry['contentVersion'] == 'v:checksum-abc'
+
+
+def test_prepare_model_center_cache_refreshes_when_strong_version_mismatches(tmp_path, monkeypatch):
+    source_root = tmp_path / 'primary-storage' / 'ai-model-cache'
+    target = source_root / 'models' / 'model-uuid' / 'v1'
+    target.mkdir(parents=True)
+    (target / 'config.json').write_text('stale')
+    virtiofs_source.write_local_content_version(str(target), 'v:old')
+    provider_root = tmp_path / 'provider-mounts'
+    lock_root = tmp_path / 'provider-locks'
+    events = []
+
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_PROVIDER_ROOT', str(provider_root))
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_LOCK_ROOT', str(lock_root))
+
+    def mount_model_center(storage_url, mount_path, storage_subdir):
+        events.append(('mount', storage_subdir))
+        model_dir = os.path.join(mount_path, 'qwen', 'v1')
+        os.makedirs(model_dir)
+        with open(os.path.join(model_dir, 'config.json'), 'w') as stream:
+            stream.write('fresh')
+
+    monkeypatch.setattr(virtiofs_source, '_mount_model_center', mount_model_center)
+    monkeypatch.setattr(virtiofs_source, '_unmount_model_center', lambda mount_path: events.append('unmount'))
+
+    entry = virtiofs_source.prepare_model_center_cache(
+        str(source_root),
+        str(target),
+        'model-center-uuid',
+        'redis://model-center',
+        'qwen/v1',
+        1024,
+        content_version='new')
+
+    assert events[0] == ('mount', 'models')
+    assert events[-1] == 'unmount'
+    assert (target / 'config.json').read_text() == 'fresh'
+    assert entry['contentVersion'] == 'v:new'
+    assert virtiofs_source.read_local_content_version(str(target)) == 'v:new'
+
+
+def test_prepare_model_center_cache_refreshes_when_meta_mismatches(tmp_path, monkeypatch):
+    source_root = tmp_path / 'primary-storage' / 'ai-model-cache'
+    target = source_root / 'models' / 'template' / 'root'
+    target.mkdir(parents=True)
+    (target / 'template.yaml').write_text('old-template')
+    virtiofs_source.write_local_content_version(str(target), 'meta:1:1')
+    provider_root = tmp_path / 'provider-mounts'
+    lock_root = tmp_path / 'provider-locks'
+    events = []
+
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_PROVIDER_ROOT', str(provider_root))
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_LOCK_ROOT', str(lock_root))
+
+    def mount_model_center(storage_url, mount_path, storage_subdir):
+        events.append('mount')
+        model_dir = os.path.join(mount_path, 'template-id')
+        os.makedirs(model_dir)
+        with open(os.path.join(model_dir, 'template.yaml'), 'w') as stream:
+            stream.write('new-template-content')
+
+    monkeypatch.setattr(virtiofs_source, '_mount_model_center', mount_model_center)
+    monkeypatch.setattr(virtiofs_source, '_unmount_model_center', lambda mount_path: events.append('unmount'))
+
+    entry = virtiofs_source.prepare_model_center_cache(
+        str(source_root),
+        str(target),
+        'model-center-uuid',
+        'redis://model-center',
+        'template-id',
+        1024,
+        'model_service',
+        False)
+
+    assert 'mount' in events
+    assert (target / 'template.yaml').read_text() == 'new-template-content'
+    assert entry['contentVersion'].startswith('meta:')
+    assert entry['contentVersion'] != 'meta:1:1'
+
+
+def test_prepare_model_center_cache_reuses_when_meta_matches_after_mount(tmp_path, monkeypatch):
+    source_root = tmp_path / 'primary-storage' / 'ai-model-cache'
+    target = source_root / 'models' / 'template' / 'root'
+    target.mkdir(parents=True)
+    (target / 'template.yaml').write_text('same')
+    provider_root = tmp_path / 'provider-mounts'
+    lock_root = tmp_path / 'provider-locks'
+    mounted = []
+
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_PROVIDER_ROOT', str(provider_root))
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_LOCK_ROOT', str(lock_root))
+
+    def mount_model_center(storage_url, mount_path, storage_subdir):
+        mounted.append(mount_path)
+        model_dir = os.path.join(mount_path, 'template-id')
+        os.makedirs(model_dir)
+        with open(os.path.join(model_dir, 'template.yaml'), 'w') as stream:
+            stream.write('same')
+        # Align local sidecar to remote meta so prepare is a hit after mount.
+        meta = virtiofs_source.remote_directory_meta(model_dir)
+        virtiofs_source.write_local_content_version(str(target), meta)
+
+    monkeypatch.setattr(virtiofs_source, '_mount_model_center', mount_model_center)
+    monkeypatch.setattr(virtiofs_source, '_unmount_model_center', lambda mount_path: None)
+    monkeypatch.setattr(
+        virtiofs_source,
+        'prepare_copy_source',
+        lambda *args, **kwargs: pytest.fail('matching meta must not recopy'))
+
+    entry = virtiofs_source.prepare_model_center_cache(
+        str(source_root),
+        str(target),
+        'model-center-uuid',
+        'redis://model-center',
+        'template-id',
+        1024,
+        'model_service',
+        False)
+
+    assert mounted
+    assert entry['contentVersion'].startswith('meta:')
+    assert (target / 'template.yaml').read_text() == 'same'
+
+
+def test_prepare_model_center_cache_without_sidecar_refreshes_existing_dir(tmp_path, monkeypatch):
+    """ZSTAC-87450: existence-only hit is wrong; no sidecar forces remount/refresh."""
+    source_root = tmp_path / 'primary-storage' / 'ai-model-cache'
+    target = source_root / 'models' / 'template' / 'root'
+    target.mkdir(parents=True)
+    (target / 'template.yaml').write_text('stale-no-sidecar')
+    provider_root = tmp_path / 'provider-mounts'
+    lock_root = tmp_path / 'provider-locks'
+    events = []
+
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_PROVIDER_ROOT', str(provider_root))
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_LOCK_ROOT', str(lock_root))
+
+    def mount_model_center(storage_url, mount_path, storage_subdir):
+        events.append('mount')
+        model_dir = os.path.join(mount_path, 'template-id')
+        os.makedirs(model_dir)
+        with open(os.path.join(model_dir, 'template.yaml'), 'w') as stream:
+            stream.write('refreshed')
+
+    monkeypatch.setattr(virtiofs_source, '_mount_model_center', mount_model_center)
+    monkeypatch.setattr(virtiofs_source, '_unmount_model_center', lambda mount_path: events.append('unmount'))
+
+    entry = virtiofs_source.prepare_model_center_cache(
+        str(source_root),
+        str(target),
+        'model-center-uuid',
+        'redis://model-center',
+        'template-id',
+        None,
+        'model_service',
+        False)
+
+    assert events == ['mount', 'unmount']
+    assert (target / 'template.yaml').read_text() == 'refreshed'
+    assert entry['contentVersion'].startswith('meta:')
 
 
 def test_prepare_path_source_rejects_empty_command_source_root(tmp_path):

--- a/tests/unit/kvmagent/test_virtiofs_source.py
+++ b/tests/unit/kvmagent/test_virtiofs_source.py
@@ -12,6 +12,12 @@ class Obj(object):
     pass
 
 
+class Statvfs(object):
+    def __init__(self, available_bytes):
+        self.f_frsize = 1
+        self.f_bavail = available_bytes
+
+
 def _provider_with_roots(*roots):
     provider = virtiofs_source.PreparedPathSourceProvider()
     provider.allowed_roots = roots
@@ -69,6 +75,250 @@ def test_prepare_path_source_records_ready_source(tmp_path):
         registry = json.load(fd)
     assert registry['source-a']['state'] == 'ready'
     assert registry['source-a']['capability']['persistent'] is True
+
+
+def test_prepare_path_source_accepts_command_source_root(tmp_path):
+    source_dir = tmp_path / 'large-disk' / 'model-centers' / 'mc' / 'root' / 'models' / 'qwen'
+    source_dir.mkdir(parents=True)
+    registry_file = tmp_path / 'registry.json'
+    manager = virtiofs_source.SourceManager(
+        registry=virtiofs_source.SourceRegistry(str(registry_file)),
+    )
+
+    host_source = manager.ensure_ready({
+        'type': 'preparedPath',
+        'sourcePath': str(source_dir),
+        'sourceRootPath': str(tmp_path / 'large-disk'),
+        'sourceUuid': 'source-a',
+    })
+
+    assert host_source.path == os.path.realpath(str(source_dir))
+
+
+def test_prepare_path_source_copies_remote_source_to_target_root(tmp_path):
+    remote_dir = tmp_path / 'virtiofs-sources' / 'model-centers' / 'mc' / 'root' / 'models' / 'qwen'
+    remote_dir.mkdir(parents=True)
+    (remote_dir / 'config.json').write_text('{}')
+    target_dir = tmp_path / 'primary-storage' / 'ai-model-cache' / 'models' / 'model-uuid' / 'v1'
+    registry_file = tmp_path / 'registry.json'
+    manager = virtiofs_source.SourceManager(
+        registry=virtiofs_source.SourceRegistry(str(registry_file)),
+    )
+
+    host_source = manager.ensure_ready({
+        'type': 'preparedPath',
+        'sourcePath': str(target_dir),
+        'sourceRootPath': str(tmp_path / 'primary-storage'),
+        'remoteSourcePath': str(remote_dir),
+        'remoteSourceRootPath': str(tmp_path / 'virtiofs-sources'),
+        'sourceUuid': 'model-cache',
+    })
+
+    assert host_source.path == os.path.realpath(str(target_dir))
+    assert (target_dir / 'config.json').read_text() == '{}'
+
+
+def test_prepare_model_center_cache_mounts_copies_and_unmounts(tmp_path, monkeypatch):
+    source_root = tmp_path / 'primary-storage' / 'ai-model-cache'
+    source_root.mkdir(parents=True)
+    target = source_root / 'models' / 'model-uuid' / 'v1'
+    provider_root = tmp_path / 'provider-mounts'
+    lock_root = tmp_path / 'provider-locks'
+    events = []
+
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_PROVIDER_ROOT', str(provider_root))
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_LOCK_ROOT', str(lock_root))
+
+    def mount_model_center(storage_url, mount_path):
+        events.append(('mount', storage_url, mount_path))
+        model_dir = os.path.join(mount_path, 'qwen', 'v1')
+        os.makedirs(model_dir)
+        with open(os.path.join(model_dir, 'config.json'), 'w') as stream:
+            stream.write('{}')
+
+    def unmount_model_center(mount_path):
+        events.append(('unmount', mount_path))
+
+    monkeypatch.setattr(virtiofs_source, '_mount_model_center', mount_model_center)
+    monkeypatch.setattr(virtiofs_source, '_unmount_model_center', unmount_model_center)
+
+    entry = virtiofs_source.prepare_model_center_cache(
+        str(source_root),
+        str(target),
+        'model-center-uuid',
+        'redis://model-center',
+        'qwen/v1',
+        1024)
+
+    assert entry['sourcePath'] == os.path.realpath(str(target))
+    assert (target / 'config.json').read_text() == '{}'
+    registry = json.loads((source_root / '.registry').read_text())
+    assert list(registry.values())[0]['path'] == os.path.realpath(str(target))
+    assert events[0][0] == 'mount'
+    assert events[-1][0] == 'unmount'
+
+
+def test_mount_model_center_uses_packaged_juicefs_layout(tmp_path, monkeypatch):
+    mount_path = tmp_path / 'provider-mount'
+    cache_path = tmp_path / 'juicefs-cache'
+    commands = []
+    mount_checks = iter([False, True])
+
+    monkeypatch.setattr(virtiofs_source, 'JUICEFS_CACHE_DIR', str(cache_path))
+    monkeypatch.setattr(virtiofs_source, '_find_juicefs_binary', lambda: '/usr/local/bin/juicefs')
+    monkeypatch.setattr(
+        virtiofs_source,
+        '_run_process',
+        lambda args, error_message: commands.append(args))
+    monkeypatch.setattr(os.path, 'ismount', lambda path: next(mount_checks))
+
+    virtiofs_source._mount_model_center('redis://model-center', str(mount_path))
+
+    assert commands == [[
+        '/usr/local/bin/juicefs', 'mount',
+        '--read-only', '-d', '--subdir', 'models',
+        '--cache-dir', str(cache_path),
+        'redis://model-center', str(mount_path),
+    ]]
+    assert cache_path.is_dir()
+
+
+def test_prepare_model_center_cache_rejects_escaping_model_path(tmp_path):
+    source_root = tmp_path / 'primary-storage' / 'ai-model-cache'
+    source_root.mkdir(parents=True)
+
+    with pytest.raises(Exception) as exc_info:
+        virtiofs_source.prepare_model_center_cache(
+            str(source_root),
+            str(source_root / 'models' / 'model-uuid' / 'v1'),
+            'model-center-uuid',
+            'redis://model-center',
+            '../outside',
+            1024)
+
+    assert 'escapes its source root' in str(exc_info.value)
+
+
+def test_prepare_model_center_cache_unmounts_when_model_is_missing(tmp_path, monkeypatch):
+    source_root = tmp_path / 'primary-storage' / 'ai-model-cache'
+    source_root.mkdir(parents=True)
+    provider_root = tmp_path / 'provider-mounts'
+    lock_root = tmp_path / 'provider-locks'
+    unmounted = []
+
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_PROVIDER_ROOT', str(provider_root))
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_LOCK_ROOT', str(lock_root))
+    monkeypatch.setattr(
+        virtiofs_source,
+        '_mount_model_center',
+        lambda storage_url, mount_path: os.makedirs(mount_path))
+    monkeypatch.setattr(
+        virtiofs_source,
+        '_unmount_model_center',
+        lambda mount_path: unmounted.append(mount_path))
+
+    with pytest.raises(Exception) as exc_info:
+        virtiofs_source.prepare_model_center_cache(
+            str(source_root),
+            str(source_root / 'models' / 'model-uuid' / 'v1'),
+            'model-center-uuid',
+            'redis://model-center',
+            'missing/model',
+            1024)
+
+    assert 'does not exist' in str(exc_info.value)
+    assert unmounted == [str(provider_root / 'model-center-uuid')]
+
+
+def test_prepare_model_center_cache_reuses_existing_cache_without_mounting(tmp_path, monkeypatch):
+    source_root = tmp_path / 'primary-storage' / 'ai-model-cache'
+    target = source_root / 'models' / 'model-uuid' / 'v1'
+    target.mkdir(parents=True)
+    (target / 'config.json').write_text('{}')
+    monkeypatch.setattr(
+        virtiofs_source,
+        'MODEL_CENTER_PROVIDER_ROOT',
+        str(tmp_path / 'provider-mounts'))
+    monkeypatch.setattr(
+        virtiofs_source,
+        'MODEL_CENTER_LOCK_ROOT',
+        str(tmp_path / 'provider-locks'))
+    monkeypatch.setattr(
+        virtiofs_source,
+        '_mount_model_center',
+        lambda storage_url, mount_path: pytest.fail('existing cache must not remount model center'))
+    monkeypatch.setattr(
+        virtiofs_source,
+        'check_available_capacity',
+        lambda path, required: pytest.fail('existing cache must not reserve capacity again'))
+
+    entry = virtiofs_source.prepare_model_center_cache(
+        str(source_root),
+        str(target),
+        'model-center-uuid',
+        'redis://model-center',
+        'qwen/v1',
+        1024)
+
+    assert entry['sourcePath'] == os.path.realpath(str(target))
+
+
+def test_prepare_path_source_rejects_empty_command_source_root(tmp_path):
+    source_dir = tmp_path / 'virtiofs-sources' / 'source-a'
+    source_dir.mkdir(parents=True)
+    manager = virtiofs_source.SourceManager(
+        registry=virtiofs_source.SourceRegistry(str(tmp_path / 'registry.json')),
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        manager.ensure_ready({
+            'type': 'preparedPath',
+            'sourcePath': str(source_dir),
+            'sourceRootPath': ' ',
+        })
+
+    assert 'virtiofs sourceRootPath must not be empty' in str(exc_info.value)
+
+
+def test_prepare_path_source_does_not_fallback_when_command_source_root_is_explicit(tmp_path, monkeypatch):
+    default_root = tmp_path / 'virtiofs-sources'
+    explicit_root = tmp_path / 'large-disk'
+    source_dir = default_root / 'source-a'
+    source_dir.mkdir(parents=True)
+    explicit_root.mkdir()
+    monkeypatch.setattr(virtiofs_source, 'HOST_SOURCE_ROOT', str(default_root))
+    monkeypatch.setattr(virtiofs_source, 'VM_VIEW_ROOT', str(tmp_path / 'vm-views'))
+    manager = virtiofs_source.SourceManager(
+        registry=virtiofs_source.SourceRegistry(str(tmp_path / 'registry.json')),
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        manager.ensure_ready({
+            'type': 'preparedPath',
+            'sourcePath': str(source_dir),
+            'sourceRootPath': str(explicit_root),
+        })
+
+    assert 'outside allowed virtiofs source directory' in str(exc_info.value)
+
+
+def test_prepare_path_source_rejects_insufficient_capacity(tmp_path, monkeypatch):
+    source_dir = tmp_path / 'large-disk' / 'source-a'
+    source_dir.mkdir(parents=True)
+    monkeypatch.setattr(virtiofs_source.os, 'statvfs', lambda path: Statvfs(512))
+    manager = virtiofs_source.SourceManager(
+        registry=virtiofs_source.SourceRegistry(str(tmp_path / 'registry.json')),
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        manager.ensure_ready({
+            'type': 'preparedPath',
+            'sourcePath': str(source_dir),
+            'sourceRootPath': str(tmp_path / 'large-disk'),
+            'requiredCapacityBytes': 1024,
+        })
+
+    assert 'available capacity[512 bytes] is less than required capacity[1024 bytes]' in str(exc_info.value)
 
 
 def test_prepare_path_source_accepts_vm_view_root(tmp_path):

--- a/tests/unit/kvmagent/test_virtiofs_source.py
+++ b/tests/unit/kvmagent/test_virtiofs_source.py
@@ -129,8 +129,8 @@ def test_prepare_model_center_cache_mounts_copies_and_unmounts(tmp_path, monkeyp
     monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_PROVIDER_ROOT', str(provider_root))
     monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_LOCK_ROOT', str(lock_root))
 
-    def mount_model_center(storage_url, mount_path):
-        events.append(('mount', storage_url, mount_path))
+    def mount_model_center(storage_url, mount_path, storage_subdir):
+        events.append(('mount', storage_url, mount_path, storage_subdir))
         model_dir = os.path.join(mount_path, 'qwen', 'v1')
         os.makedirs(model_dir)
         with open(os.path.join(model_dir, 'config.json'), 'w') as stream:
@@ -155,6 +155,7 @@ def test_prepare_model_center_cache_mounts_copies_and_unmounts(tmp_path, monkeyp
     registry = json.loads((source_root / '.registry').read_text())
     assert list(registry.values())[0]['path'] == os.path.realpath(str(target))
     assert events[0][0] == 'mount'
+    assert events[0][3] == 'models'
     assert events[-1][0] == 'unmount'
 
 
@@ -211,7 +212,7 @@ def test_prepare_model_center_cache_unmounts_when_model_is_missing(tmp_path, mon
     monkeypatch.setattr(
         virtiofs_source,
         '_mount_model_center',
-        lambda storage_url, mount_path: os.makedirs(mount_path))
+        lambda storage_url, mount_path, storage_subdir: os.makedirs(mount_path))
     monkeypatch.setattr(
         virtiofs_source,
         '_unmount_model_center',
@@ -228,6 +229,46 @@ def test_prepare_model_center_cache_unmounts_when_model_is_missing(tmp_path, mon
 
     assert 'does not exist' in str(exc_info.value)
     assert unmounted == [str(provider_root / 'model-center-uuid')]
+
+
+def test_prepare_model_center_artifact_uses_requested_subdir_without_cache_registration(tmp_path, monkeypatch):
+    source_root = tmp_path / 'virtiofs-sources'
+    source_root.mkdir()
+    target = source_root / 'model-centers' / 'mc' / 'root' / 'datasets' / 'eval'
+    provider_root = tmp_path / 'provider-mounts'
+    lock_root = tmp_path / 'provider-locks'
+    mounted_subdirs = []
+
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_PROVIDER_ROOT', str(provider_root))
+    monkeypatch.setattr(virtiofs_source, 'MODEL_CENTER_LOCK_ROOT', str(lock_root))
+
+    def mount_model_center(storage_url, mount_path, storage_subdir):
+        mounted_subdirs.append(storage_subdir)
+        artifact_dir = os.path.join(mount_path, 'eval')
+        os.makedirs(artifact_dir)
+        with open(os.path.join(artifact_dir, 'dataset.json'), 'w') as stream:
+            stream.write('{}')
+
+    monkeypatch.setattr(virtiofs_source, '_mount_model_center', mount_model_center)
+    monkeypatch.setattr(virtiofs_source, '_unmount_model_center', lambda mount_path: None)
+    monkeypatch.setattr(
+        virtiofs_source,
+        '_register_model_center_cache',
+        lambda root, path: pytest.fail('non-model artifacts must not enter the model cache registry'))
+
+    entry = virtiofs_source.prepare_model_center_cache(
+        str(source_root),
+        str(target),
+        'mc',
+        'redis://model-center',
+        'eval',
+        256,
+        'datasets',
+        False)
+
+    assert mounted_subdirs == ['datasets']
+    assert entry['sourcePath'] == str(target)
+    assert (target / 'dataset.json').read_text() == '{}'
 
 
 def test_prepare_model_center_cache_reuses_existing_cache_without_mounting(tmp_path, monkeypatch):

--- a/tests/unit/kvmagent/test_virtiofs_source.py
+++ b/tests/unit/kvmagent/test_virtiofs_source.py
@@ -316,6 +316,64 @@ def test_prepare_model_center_cache_reuses_existing_cache_with_matching_strong_v
     assert entry['prepareActions'] == 'mount=0,copy=0'
 
 
+def test_report_source_root_uses_parent_capacity_without_creating_missing_leaf(tmp_path, monkeypatch):
+    parent = tmp_path / 'primary-storage'
+    parent.mkdir()
+    source_root = parent / 'ai-model-cache'
+
+    capacity_paths = []
+    monkeypatch.setattr(
+        virtiofs_source,
+        'statvfs_capacity',
+        lambda path: capacity_paths.append(path) or
+        {'physicalTotalBytes': 100, 'physicalAvailableBytes': 80})
+
+    report = virtiofs_source.report_source_root(str(source_root))
+
+    assert not source_root.exists()
+    assert capacity_paths == [os.path.realpath(str(parent))]
+    assert report['sourceRoot'] == os.path.realpath(str(source_root))
+    assert report['physicalTotalBytes'] == 100
+    assert report['physicalAvailableBytes'] == 80
+    assert report['cacheEntries'] == []
+
+
+def test_report_source_root_initializes_managed_default_root(tmp_path, monkeypatch):
+    source_root = tmp_path / 'zstack' / 'aios' / 'virtiofs-sources'
+    monkeypatch.setattr(virtiofs_source, 'HOST_SOURCE_ROOT', str(source_root))
+    monkeypatch.setattr(
+        virtiofs_source,
+        'statvfs_capacity',
+        lambda path: {'physicalTotalBytes': 100, 'physicalAvailableBytes': 80})
+
+    report = virtiofs_source.report_source_root(None)
+
+    assert source_root.is_dir()
+    assert report['sourceRoot'] == os.path.realpath(str(source_root))
+    assert report['cacheEntries'] == []
+
+
+def test_report_source_root_rejects_missing_parent_mount(tmp_path):
+    source_root = tmp_path / 'missing-mount' / 'ai-model-cache'
+
+    with pytest.raises(Exception) as exc_info:
+        virtiofs_source.report_source_root(str(source_root))
+
+    assert 'does not exist' in str(exc_info.value)
+
+
+def test_report_source_root_rejects_non_directory_parent(tmp_path):
+    parent_file = tmp_path / 'not-a-directory'
+    parent_file.write_text('file parent')
+    source_root = parent_file / 'ai-model-cache'
+
+    with pytest.raises(Exception) as exc_info:
+        virtiofs_source.report_source_root(str(source_root))
+
+    assert 'parent[' in str(exc_info.value)
+    assert 'is not a directory' in str(exc_info.value)
+
+
 def test_prepare_model_center_cache_refreshes_when_strong_version_mismatches(tmp_path, monkeypatch):
     source_root = tmp_path / 'primary-storage' / 'ai-model-cache'
     target = source_root / 'models' / 'model-uuid' / 'v1'


### PR DESCRIPTION
## Summary

Port 5.5.32 kvmagent virtiofs host model cache prepare/report/cleanup handlers onto 5.5.38.

Branch is `@@3` (zstack + premium + zstack-utility).

Replaces !7681 (`@@2`, wrong pairing count).

Related: ZSTAC-87595, ZSTAC-84946

sync from gitlab !7682